### PR TITLE
fix(core): Effect matching hazard

### DIFF
--- a/packages/core/src/effects/effects.combiner.ts
+++ b/packages/core/src/effects/effects.combiner.ts
@@ -1,5 +1,5 @@
-import { merge, of } from 'rxjs';
-import { mergeMap, switchMap } from 'rxjs/operators';
+import { concat, of } from 'rxjs';
+import { concatMap, switchMap } from 'rxjs/operators';
 import { HttpRequest } from '../http.interface';
 import { matchPath } from '../operators';
 import { isGroup } from './effects.helpers';
@@ -10,12 +10,12 @@ export const combineEffects: EffectCombiner = effects => res => req => {
   const mappedEffects = effects.map(effect => isGroup(effect)
     ? req$.pipe(
         matchPath(effect.path, { suffix: '/:foo*', combiner: true }),
-        mergeMap(combineEffects(effect.effects)(res))
+        concatMap(combineEffects(effect.effects)(res))
       )
     : effect(req$, res, undefined)
   );
 
-  return merge(...mappedEffects);
+  return concat(...mappedEffects);
 };
 
 export const combineMiddlewareEffects: MiddlewareCombiner = effects => res => req => {

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -2,9 +2,11 @@ import * as http from 'http';
 
 export interface HttpRequest extends http.IncomingMessage {
   body?: any;
-  matchers?: string[];
   params?: RouteParameters;
   query?: QueryParameters;
+  matchers?: string[];
+  matchPath: boolean;
+  matchType: boolean;
   [key: string]: any;
 }
 

--- a/packages/core/src/operators/matchPath/matchPath.operator.spec.ts
+++ b/packages/core/src/operators/matchPath/matchPath.operator.spec.ts
@@ -9,7 +9,8 @@ const reqMatched = (
   matchers: string[] = [],
   params: RouteParameters = {},
   query: QueryParameters = {},
-) => ({ url, matchers, params, query } as any as HttpRequest);
+  matchPath = true,
+) => ({ url, matchers, params, query, matchPath } as any as HttpRequest);
 
 describe('matchPath operator', () => {
   let operators;
@@ -88,15 +89,13 @@ describe('matchPath operator', () => {
     operators = [matchPath('/test', { combiner: true })];
     Marbles.assert(operators, [
       ['-a--', { a: req('/test') }],
-      ['-a--', { a: reqMatched('/test', ['/test']) }],
+      ['-a--', { a: reqMatched('/test', ['/test'], undefined, undefined, false) }],
     ]);
 
-    operators = [
-      matchPath('/test/:id/foo', { combiner: true, suffix: '/:foo*' })
-    ];
+    operators = [matchPath('/test/:id/foo', { combiner: true, suffix: '/:foo*' })];
     Marbles.assert(operators, [
       ['-a--', { a: req('/test/2/foo') }],
-      ['-a--', { a: reqMatched('/test/2/foo', ['/test/:id/foo'], { id: '2' }) }],
+      ['-a--', { a: reqMatched('/test/2/foo', ['/test/:id/foo'], { id: '2' }, undefined, false) }],
     ]);
   });
 });

--- a/packages/core/src/operators/matchPath/matchPath.operator.ts
+++ b/packages/core/src/operators/matchPath/matchPath.operator.ts
@@ -21,8 +21,11 @@ export const matchPath = (path: string, opts: MatcherOpts = {}) => (source$: Obs
     tap(req => (req.matchers = req.matchers || [])),
     filter(isRequestMatched),
     filter(req => {
+      if (path === '*') { return true; }
+
       const matcher = matcherFactory(req.matchers!, path, opts.suffix);
       const url = removeQueryParams(req.url!);
+
       return pathToRegexp(matcher).test(url);
     }),
     tap(req => (req.params = urlParamsFactory(req, path))),

--- a/packages/core/src/operators/matchPath/matchPath.operator.ts
+++ b/packages/core/src/operators/matchPath/matchPath.operator.ts
@@ -11,13 +11,15 @@ type MatcherOpts = {
   combiner?: boolean;
 };
 
-export const matchPath = (path: string, opts: MatcherOpts = {}) => (
-  source$: Observable<HttpRequest>
-) =>
+const isRequestMatched = (req: HttpRequest) =>
+  !(req.matchPath && req.matchType);
+
+export const matchPath = (path: string, opts: MatcherOpts = {}) => (source$: Observable<HttpRequest>) =>
   source$.pipe(
     tap(req => (req.query = req.query || {})),
     tap(req => (req.params = req.params || {})),
     tap(req => (req.matchers = req.matchers || [])),
+    filter(isRequestMatched),
     filter(req => {
       const matcher = matcherFactory(req.matchers!, path, opts.suffix);
       const url = removeQueryParams(req.url!);
@@ -25,5 +27,6 @@ export const matchPath = (path: string, opts: MatcherOpts = {}) => (
     }),
     tap(req => (req.params = urlParamsFactory(req, path))),
     tap(req => (req.query = queryParamsFactory(req.url!))),
-    tap(req => opts.combiner && req.matchers!.push(path))
+    tap(req => opts.combiner && req.matchers!.push(path)),
+    tap(req => (req.matchPath = !opts.combiner ? true : false)),
   );

--- a/packages/core/src/operators/matchType/matchType.operator.spec.ts
+++ b/packages/core/src/operators/matchType/matchType.operator.spec.ts
@@ -2,23 +2,24 @@ import { Marbles } from '../../../../util/marbles.spec-util';
 import { HttpRequest } from '../../http.interface';
 import { matchType } from './matchType.operator';
 
-const createMockReq = (method: string) => ({ method } as HttpRequest);
+const mockReq = (method: string) => ({ method } as HttpRequest);
+const mockReqMatched = (method: string) => ({ method, matchType: true } as HttpRequest);
 
 describe('matchType operator', () => {
 
   it('filters GET request stream', () => {
     const operators = [matchType('GET')];
     Marbles.assert(operators, [
-      ['-a-b---', { a: createMockReq('GET'), b: createMockReq('POST') }],
-      ['-a-----', { a: createMockReq('GET') }],
+      ['-a-b---', { a: mockReq('GET'), b: mockReq('POST') }],
+      ['-a-----', { a: mockReqMatched('GET') }],
     ]);
   });
 
   it('filters POST request stream', () => {
     const operators = [matchType('POST')];
     Marbles.assert(operators, [
-      ['-a-b---', { a: createMockReq('GET'), b: createMockReq('POST') }],
-      ['---b---', { b: createMockReq('POST') }],
+      ['-a-b---', { a: mockReq('GET'), b: mockReq('POST') }],
+      ['---b---', { b: mockReqMatched('POST') }],
     ]);
   });
 

--- a/packages/core/src/operators/matchType/matchType.operator.ts
+++ b/packages/core/src/operators/matchType/matchType.operator.ts
@@ -1,8 +1,9 @@
 import { Observable } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, tap } from 'rxjs/operators';
 import { HttpMethod, HttpRequest } from '../../http.interface';
 
 export const matchType = (method: HttpMethod) => (source$: Observable<HttpRequest>) =>
   source$.pipe(
-    filter(req => req.method === method)
+    filter(req => req.method === method),
+    tap(req => req.matchType = true),
   );

--- a/packages/spec/routing.integration.spec.ts
+++ b/packages/spec/routing.integration.spec.ts
@@ -1,0 +1,94 @@
+import { delay, map, tap } from 'rxjs/operators';
+import * as request from 'supertest';
+import { Effect, httpListener, matchPath, matchType } from '../core/src';
+
+describe('Routing integration', async () => {
+
+  test('flow goes through Effects in array order', () => {
+    // given
+    const p1$: Effect = req$ => req$.pipe(
+      tap(req => req.test = req.test || []),
+      tap(req => req.test.push(1)),
+      matchPath('/p1'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const p2$: Effect = req$ => req$.pipe(
+      tap(req => req.test = req.test || []),
+      tap(req => req.test.push(2)),
+      delay(100),
+      matchPath('/p2'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const p3$: Effect = req$ => req$.pipe(
+      tap(req => req.test = req.test || []),
+      tap(req => req.test.push(3)),
+      matchPath('/p3'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const app = httpListener({ effects: [p1$, p2$, p3$ ] });
+
+    // when
+    return Promise.all([
+      request(app).get('/p1').expect(200, [1]),
+      request(app).get('/p2').expect(200, [1, 2]),
+      request(app).get('/p3').expect(200, [1, 2, 3]),
+    ]);
+  });
+
+  test('when all paths are the same - resolves only one Effect', () => {
+    // given
+    const p1$: Effect = req$ => req$.pipe(
+      tap(req => req.test = req.test || []),
+      tap(req => req.test.push(1)),
+      delay(100),
+      matchPath('/p1'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const p2$: Effect = req$ => req$.pipe(
+      tap(req => req.test = req.test || []),
+      tap(req => req.test.push(2)),
+      matchPath('/p1'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const p3$: Effect = req$ => req$.pipe(
+      tap(req => req.test = req.test || []),
+      tap(req => req.test.push(3)),
+      matchPath('/p1'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const app = httpListener({ effects: [p1$, p2$, p3$ ] });
+
+    // when
+    return request(app).get('/p1').expect(200, [1]);
+  });
+
+  test('when paths with params are matched - resolves Effects in array order', () => {
+    // given
+    const p1$: Effect = req$ => req$.pipe(
+      tap(req => req.test = req.test || []),
+      tap(req => req.test.push(1)),
+      matchPath('/p1'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const p2$: Effect = req$ => req$.pipe(
+      tap(req => req.test = req.test || []),
+      tap(req => req.test.push(2)),
+      matchPath('/:name'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    // then
+    const app1 = httpListener({ effects: [p1$, p2$ ] });
+    const app2 = httpListener({ effects: [p2$, p1$ ] });
+
+    // when
+    return Promise.all([
+      // 1 - /p1  2 - /:name
+      request(app1).get('/p1').expect(200, [1]),
+      request(app1).get('/test').expect(200, [1, 2]),
+      // 1 - /:name  2 - /p1
+      request(app2).get('/test').expect(200, [2]),
+      request(app2).get('/p1').expect(200, [2]),
+    ]);
+  });
+
+});

--- a/packages/spec/routing.integration.spec.ts
+++ b/packages/spec/routing.integration.spec.ts
@@ -1,6 +1,6 @@
 import { delay, map, tap } from 'rxjs/operators';
 import * as request from 'supertest';
-import { Effect, httpListener, matchPath, matchType } from '../core/src';
+import { Effect, combineRoutes, httpListener, matchPath, matchType } from '../core/src';
 
 describe('Routing integration', async () => {
 
@@ -25,13 +25,23 @@ describe('Routing integration', async () => {
       matchPath('/p3'), matchType('GET'), map(req => ({ body: req.test }))
     );
 
-    const app = httpListener({ effects: [p1$, p2$, p3$ ] });
+    const all$: Effect = req$ => req$.pipe(
+      tap(req => req.test = req.test || []),
+      tap(req => req.test.push('all')),
+      matchPath('*'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const combined$ = combineRoutes('/combined', [p1$]);
+
+    const app = httpListener({ effects: [p1$, p2$, combined$, p3$, all$] });
 
     // when
     return Promise.all([
       request(app).get('/p1').expect(200, [1]),
+      request(app).get('/combined/p1').expect(200, [1, 2, 1]),
       request(app).get('/p2').expect(200, [1, 2]),
       request(app).get('/p3').expect(200, [1, 2, 3]),
+      request(app).get('/combined/not-found').expect(200, [1, 2, 1, 3, 'all']),
     ]);
   });
 
@@ -89,6 +99,26 @@ describe('Routing integration', async () => {
       request(app2).get('/test').expect(200, [2]),
       request(app2).get('/p1').expect(200, [2]),
     ]);
+  });
+
+  test('when no paths are matched - executes last "*" handler', () => {
+    // given
+    const p1$: Effect = req$ => req$.pipe(
+      matchPath('/p1'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const p2$: Effect = req$ => req$.pipe(
+      matchPath('/p2'), matchType('GET'), map(req => ({ body: req.test }))
+    );
+
+    const notFound$: Effect = req$ => req$.pipe(
+      matchPath('*'), matchType('GET'), map(req => ({ body: 'not-found' }))
+    );
+
+    const app = httpListener({ effects: [p1$, p2$, notFound$ ] });
+
+    // when
+    return request(app).get('/test').expect(200, '"not-found"');
   });
 
 });


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Tests
```

## What is the current behavior?
For two effects defined:
- `/user/search`
- `/user/:id`

Both effects got applied, resulting in:
`Error: Can't set headers after they are sent.`

Issue Number: #35, #27  


## What is the new behavior?
- _Effects_ are matched one by one
- only one _Effect_ should be resolved
- match all paths using `*` sign

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```