### PR TITLE
feat(core): handle response content types

### DIFF
--- a/docs/assets/index.html
+++ b/docs/assets/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Test HTML</title>
+</head>
+<body>
+  <h1>Test</h1>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,19 @@
       "integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg==",
       "dev": true
     },
+    "@types/mock-fs": {
+      "version": "3.6.30",
+      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-3.6.30.tgz",
+      "integrity": "sha1-TYElQeh7I1dyYaWqlfcE3T0B5BA=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.8.tgz",
-      "integrity": "sha512-MFFKFv2X4iZy/NFl1m1E8uwE1CR96SGwJjgHma09PLtqOWoj3nqeJHMG+P/EuJGVLvC2I6MdQRQsr4TcRduIow==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.3.tgz",
+      "integrity": "sha512-GiCx7dRvta0hbxXoJFAUxz+CKX6bZSCKjM5slq2vPp/5zwK01T4ibYZkGr6EN4F2QmxDQR76/ZHg6q+7iFWCWw==",
       "dev": true
     },
     "@types/superagent": {
@@ -5905,12 +5914,6 @@
         }
       }
     },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
-    },
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
@@ -5986,6 +5989,12 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "mock-fs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.5.0.tgz",
+      "integrity": "sha512-qqudNfOX7ZmX9vm1WIAU+gWlmxVNAnwY6UG3RkFutNywmRCUGP83tujP6IxX2DS1TmcaEZBOhYwDuYEmJYE+3w==",
+      "dev": true
     },
     "mock-req": {
       "version": "0.2.0",
@@ -7937,6 +7946,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,11 +49,13 @@
   },
   "devDependencies": {
     "@types/jest": "^22.2.3",
+    "@types/mock-fs": "^3.6.30",
     "@types/supertest": "^2.0.4",
     "husky": "^0.14.0",
     "jest": "^22.4.3",
     "lerna": "^2.11.0",
     "lint-staged": "^7.1.1",
+    "mock-fs": "^4.5.0",
     "mock-req": "^0.2.0",
     "prettier": "1.12.1",
     "rimraf": "^2.6.2",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,76 +1,68 @@
 {
-	"requires": true,
+	"name": "@marblejs/core",
+	"version": "0.3.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
-		"@types/chalk": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
-			"integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
+		"@types/file-type": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-5.2.1.tgz",
+			"integrity": "sha512-Im0cJaIPJbbpuW91OrjXnqWPZCJK/tcFy2cFX+1qjG1gubgVZPPO9OVsTVAjotN4I1E6FAV0eIqt+rR8Y1c3iA==",
+			"dev": true,
 			"requires": {
-				"chalk": "2.4.1"
+				"@types/node": "*"
 			}
+		},
+		"@types/mime": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+			"integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
+			"dev": true
+		},
+		"@types/mock-fs": {
+			"version": "3.6.30",
+			"resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-3.6.30.tgz",
+			"integrity": "sha1-TYElQeh7I1dyYaWqlfcE3T0B5BA=",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/node": {
+			"version": "10.1.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.3.tgz",
+			"integrity": "sha512-GiCx7dRvta0hbxXoJFAUxz+CKX6bZSCKjM5slq2vPp/5zwK01T4ibYZkGr6EN4F2QmxDQR76/ZHg6q+7iFWCWw==",
+			"dev": true
 		},
 		"@types/path-to-regexp": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@types/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 			"integrity": "sha1-8a+dnJ21+K2AqnXtQk22ZcSNbNQ=",
+			"dev": true,
 			"requires": {
-				"path-to-regexp": "2.2.1"
+				"path-to-regexp": "*"
 			}
 		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"requires": {
-				"color-convert": "1.9.1"
-			}
+		"file-type": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-8.0.0.tgz",
+			"integrity": "sha512-vaWQ+6lIlPyzIRSqxcSaOhTPLOWTdVuzSwDvfOKEcnJS7B0yzJHMzAG8Z3+qNBXS7CPP/7PsGLTlAmRq0X5A+w=="
 		},
-		"chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.4.0"
-			}
+		"mime": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+			"integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
 		},
-		"color-convert": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		"mock-fs": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.5.0.tgz",
+			"integrity": "sha512-qqudNfOX7ZmX9vm1WIAU+gWlmxVNAnwY6UG3RkFutNywmRCUGP83tujP6IxX2DS1TmcaEZBOhYwDuYEmJYE+3w==",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
 			"integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
-		},
-		"supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-			"requires": {
-				"has-flag": "3.0.0"
-			}
 		}
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,9 +32,13 @@
     "rxjs": "~6.1.0"
   },
   "dependencies": {
+    "file-type": "^8.0.0",
+    "mime": "^2.3.1",
     "path-to-regexp": "^2.2.1"
   },
   "devDependencies": {
+    "@types/file-type": "^5.2.1",
+    "@types/mime": "^2.0.0",
     "@types/path-to-regexp": "^1.7.0"
   },
   "publishConfig": {

--- a/packages/core/src/effects/effects.combiner.spec.ts
+++ b/packages/core/src/effects/effects.combiner.spec.ts
@@ -1,6 +1,6 @@
 import { mapTo, tap } from 'rxjs/operators';
+import { Marbles } from '../../../util/marbles.spec-util';
 import { HttpRequest, HttpResponse } from '../http.interface';
-import { Marbles } from '../util/marbles.spec-util';
 import { combineEffects, combineMiddlewareEffects, combineRoutes } from './effects.combiner';
 import { Effect, GroupedEffects } from './effects.interface';
 

--- a/packages/core/src/http.listener.ts
+++ b/packages/core/src/http.listener.ts
@@ -1,36 +1,50 @@
 import { Subject, of } from 'rxjs';
-import { catchError, defaultIfEmpty, switchMap, mergeMap, tap } from 'rxjs/operators';
-import { combineEffects, combineMiddlewareEffects } from './effects/effects.combiner';
-import { Effect, EffectResponse, GroupedEffects } from './effects/effects.interface';
+import {
+  catchError,
+  defaultIfEmpty,
+  mergeMap,
+  switchMap,
+  tap,
+} from 'rxjs/operators';
+import {
+  combineEffects,
+  combineMiddlewareEffects,
+} from './effects/effects.combiner';
+import {
+  Effect,
+  EffectResponse,
+  GroupedEffects,
+} from './effects/effects.interface';
 import { Http, HttpRequest, HttpResponse, HttpStatus } from './http.interface';
 import { getErrorMiddleware } from './middlewares/error.middleware';
 import { handleResponse } from './response/response.handler';
 
 type HttpListenerConfig = {
-  middlewares?: Effect<HttpRequest>[],
-  effects: (Effect | GroupedEffects)[],
-  errorMiddleware?: Effect<EffectResponse, Error>,
+  middlewares?: Effect<HttpRequest>[];
+  effects: (Effect | GroupedEffects)[];
+  errorMiddleware?: Effect<EffectResponse, Error>;
 };
 
-export const httpListener = ({ middlewares = [], effects, errorMiddleware }: HttpListenerConfig) => {
+export const httpListener = ({
+  middlewares = [],
+  effects,
+  errorMiddleware,
+}: HttpListenerConfig) => {
   const request$ = new Subject<Http>();
-  const effect$ = request$
-    .pipe(
-      mergeMap(({ req, res }) =>
-        combineMiddlewareEffects(middlewares)(res)(req)
-          .pipe(
-            switchMap(combineEffects(effects)(res)),
-            defaultIfEmpty({ status: HttpStatus.NOT_FOUND } as EffectResponse),
-            tap(handleResponse(res)),
-            catchError(error =>
-              getErrorMiddleware(errorMiddleware)(of(req), res, error)
-                .pipe(
-                  tap(handleResponse(res)),
-                ),
-            )
-          )
-      )
-    );
+  const effect$ = request$.pipe(
+    mergeMap(({ req, res }) =>
+      combineMiddlewareEffects(middlewares)(res)(req).pipe(
+        switchMap(combineEffects(effects)(res)),
+        defaultIfEmpty({ status: HttpStatus.NOT_FOUND } as EffectResponse),
+        tap(handleResponse(res)(req)),
+        catchError(error =>
+          getErrorMiddleware(errorMiddleware)(of(req), res, error).pipe(
+            tap(handleResponse(res)(req)),
+          ),
+        ),
+      ),
+    ),
+  );
 
   effect$.subscribe();
 

--- a/packages/core/src/middlewares/error.middleware.spec.ts
+++ b/packages/core/src/middlewares/error.middleware.spec.ts
@@ -1,7 +1,7 @@
 import { mapTo } from 'rxjs/operators';
+import { Marbles } from '../../../util/marbles.spec-util';
 import { HttpRequest, HttpResponse } from '../http.interface';
 import { HttpError } from '../util/error.util';
-import { Marbles } from '../util/marbles.spec-util';
 import { error$, getErrorMiddleware } from './error.middleware';
 
 const createMockRes = () => ({} as HttpResponse);

--- a/packages/core/src/operators/matchPath/matchPath.operator.spec.ts
+++ b/packages/core/src/operators/matchPath/matchPath.operator.spec.ts
@@ -1,5 +1,5 @@
+import { Marbles } from '../../../../util/marbles.spec-util';
 import { HttpRequest, QueryParameters, RouteParameters } from '../../http.interface';
-import { Marbles } from '../../util/marbles.spec-util';
 import { matchPath } from './matchPath.operator';
 
 const req = (url: string) => ({ url } as HttpRequest);

--- a/packages/core/src/operators/matchType/matchType.operator.spec.ts
+++ b/packages/core/src/operators/matchType/matchType.operator.spec.ts
@@ -1,5 +1,5 @@
+import { Marbles } from '../../../../util/marbles.spec-util';
 import { HttpRequest } from '../../http.interface';
-import { Marbles } from '../../util/marbles.spec-util';
 import { matchType } from './matchType.operator';
 
 const createMockReq = (method: string) => ({ method } as HttpRequest);

--- a/packages/core/src/operators/use/use.operator.spec.ts
+++ b/packages/core/src/operators/use/use.operator.spec.ts
@@ -1,7 +1,7 @@
 import { tap } from 'rxjs/operators';
+import { Marbles } from '../../../../util/marbles.spec-util';
 import { Effect } from '../../effects/effects.interface';
 import { HttpRequest } from '../../http.interface';
-import { Marbles } from '../../util/marbles.spec-util';
 import { use } from './use.operator';
 
 const createMockReq = (test = 0) => ({ test } as any as HttpRequest);

--- a/packages/core/src/response/response.handler.spec.ts
+++ b/packages/core/src/response/response.handler.spec.ts
@@ -1,15 +1,20 @@
-import { HttpResponse, HttpStatus } from '../http.interface';
+import { HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
 import { handleResponse } from './response.handler';
 import { DEFAULT_HEADERS } from './responseHeaders.factory';
 
 const RESPONSE = {
   writeHead: jest.fn(),
+  setHeader: jest.fn(),
   end: jest.fn(),
 } as any as HttpResponse;
 
+const REQUEST = {
+  url: '/',
+} as any as HttpRequest;
+
 describe('Response handler', () => {
 
-  const handle = handleResponse(RESPONSE);
+  const handle = handleResponse(RESPONSE)(REQUEST);
 
   it('sets provided status', () => {
     handle({ status: HttpStatus.FORBIDDEN });
@@ -28,8 +33,9 @@ describe('Response handler', () => {
 
   it('sets provided headers', () => {
     const CUSTOM_HEADERS = { 'Content-Encoding': 'gzip' };
-    handle({ headers: CUSTOM_HEADERS });
+    handle({ headers: CUSTOM_HEADERS, body: {} });
     expect(RESPONSE.writeHead).toHaveBeenCalledWith(HttpStatus.OK, { ...DEFAULT_HEADERS, ...CUSTOM_HEADERS });
+    expect(RESPONSE.setHeader).toHaveBeenCalledWith('Content-Length', 2);
   });
 
   it('sets unefined response if body is not provided', () => {

--- a/packages/core/src/response/responseBody.factory.spec.ts
+++ b/packages/core/src/response/responseBody.factory.spec.ts
@@ -1,0 +1,30 @@
+import { ContentType } from '../util/contentType.util';
+import { bodyFactory } from './responseBody.factory';
+
+describe('Response body factory', () => {
+
+  it('#bodyFactory factorizes body for JSON', () => {
+    // given
+    const headers = { 'Content-Type': ContentType.APPLICATION_JSON };
+    const body = { test: 'test' };
+
+    // when
+    const factorizedBody = bodyFactory(headers)(body);
+
+    // then
+    expect(factorizedBody).toEqual(JSON.stringify(body));
+  });
+
+  it(`#bodyFactory doesn't factorize body`, () => {
+    // given
+    const headers = { 'Content-Type': ContentType.AUDIO };
+    const body = '1234';
+
+    // when
+    const factorizedBody = bodyFactory(headers)(body);
+
+    // then
+    expect(factorizedBody).toEqual('1234');
+  });
+
+});

--- a/packages/core/src/response/responseBody.factory.ts
+++ b/packages/core/src/response/responseBody.factory.ts
@@ -1,0 +1,11 @@
+import { HttpHeaders } from '../http.interface';
+import { ContentType } from '../util/contentType.util';
+
+export const bodyFactory = (headers: HttpHeaders) => (body: any) => {
+  switch (headers['Content-Type']) {
+    case ContentType.APPLICATION_JSON:
+      return JSON.stringify(body);
+    default:
+      return body;
+  }
+};

--- a/packages/core/src/response/responseContentType.factory.spec.ts
+++ b/packages/core/src/response/responseContentType.factory.spec.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs';
+import { ContentType } from '../util/contentType.util';
+import { DEFAULT_CONTENT_TYPE, contentTypeFactory, getMimeType } from './responseContentType.factory';
+
+describe('Response content-type factory', () => {
+
+  it('#getMimeType detects mime-type from path', () => {
+    // given
+    const body = new Buffer('test');
+    const path = '/test/index.html';
+
+    // when
+    const mimeType = getMimeType(body, path);
+
+    // then
+    expect(mimeType).toEqual(ContentType.TEXT_HTML);
+  });
+
+  it('#getMimeType detects mime-type from buffer', () => {
+    // given
+    const body = fs.readFileSync(__dirname + '/../../../../docs/assets/logo.png');
+    const path = '/test/index.html';
+
+    // when
+    const mimeType = getMimeType(body, path);
+
+    // then
+    expect(mimeType).toEqual(ContentType.IMAGE_PNG);
+  });
+
+  it('#getMimeType returns DEFAULT_CONTENT_TYPE', () => {
+    // given
+    const body = new Buffer('test');
+    const path = '/test/index';
+
+    // when
+    const mimeType = getMimeType(body, path);
+
+    // then
+    expect(mimeType).toEqual(DEFAULT_CONTENT_TYPE);
+  });
+
+  it('#contentTypeFactory returns DEFAULT_CONTENT_TYPE', () => {
+    // given
+    const data = { body: {}, path: '/index.html', status: 400 };
+
+    // when
+    const contentType = contentTypeFactory(data);
+
+    // then
+    expect(contentType).toEqual({ 'Content-Type': DEFAULT_CONTENT_TYPE });
+  });
+
+});

--- a/packages/core/src/response/responseContentType.factory.ts
+++ b/packages/core/src/response/responseContentType.factory.ts
@@ -1,0 +1,27 @@
+import * as fileType from 'file-type';
+import * as mime from 'mime';
+import { HttpStatus } from '../http.interface';
+import { ContentType } from '../util/contentType.util';
+
+export const DEFAULT_CONTENT_TYPE = ContentType.APPLICATION_JSON;
+
+export const getMimeType = (body: any, path: string) => {
+  const mimeFromBuffer = Buffer.isBuffer(body) && fileType(body);
+
+  if (mimeFromBuffer) {
+    return mimeFromBuffer.mime;
+  }
+
+  return mime.getType(path) || DEFAULT_CONTENT_TYPE;
+};
+
+export const contentTypeFactory = (data: {
+  body: any;
+  path: string;
+  status: HttpStatus;
+}) => ({
+  'Content-Type':
+    data.status === 200
+      ? getMimeType(data.body, data.path)
+      : DEFAULT_CONTENT_TYPE,
+});

--- a/packages/core/src/response/responseHeaders.factory.spec.ts
+++ b/packages/core/src/response/responseHeaders.factory.spec.ts
@@ -1,22 +1,21 @@
-import { headersFactory } from './responseHeaders.factory';
+import { DEFAULT_HEADERS, headersFactory } from './responseHeaders.factory';
 
 describe('Response headers factory', () => {
 
+  const FACTORY_DATA = { status: 400, body: '', path: '/' };
+
   it('returns default headers if custom are not provided', () => {
-    const DEFAULT_HEADERS = { 'Content-Type': 'application/json' };
-    expect(headersFactory()).toEqual(DEFAULT_HEADERS);
+    expect(headersFactory(FACTORY_DATA)()).toEqual(DEFAULT_HEADERS);
   });
 
   it('returns custom headers if are provided', () => {
-    const DEFAULT_HEADERS = { 'Content-Type': 'application/json' };
     const CUSTOM_HEADERS = { 'Content-Encoding': 'gzip' };
-    expect(headersFactory(CUSTOM_HEADERS)).toEqual({ ...DEFAULT_HEADERS, ...CUSTOM_HEADERS });
+    expect(headersFactory(FACTORY_DATA)(CUSTOM_HEADERS)).toEqual({ ...DEFAULT_HEADERS, ...CUSTOM_HEADERS });
   });
 
   it('returns not duplicated headers', () => {
-    const DEFAULT_HEADERS = { 'Content-Type': 'application/json' };
     const CUSTOM_HEADERS = { 'Content-Type': 'application/json' };
-    expect(headersFactory(CUSTOM_HEADERS)).toEqual({ ...DEFAULT_HEADERS });
+    expect(headersFactory(FACTORY_DATA)(CUSTOM_HEADERS)).toEqual({ ...DEFAULT_HEADERS });
   });
 
 });

--- a/packages/core/src/response/responseHeaders.factory.ts
+++ b/packages/core/src/response/responseHeaders.factory.ts
@@ -1,11 +1,17 @@
-import { HttpHeaders } from '../http.interface';
-import { ContentType } from '../util/contentType.util';
+import { HttpHeaders, HttpStatus } from '../http.interface';
+import { contentTypeFactory } from './responseContentType.factory';
 
 export const DEFAULT_HEADERS = {
-  'Content-Type': ContentType.APPLICATION_JSON,
+  'Content-Type': 'application/json',
+  'X-Content-Type-Options': 'nosniff',
 };
 
-export const headersFactory = (headers?: HttpHeaders) => ({
+export const headersFactory = (data: {
+  body: any;
+  path: string;
+  status: HttpStatus;
+}) => (headers?: HttpHeaders) => ({
   ...DEFAULT_HEADERS,
+  ...contentTypeFactory(data),
   ...headers,
 });

--- a/packages/core/src/util/contentType.util.ts
+++ b/packages/core/src/util/contentType.util.ts
@@ -1,3 +1,18 @@
 export enum ContentType {
+  APPLICATION = 'application/*',
   APPLICATION_JSON = 'application/json',
+  APPLICATION_JAVASCRIPT = 'application/javascript',
+  APPLICATION_ECMASCRIPT = 'application/ecmascript',
+  APPLICATION_OCTET_STREAM = 'application/octet-stream',
+  TEXT_PLAIN = 'text/plain',
+  TEXT_HTML = 'text/html',
+  TEXT_CSS = 'text/css',
+  IMAGE_JPEG = 'image/jpeg',
+  IMAGE_PNG = 'image/png',
+  IMAGE_GIF = 'image/gif',
+  IMAGE_SVG_XML = 'image/svg+xml',
+  AUDIO_MPEG = 'audio/mpeg',
+  AUDIO_OGG = 'audio/ogg',
+  AUDIO = 'audio/*',
+  VIDEO_MP4 = 'video/mp4',
 }

--- a/packages/middleware-body/src/indes.spec.ts
+++ b/packages/middleware-body/src/indes.spec.ts
@@ -1,6 +1,6 @@
 import { HttpRequest, HttpResponse } from '@marblejs/core';
 import { of } from 'rxjs';
-import { Marbles } from '../../core/src/util/marbles.spec-util';
+import { Marbles } from '../../util/marbles.spec-util';
 import { bodyParser$ } from './index';
 
 const MockReq = require('mock-req');

--- a/packages/middleware-logger/src/index.spec.ts
+++ b/packages/middleware-logger/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { HttpRequest, HttpResponse } from '@marblejs/core';
 import { EventEmitter } from 'events';
-import { Marbles } from '../../core/src/util/marbles.spec-util';
+import { Marbles } from '../../util/marbles.spec-util';
 import { logger$ } from './index';
 
 const createMockReq = (url: string, method: string) => ({ url, method } as HttpRequest);

--- a/packages/spec/api.integration.spec.ts
+++ b/packages/spec/api.integration.spec.ts
@@ -1,8 +1,10 @@
 import { of } from 'rxjs';
 import { filter, map, mapTo, switchMap } from 'rxjs/operators';
 import * as request from 'supertest';
+import { ContentType } from '../core/dist/util/contentType.util';
 import { Effect, HttpRequest, combineRoutes, httpListener, matchPath, matchType, use } from '../core/src';
 import { bodyParser$ } from '../middleware-body/src';
+import { readFile } from '../util/fileReader.helper';
 
 const MOCKED_USER_LIST = [{ id: 1 }, { id: 2 }];
 
@@ -15,7 +17,7 @@ const root$: Effect = req$ =>
   req$.pipe(
     matchPath('/'),
     matchType('GET'),
-    mapTo({ status: 200 }),
+    mapTo({ status: 200, body: 'root' }),
   );
 
 const getUserList$: Effect = request$ =>
@@ -42,9 +44,18 @@ const postUser$: Effect = request$ =>
     map(response => ({ body: response }))
   );
 
+const file$: Effect = request$ =>
+  request$.pipe(
+    matchPath('/static/:dir'),
+    matchType('GET'),
+    map(req => req.params!.dir as string),
+    switchMap(readFile(__dirname + './../../docs/assets')),
+    map(body => ({ body }))
+  );
+
 const user$ = combineRoutes('/user', [getUserList$, getUserSingle$, postUser$]);
 
-const api$ = combineRoutes('/api/:version', [root$, user$]);
+const api$ = combineRoutes('/api/:version', [root$, file$, user$]);
 
 const app = httpListener({
   middlewares: [bodyParser$],
@@ -60,7 +71,7 @@ describe('API integration', () => {
   it('returns only status 200: /api/v1', async () =>
     request(app)
       .get('/api/v1')
-      .expect(200));
+      .expect(200, '"root"'));
 
   it('returns object: /api/v1/user', async () =>
     request(app)
@@ -81,4 +92,11 @@ describe('API integration', () => {
       .set('Authorization', 'Bearer test')
       .send({ test: 'test' })
       .expect(200, { test: 'test' }));
+
+  it(`returns static file as ${ContentType.TEXT_HTML}: /api/v1/static/index.html`, async () =>
+    request(app)
+      .get('/api/v1/static/index.html')
+      .expect('Content-Type', ContentType.TEXT_HTML)
+      .then(res => expect(res.text).toContain('<h1>Test</h1>')));
+
 });

--- a/packages/spec/api.integration.spec.ts
+++ b/packages/spec/api.integration.spec.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { of } from 'rxjs';
 import { filter, map, mapTo, switchMap } from 'rxjs/operators';
 import * as request from 'supertest';
@@ -7,6 +8,7 @@ import { bodyParser$ } from '../middleware-body/src';
 import { readFile } from '../util/fileReader.helper';
 
 const MOCKED_USER_LIST = [{ id: 1 }, { id: 2 }];
+const STATIC_PATH = path.resolve(__dirname, '../../docs/assets');
 
 const authorize$: Effect<HttpRequest> = request$ =>
   request$.pipe(
@@ -49,7 +51,7 @@ const file$: Effect = request$ =>
     matchPath('/static/:dir'),
     matchType('GET'),
     map(req => req.params!.dir as string),
-    switchMap(readFile(__dirname + './../../docs/assets')),
+    switchMap(readFile(STATIC_PATH)),
     map(body => ({ body }))
   );
 

--- a/packages/util/fileReader.helper.spec.ts
+++ b/packages/util/fileReader.helper.spec.ts
@@ -1,0 +1,57 @@
+import * as mockFs from 'mock-fs';
+import { readFile } from './fileReader.helper';
+
+describe('File reader', () => {
+
+  beforeEach(() => {
+    spyOn(console, 'log').and.stub();
+    spyOn(console, 'info').and.stub();
+    spyOn(console, 'error').and.stub();
+  });
+
+  it('#readFile returns error when not found', done => {
+    // given
+    mockFs();
+
+    // when
+    const subscription = readFile('test/url')('index.html');
+
+    // then
+    subscription.subscribe(
+      () => {
+        fail('Exceptions should be thrown');
+        done();
+      },
+      error => {
+        expect(error).toBeDefined();
+        expect(error.message).toBe('File not found');
+        done();
+      }
+    );
+  });
+
+  it('#readFile returns Buffer when found', done => {
+    // given
+    mockFs({ 'test/url': { 'index.html': 'test' } });
+
+    // when
+    const subscription = readFile('test/url')('index.html');
+
+    // then
+    subscription.subscribe(
+      data => {
+        expect(data).toBeDefined();
+        expect(Buffer.isBuffer(data)).toEqual(true);
+        expect(data.toString()).toEqual('test');
+        done();
+      },
+      error => {
+        fail(`Exceptions shouldn't be thrown`);
+        done();
+      }
+    );
+  });
+
+  afterEach(() => mockFs.restore());
+
+});

--- a/packages/util/fileReader.helper.ts
+++ b/packages/util/fileReader.helper.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Observable } from 'rxjs';
+import { HttpError, HttpStatus } from '../core/src';
+
+export const readFile = (basePath: string) => (dir: string) =>
+  new Observable<Buffer>(subscriber => {
+    const pathname = path.resolve(basePath, dir);
+
+    fs.readFile(pathname, (err, file) => {
+      if (err && err.code === 'ENOENT') {
+        const error = new HttpError('File not found', HttpStatus.NOT_FOUND);
+        subscriber.error(error);
+      }
+      subscriber.next(file);
+      subscriber.complete();
+    });
+  });

--- a/packages/util/marbles.spec-util.ts
+++ b/packages/util/marbles.spec-util.ts
@@ -1,22 +1,19 @@
 import { Observable, OperatorFunction, from } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { Effect } from '../effects/effects.interface';
-import { HttpRequest, HttpResponse } from '../http.interface';
+import { Effect } from '../core/src/effects/effects.interface';
+import { HttpRequest, HttpResponse } from '../core/src/http.interface';
 
 type MarbleFlow = [string, object];
-type MarbleDependencies = { response: HttpResponse, error?: Error };
+type MarbleDependencies = { response: HttpResponse; error?: Error };
 
 export namespace Marbles {
+  const deepEquals = (actual, expected) => expect(actual).toEqual(expected);
 
-  const deepEquals = (actual, expected) =>
-    expect(actual).toEqual(expected);
-
-  const createTestScheduler = () =>
-    new TestScheduler(deepEquals);
+  const createTestScheduler = () => new TestScheduler(deepEquals);
 
   export const assert = <T>(
     operators: OperatorFunction<T, any>[],
-    marbleflow: [MarbleFlow, MarbleFlow]
+    marbleflow: [MarbleFlow, MarbleFlow],
   ) => {
     const [initStream, initValues] = marbleflow[0];
     const [expectedStream, expectedValues] = marbleflow[1];
@@ -59,11 +56,8 @@ export namespace Marbles {
     const [expectedStream, expectedValues] = marbleflow;
     const scheduler = createTestScheduler();
 
-    scheduler
-      .expectObservable(effects$)
-      .toBe(expectedStream, expectedValues);
+    scheduler.expectObservable(effects$).toBe(expectedStream, expectedValues);
 
     scheduler.flush();
   };
-
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Tests
```

## What is the current behavior?
- When trying to serve static files, `responseHandler` tries to `JSON.stringify()` every outgoing response.
- `responseHandler` doesn't detect mime-types automatically

Issue Number: #33 

## What is the new behavior?
- stream based `fileReader`
- integration tests for serving static files
- auto set response `content-type` based on provided body
- moved `marbles.spec-util` to common `util` folder
- added `mock-fs`, `mime` and `file-type` packages

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```