### PR TITLE
improvement - error.middleware - corrected spelling

### DIFF
--- a/packages/core/src/middlewares/error.middleware.ts
+++ b/packages/core/src/middlewares/error.middleware.ts
@@ -3,13 +3,13 @@ import { Effect, EffectResponse } from '../effects/effects.interface';
 import { HttpStatus } from '../http.interface';
 import { HttpError, isHttpError } from '../util/error.util';
 
-export type ThrowedError = HttpError | Error;
+export type ThrownError = HttpError | Error;
 
-export const getErrorMiddleware = (customError$?: Effect<EffectResponse, ThrowedError>) => !!customError$
+export const getErrorMiddleware = (customError$?: Effect<EffectResponse, ThrownError>) => !!customError$
   ? customError$
   : error$;
 
-const getStatusCode = (error: ThrowedError): HttpStatus => isHttpError(error)
+const getStatusCode = (error: ThrownError): HttpStatus => isHttpError(error)
   ? error.status
   : HttpStatus.INTERNAL_SERVER_ERROR;
 
@@ -17,7 +17,7 @@ const errorFactory = (message: string, status: HttpStatus, data?: any) => ({
   error: { status, message, data }
 });
 
-export const error$: Effect<EffectResponse, ThrowedError> = (request$, response, error) => request$
+export const error$: Effect<EffectResponse, ThrownError> = (request$, response, error) => request$
   .pipe(
     map(req => {
       const { message } = error;


### PR DESCRIPTION
Fixed some `error.middleware` spellings. Yup, English is hard to learn.