### PR TITLE
fix(core): Allow parrallel requests to work.

### DIFF
--- a/packages/core/src/http.listener.ts
+++ b/packages/core/src/http.listener.ts
@@ -1,5 +1,5 @@
 import { Subject, of } from 'rxjs';
-import { catchError, defaultIfEmpty, switchMap, flatMap, tap } from 'rxjs/operators';
+import { catchError, defaultIfEmpty, switchMap, mergeMap, tap } from 'rxjs/operators';
 import { combineEffects, combineMiddlewareEffects } from './effects/effects.combiner';
 import { Effect, EffectResponse, GroupedEffects } from './effects/effects.interface';
 import { Http, HttpRequest, HttpResponse, HttpStatus } from './http.interface';
@@ -16,7 +16,7 @@ export const httpListener = ({ middlewares = [], effects, errorMiddleware }: Htt
   const request$ = new Subject<Http>();
   const effect$ = request$
     .pipe(
-      flatMap(({ req, res }) =>
+      mergeMap(({ req, res }) =>
         combineMiddlewareEffects(middlewares)(res)(req)
           .pipe(
             switchMap(combineEffects(effects)(res)),

--- a/packages/core/src/http.listener.ts
+++ b/packages/core/src/http.listener.ts
@@ -1,5 +1,5 @@
 import { Subject, of } from 'rxjs';
-import { catchError, defaultIfEmpty, switchMap, tap } from 'rxjs/operators';
+import { catchError, defaultIfEmpty, switchMap, flatMap, tap } from 'rxjs/operators';
 import { combineEffects, combineMiddlewareEffects } from './effects/effects.combiner';
 import { Effect, EffectResponse, GroupedEffects } from './effects/effects.interface';
 import { Http, HttpRequest, HttpResponse, HttpStatus } from './http.interface';

--- a/packages/core/src/http.listener.ts
+++ b/packages/core/src/http.listener.ts
@@ -16,7 +16,7 @@ export const httpListener = ({ middlewares = [], effects, errorMiddleware }: Htt
   const request$ = new Subject<Http>();
   const effect$ = request$
     .pipe(
-      switchMap(({ req, res }) =>
+      flatMap(({ req, res }) =>
         combineMiddlewareEffects(middlewares)(res)(req)
           .pipe(
             switchMap(combineEffects(effects)(res)),


### PR DESCRIPTION
I'm not sure of this correction at all but it seems that otherwise when there are two almost concurrent (and long) requests the second cancels the first one. (switchMap vs flatMap).

## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When there are two long requests at the same time on the same path. The second cancel the first one. The browser won't receive any response for the first request. Only the second is successful.

Issue Number: N/A


## What is the new behavior?
Both browser pages seems to receive the response

## Does this PR introduce a breaking change?
```
[X] I don't know
```

## Other information
