### PR TITLE
feature - intercepting url parameters

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -7,7 +7,7 @@
 			"resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
 			"integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
 			"requires": {
-				"chalk": "*"
+				"chalk": "2.4.1"
 			}
 		},
 		"@types/path-to-regexp": {
@@ -15,7 +15,7 @@
 			"resolved": "https://registry.npmjs.org/@types/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-8a+dnJ21+K2AqnXtQk22ZcSNbNQ=",
 			"requires": {
-				"path-to-regexp": "*"
+				"path-to-regexp": "2.2.1"
 			}
 		},
 		"ansi-styles": {
@@ -23,7 +23,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "1.9.1"
 			}
 		},
 		"chalk": {
@@ -31,9 +31,9 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.4.0"
 			}
 		},
 		"color-convert": {
@@ -41,7 +41,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"requires": {
-				"color-name": "^1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
@@ -64,26 +64,13 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
 			"integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
 		},
-		"rxjs": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.1.0.tgz",
-			"integrity": "sha512-lMZdl6xbHJCSb5lmnb6nOhsoBVCyoDC5LDJQK9WWyq+tsI7KnlDIZ0r0AZAlBpRPLbwQA9kzSBAZwNIZEZ+hcw==",
-			"requires": {
-				"tslib": "^1.9.0"
-			}
-		},
 		"supports-color": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "3.0.0"
 			}
-		},
-		"tslib": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
-			"integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg=="
 		}
 	}
 }

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -3,7 +3,18 @@ import * as http from 'http';
 export interface HttpRequest extends http.IncomingMessage {
   body?: any;
   matchers?: string[];
+  route?: HttpRoute;
   [key: string]: any;
+}
+
+export interface HttpRoute {
+  url?: string;
+  params?: HttpParameters;
+  query?: HttpParameters;
+}
+
+export interface HttpParameters {
+  [key: string]: string | number;
 }
 
 export interface HttpResponse extends http.ServerResponse {}

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -7,12 +7,11 @@ export interface HttpRequest extends http.IncomingMessage {
   [key: string]: any;
 }
 
-export type HttpParameters = Record<string, string | number>;
+export type RouteParameters = Record<string, string | number>;
 
 export interface HttpRoute {
   url: string;
-  params?: HttpParameters;
-  query?: any;
+  params?: RouteParameters;
 }
 
 export interface HttpResponse extends http.ServerResponse {}

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -7,14 +7,12 @@ export interface HttpRequest extends http.IncomingMessage {
   [key: string]: any;
 }
 
-export interface HttpRoute {
-  url?: string;
-  params?: HttpParameters;
-  query?: HttpParameters;
-}
+export type HttpParameters = Record<string, string | number>;
 
-export interface HttpParameters {
-  [key: string]: string | number;
+export interface HttpRoute {
+  url: string;
+  params?: HttpParameters;
+  query?: any;
 }
 
 export interface HttpResponse extends http.ServerResponse {}

--- a/packages/core/src/http.listener.spec.ts
+++ b/packages/core/src/http.listener.spec.ts
@@ -1,5 +1,6 @@
 import { map, mapTo, tap } from 'rxjs/operators';
 import * as request from 'supertest';
+import { combineRoutes } from './effects/effects.combiner';
 import { Effect } from './effects/effects.interface';
 import { HttpRequest } from './http.interface';
 import { httpListener } from './http.listener';
@@ -50,6 +51,57 @@ describe('Http listener', () => {
     return request(app)
       .get('/test')
       .expect(200, { test: 'test' });
+  });
+
+  it('integrates with "matchPath" operator', async () => {
+    const effect$1: Effect = req$ => req$.pipe(
+      matchPath('/test/:id/foo'),
+      map(req => req.route.params.id),
+      map(id => ({ status: 200, body: { id } })),
+    );
+
+    const effect$2: Effect = req$ => req$.pipe(
+      matchPath('/test/:id/foo/:id/test'),
+      map(req => req.route.params),
+      map(params => ({ status: 200, body: { id: params.id } })),
+    );
+
+    const effect$3: Effect = req$ => req$.pipe(
+      matchPath('/test/:id/bar/:type/test'),
+      map(req => req.route.params),
+      map(params => ({ status: 200, body: { id: params.id, type: params.type } })),
+    );
+
+    const app = httpListener({ effects: [effect$1, effect$2, effect$3] });
+
+    return Promise.all([
+      request(app)
+        .get('/test/2/foo')
+        .expect(200, { id: '2' }),
+
+      request(app)
+        .get('/test/2/foo/marble/test')
+        .expect(200, { id: 'marble' }),
+
+      request(app)
+        .get('/test/2/bar/marble/test')
+        .expect(200, { id: '2', type: 'marble' }),
+    ]);
+  });
+
+  it('integrates with "combineRoutes"', async () => {
+    const effect$: Effect = req$ => req$.pipe(
+      matchPath('/user/:id'),
+      map(req => req.route.params),
+      map(params => ({ status: 200, body: { id: params.id, version: params.version } })),
+    );
+
+    const api$ = combineRoutes('/api/:version', [ effect$ ]);
+    const app = httpListener({ effects: [api$] });
+
+    return request(app)
+      .get('/api/v1/user/1')
+      .expect(200, { version: 'v1', id: '1' });
   });
 
 });

--- a/packages/core/src/operators/matchPath.operator.spec.ts
+++ b/packages/core/src/operators/matchPath.operator.spec.ts
@@ -1,9 +1,14 @@
-import { HttpRequest } from '../http.interface';
+import { HttpRequest, RouteParameters, HttpRoute } from '../http.interface';
 import { Marbles } from '../util/marbles.spec-util';
 import { matchPath } from './matchPath.operator';
 
 const req = (url: string) => ({ url } as HttpRequest);
-const reqMatched = (url: string, matchers: string[] = []) => ({ url, matchers } as HttpRequest);
+const reqRoute = (url: string, params: RouteParameters = {}) => ({ url, params }) as HttpRoute;
+const reqMatched = (url: string, query = '', matchers: string[] = [], params?: RouteParameters) => ({
+  url: !!query ? `${url}?${query}` : url,
+  matchers,
+  route: reqRoute(url, params),
+} as HttpRequest);
 
 describe('matchPath operator', () => {
   let operators;
@@ -30,31 +35,49 @@ describe('matchPath operator', () => {
     operators = [matchPath('/test/:foo/bar')];
     Marbles.assert(operators, [
       ['-a-b---', { a: req('/test/bar'), b: req('/test/url/bar') }],
-      ['---b---', { b: reqMatched('/test/url/bar') }],
+      ['---b---', { b: reqMatched('/test/url/bar', null, [], { foo: 'url' }) }],
     ]);
   });
 
   it('matches path with query parameter', () => {
     operators = [matchPath('/test')];
     Marbles.assert(operators, [
-      ['-a-b-c-', { a: req('/test/bar'), b: req('/test?foo=bar'), c: req('/test/?foo=bar') }],
-      ['---b-c-', { b: reqMatched('/test?foo=bar'), c: reqMatched('/test/?foo=bar') }],
+      ['-a-b-c-', {
+        a: req('/test/bar'),
+        b: req('/test?foo=bar'),
+        c: req('/test/?foo=bar'),
+      }],
+      ['---b-c-', {
+        b: reqMatched('/test', 'foo=bar'),
+        c: reqMatched('/test/', 'foo=bar'),
+      }],
     ]);
   });
 
   it('matches path with url and query parameter', () => {
     operators = [matchPath('/test/:foo/bar')];
     Marbles.assert(operators, [
-      ['-a-b--', { a: req('/test/bar'), b: req('/test/url/bar?foo=bar') }],
-      ['---b--', { b: reqMatched('/test/url/bar?foo=bar') }],
+      ['-a-b--', {
+        a: req('/test/bar'),
+        b: req('/test/url/bar?foo=bar') }],
+      ['---b--', {
+        b: reqMatched('/test/url/bar', 'foo=bar', [], { foo: 'url' }) }],
     ]);
   });
 
   it('matches path with additional suffix parameter', () => {
     operators = [matchPath('/test', { suffix: '/:foo*' })];
     Marbles.assert(operators, [
-      ['-a-b-c-', { a: req('/test'), b: req('/test/bar'), c: req('/test/url/bar') }],
-      ['-a-b-c-', { a: reqMatched('/test'), b: reqMatched('/test/bar'), c: reqMatched('/test/url/bar') }],
+      ['-a-b-c-', {
+        a: req('/test'),
+        b: req('/test/bar'),
+        c: req('/test/url/bar'),
+      }],
+      ['-a-b-c-', {
+        a: reqMatched('/test', null, [], { foo: undefined }),
+        b: reqMatched('/test/bar', null, [], { foo: 'bar' }),
+        c: reqMatched('/test/url/bar', null, [], { foo: 'url/bar' }),
+      }],
     ]);
   });
 
@@ -62,7 +85,7 @@ describe('matchPath operator', () => {
     operators = [matchPath('/test', { combiner: true })];
     Marbles.assert(operators, [
       ['-a--', { a: req('/test') }],
-      ['-a--', { a: reqMatched('/test', ['/test']) }],
+      ['-a--', { a: reqMatched('/test', null, ['/test']) }],
     ]);
   });
 

--- a/packages/core/src/operators/matchPath.operator.spec.ts
+++ b/packages/core/src/operators/matchPath.operator.spec.ts
@@ -1,4 +1,4 @@
-import { HttpRequest, RouteParameters, HttpRoute } from '../http.interface';
+import { HttpRequest, HttpRoute, RouteParameters } from '../http.interface';
 import { Marbles } from '../util/marbles.spec-util';
 import { matchPath } from './matchPath.operator';
 
@@ -74,9 +74,9 @@ describe('matchPath operator', () => {
         c: req('/test/url/bar'),
       }],
       ['-a-b-c-', {
-        a: reqMatched('/test', null, [], { foo: undefined }),
-        b: reqMatched('/test/bar', null, [], { foo: 'bar' }),
-        c: reqMatched('/test/url/bar', null, [], { foo: 'url/bar' }),
+        a: reqMatched('/test'),
+        b: reqMatched('/test/bar'),
+        c: reqMatched('/test/url/bar'),
       }],
     ]);
   });
@@ -86,6 +86,12 @@ describe('matchPath operator', () => {
     Marbles.assert(operators, [
       ['-a--', { a: req('/test') }],
       ['-a--', { a: reqMatched('/test', null, ['/test']) }],
+    ]);
+
+    operators = [matchPath('/test/:id/foo', { combiner: true, suffix: '/:foo*' })];
+    Marbles.assert(operators, [
+      ['-a--', { a: req('/test/2/foo') }],
+      ['-a--', { a: reqMatched('/test/2/foo', null, ['/test/:id/foo'], { id: '2' }) }],
     ]);
   });
 

--- a/packages/core/src/operators/matchPath.operator.ts
+++ b/packages/core/src/operators/matchPath.operator.ts
@@ -34,8 +34,8 @@ const paramFactory = (params: RegExpMatchArray | null, routes: pathToRegexp.Toke
     }), {});
 };
 
-const routeFactory = (req: HttpRequest, path: string, opts: MatcherOpts = {}): HttpRoute => {
-  const match = pathFactory(req.matchers!, path, opts.suffix);
+const routeFactory = (req: HttpRequest, path: string): HttpRoute => {
+  const match = pathFactory(req.matchers!, path);
   const url = urlFactory(req.url!);
   const params = pathToRegexp(match).exec(url);
   const routes = pathToRegexp.parse(match);
@@ -56,7 +56,7 @@ export const matchPath = (path: string, opts: MatcherOpts = {}) => (source$: Obs
     }),
     tap(req => req.route = {
       ...req.route,
-      ...routeFactory(req, path, opts),
+      ...routeFactory(req, path),
     }),
     tap(req => opts.combiner && req.matchers!.push(path))
   );

--- a/packages/core/src/operators/matchPath.operator.ts
+++ b/packages/core/src/operators/matchPath.operator.ts
@@ -1,7 +1,7 @@
 import * as pathToRegexp from 'path-to-regexp';
 import { Observable } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
-import { HttpRequest, HttpParameters, HttpRoute } from '../http.interface';
+import { HttpRequest, HttpRoute, RouteParameters } from '../http.interface';
 
 type MatcherOpts = {
   suffix?: string,
@@ -23,7 +23,7 @@ const pathFactory = (matchers: string[], path: string, suffix?: string): string 
 const urlFactory = (path: string): string =>
   removeQueryParams(path);
 
-const paramFactory = (params: RegExpMatchArray | null, routes: pathToRegexp.Token[]): HttpParameters => {
+const paramFactory = (params: RegExpMatchArray | null, routes: pathToRegexp.Token[]): RouteParameters => {
   if (!params || !routes) { return {}; }
 
   return routes
@@ -48,16 +48,15 @@ const routeFactory = (req: HttpRequest, path: string, opts: MatcherOpts = {}): H
 
 export const matchPath = (path: string, opts: MatcherOpts = {}) => (source$: Observable<HttpRequest>) =>
   source$.pipe(
-    tap(req => {
-      req.matchers = req.matchers || [];
-      req.route = {
-        ...req.route,
-        ...routeFactory(req, path, opts)};
-    }),
+    tap(req => req.matchers = req.matchers || []),
     filter(req => {
       const match = pathFactory(req.matchers!, path, opts.suffix);
       const url = urlFactory(req.url!);
       return pathToRegexp(match).test(url);
+    }),
+    tap(req => req.route = {
+      ...req.route,
+      ...routeFactory(req, path, opts),
     }),
     tap(req => opts.combiner && req.matchers!.push(path))
   );

--- a/packages/core/src/operators/matchPath.operator.ts
+++ b/packages/core/src/operators/matchPath.operator.ts
@@ -23,37 +23,41 @@ const pathFactory = (matchers: string[], path: string, suffix?: string): string 
 const urlFactory = (path: string): string =>
   removeQueryParams(path);
 
-const getParams = (params: RegExpMatchArray | null, routes: pathToRegexp.Token[]): HttpParameters => {
+const paramFactory = (params: RegExpMatchArray | null, routes: pathToRegexp.Token[]): HttpParameters => {
   if (!params || !routes) { return {}; }
 
   return routes
     .filter(route => route.hasOwnProperty('name'))
     .reduce((obj, route, index) => ({
       ...obj,
-      [route['name']]: params[index],
+      [route['name']]: params[++index],
     }), {});
 };
 
-const getRoute = (req: HttpRequest, path: string, opts: MatcherOpts = {}): HttpRoute => {
+const routeFactory = (req: HttpRequest, path: string, opts: MatcherOpts = {}): HttpRoute => {
   const match = pathFactory(req.matchers!, path, opts.suffix);
   const url = urlFactory(req.url!);
   const params = pathToRegexp(match).exec(url);
   const routes = pathToRegexp.parse(match);
 
   return {
-    url: req.url,
-    params: getParams(params, routes),
+    url,
+    params: paramFactory(params, routes),
   };
 };
 
 export const matchPath = (path: string, opts: MatcherOpts = {}) => (source$: Observable<HttpRequest>) =>
   source$.pipe(
-    tap(req => req.matchers = req.matchers || []),
+    tap(req => {
+      req.matchers = req.matchers || [];
+      req.route = {
+        ...req.route,
+        ...routeFactory(req, path, opts)};
+    }),
     filter(req => {
       const match = pathFactory(req.matchers!, path, opts.suffix);
       const url = urlFactory(req.url!);
       return pathToRegexp(match).test(url);
     }),
-    tap(req => req.route = getRoute(req, path, opts)),
     tap(req => opts.combiner && req.matchers!.push(path))
   );

--- a/packages/core/src/operators/matchPath.operator.ts
+++ b/packages/core/src/operators/matchPath.operator.ts
@@ -1,7 +1,7 @@
 import * as pathToRegexp from 'path-to-regexp';
 import { Observable } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
-import { HttpRequest } from '../http.interface';
+import { HttpRequest, HttpParameters, HttpRoute } from '../http.interface';
 
 type MatcherOpts = {
   suffix?: string,
@@ -23,6 +23,29 @@ const pathFactory = (matchers: string[], path: string, suffix?: string): string 
 const urlFactory = (path: string): string =>
   removeQueryParams(path);
 
+const getParams = (params: RegExpMatchArray | null, routes: pathToRegexp.Token[]): HttpParameters => {
+  if (!params || !routes) { return {}; }
+
+  return routes
+    .filter(route => route.hasOwnProperty('name'))
+    .reduce((obj, route, index) => ({
+      ...obj,
+      [route['name']]: params[index],
+    }), {});
+};
+
+const getRoute = (req: HttpRequest, path: string, opts: MatcherOpts = {}): HttpRoute => {
+  const match = pathFactory(req.matchers!, path, opts.suffix);
+  const url = urlFactory(req.url!);
+  const params = pathToRegexp(match).exec(url);
+  const routes = pathToRegexp.parse(match);
+
+  return {
+    url: req.url,
+    params: getParams(params, routes),
+  };
+};
+
 export const matchPath = (path: string, opts: MatcherOpts = {}) => (source$: Observable<HttpRequest>) =>
   source$.pipe(
     tap(req => req.matchers = req.matchers || []),
@@ -31,5 +54,6 @@ export const matchPath = (path: string, opts: MatcherOpts = {}) => (source$: Obs
       const url = urlFactory(req.url!);
       return pathToRegexp(match).test(url);
     }),
+    tap(req => req.route = getRoute(req, path, opts)),
     tap(req => opts.combiner && req.matchers!.push(path))
   );


### PR DESCRIPTION
## What new
In the operator `matchPath` added information about the route:
* `path`
* `params`

## How you can use
Now, in `matchPath` operator you can add after sign `:` also parameters. Example: `matchPath('/foo/:id/:name?'),`
In the results, you receive the request object with information about parameters. 

## Additional information
* `/:id` - parameter
* `/:name?` - optional parameter