### PR TITLE
feat(core): matchType - match all types using * sign

### DIFF
--- a/example/src/controllers/api.controller.ts
+++ b/example/src/controllers/api.controller.ts
@@ -1,5 +1,6 @@
-import { Effect, combineRoutes, matchPath, matchType } from '@marblejs/core';
-import { map } from 'rxjs/operators';
+import { Effect, HttpError, HttpStatus, combineRoutes, matchPath, matchType } from '@marblejs/core';
+import { throwError } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 import { user$ } from './user.controller';
 
 const root$: Effect = request$ => request$
@@ -11,7 +12,16 @@ const root$: Effect = request$ => request$
     })),
   );
 
+const notFound$: Effect = request$ => request$
+  .pipe(
+    matchPath('*'),
+    matchType('*'),
+    switchMap(() =>
+      throwError(new HttpError('Route not found', HttpStatus.NOT_FOUND))
+    )
+  );
+
 export const api$ = combineRoutes(
   '/api/v1',
-  [ root$, user$ ],
+  [ root$, user$, notFound$ ],
 );

--- a/packages/core/src/operators/matchType/matchType.operator.spec.ts
+++ b/packages/core/src/operators/matchType/matchType.operator.spec.ts
@@ -23,4 +23,12 @@ describe('matchType operator', () => {
     ]);
   });
 
+  it('matches all HTTP methods', () => {
+    const operators = [matchType('*')];
+    Marbles.assert(operators, [
+      ['-a-b---', { a: mockReq('GET'), b: mockReq('POST') }],
+      ['-a-b---', { a: mockReqMatched('GET'), b: mockReqMatched('POST') }],
+    ]);
+  });
+
 });

--- a/packages/core/src/operators/matchType/matchType.operator.ts
+++ b/packages/core/src/operators/matchType/matchType.operator.ts
@@ -2,8 +2,8 @@ import { Observable } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 import { HttpMethod, HttpRequest } from '../../http.interface';
 
-export const matchType = (method: HttpMethod) => (source$: Observable<HttpRequest>) =>
+export const matchType = (method: HttpMethod | '*') => (source$: Observable<HttpRequest>) =>
   source$.pipe(
-    filter(req => req.method === method),
+    filter(req => req.method === method || method === '*'),
     tap(req => req.matchType = true),
   );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- it is impossible to implement `404` handler because `matchType` can't match all http types
Issue Number: #27 

## What is the new behavior?
- `matchType` can have as an argument `*` sign - which means: "match all method types"

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
