### PR TITLE
feature - compose middlewares inside Effect pipeline

### DIFF
--- a/packages/core/src/http.listener.spec.ts
+++ b/packages/core/src/http.listener.spec.ts
@@ -1,8 +1,10 @@
-import { mapTo, tap } from 'rxjs/operators';
+import { map, mapTo, tap } from 'rxjs/operators';
 import * as request from 'supertest';
 import { Effect } from './effects/effects.interface';
+import { HttpRequest } from './http.interface';
 import { httpListener } from './http.listener';
 import { matchPath } from './operators/matchPath.operator';
+import { use } from './operators/use.operator';
 
 describe('Http listener', () => {
 
@@ -11,6 +13,7 @@ describe('Http listener', () => {
       matchPath('/test'),
       mapTo({ status: 200 })
     );
+
     const app = httpListener({ effects: [effect$] });
 
     return request(app)
@@ -24,11 +27,29 @@ describe('Http listener', () => {
       tap(() => { throw new Error(); }),
       mapTo({ status: 200 })
     );
+
     const app = httpListener({ effects: [effect$] });
 
     return request(app)
       .get('/test')
       .expect(500);
+  });
+
+  it('integrates with "use" operator', async () => {
+    const middleware$: Effect<HttpRequest> = req$ => req$
+      .pipe(tap(req => req.test = 'test'));
+
+    const effect$: Effect = req$ => req$.pipe(
+      matchPath('/test'),
+      use(middleware$),
+      map(req => ({ status: 200, body: { test: req.test } })),
+    );
+
+    const app = httpListener({ effects: [effect$] });
+
+    return request(app)
+      .get('/test')
+      .expect(200, { test: 'test' });
   });
 
 });

--- a/packages/core/src/operators/use.operator.spec.ts
+++ b/packages/core/src/operators/use.operator.spec.ts
@@ -1,0 +1,26 @@
+import { tap } from 'rxjs/operators';
+import { Effect } from '../effects/effects.interface';
+import { HttpRequest } from '../http.interface';
+import { Marbles } from '../util/marbles.spec-util';
+import { use } from './use.operator';
+
+const createMockReq = (test = 0) => ({ test } as any as HttpRequest);
+
+const middleware$: Effect<HttpRequest> = request$ => request$
+  .pipe(tap(req => req.test++));
+
+describe('Use operator', () => {
+
+  it('applies middlewares to the request pipeline', () => {
+    const operators = [
+      use(middleware$),
+      use(middleware$)
+    ];
+
+    Marbles.assert(operators, [
+      ['-a---', { a: createMockReq() }],
+      ['-a---', { a: createMockReq(2) }],
+    ]);
+  });
+
+});

--- a/packages/core/src/operators/use.operator.ts
+++ b/packages/core/src/operators/use.operator.ts
@@ -1,0 +1,11 @@
+import { Observable, of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { Effect } from '../effects/effects.interface';
+import { HttpRequest, HttpResponse } from '../http.interface';
+
+export const use =
+  (middleware: Effect<HttpRequest>, res?: HttpResponse) =>
+  (source$: Observable<HttpRequest>) =>
+    source$.pipe(
+      switchMap(req => middleware(of(req), res!, {}))
+    );


### PR DESCRIPTION
## Whats new?
- Added `use` operator for composing custom middlewares inside *Effect* request pipeline
- Added + updated test cases for new feature

## How it works?
Using `use` operator we can compose custom middlewares inside our *Effect* pipeline. For example we can use it for authorization purposes, eg. like this:

**auth.middleware.ts**
```javascript
export const authorize$: Effect<HttpRequest> = request$ => request$
  .pipe(
    tap(req => {
      if (!isAuthorized(req)) {
        throw new HttpError('Unauthorized', HttpStatus.UNAUTHORIZED);
      }
    })
  );
```
**user.controller.ts**
```javascript
const getUsers$: Effect = request$ => request$
  .pipe(
    matchPath('/'),
    matchType('GET'),
    use(authorize$),
    ...
  );
```