### PR TITLE
fix(core): matchers should be resetted after unsuccessful matching

### DIFF
--- a/packages/core/src/operators/matchPath/matchPath.factory.spec.ts
+++ b/packages/core/src/operators/matchPath/matchPath.factory.spec.ts
@@ -1,6 +1,6 @@
-import { matcherFactory, removeQueryParams, removeTrailingSlash } from './matcher.factory';
+import { matchPathFactory, removeQueryParams, removeTrailingSlash } from './matchPath.factory';
 
-describe('matcher factory', () => {
+describe('matchPath factory', () => {
 
   it('#removeQueryParams removes query parameters from url', () => {
     // given
@@ -32,7 +32,7 @@ describe('matcher factory', () => {
     const pathToMatch = '/foo/';
 
     // when
-    const matcher = matcherFactory(matchingHistory, pathToMatch);
+    const matcher = matchPathFactory(matchingHistory, pathToMatch);
 
     // then
     expect(matcher).toEqual('/api/v1/user/foo');
@@ -44,7 +44,7 @@ describe('matcher factory', () => {
     const pathToMatch = '/foo/';
 
     // when
-    const matcher = matcherFactory(matchingHistory, pathToMatch);
+    const matcher = matchPathFactory(matchingHistory, pathToMatch);
 
     // then
     expect(matcher).toEqual('/api/v1/user/foo');
@@ -57,7 +57,7 @@ describe('matcher factory', () => {
     const suffix = '/:foo*';
 
     // when
-    const matcher = matcherFactory(matchingHistory, pathToMatch, suffix);
+    const matcher = matchPathFactory(matchingHistory, pathToMatch, suffix);
 
     // then
     expect(matcher).toEqual('/api/:version/user/foo/:foo*');

--- a/packages/core/src/operators/matchPath/matchPath.factory.ts
+++ b/packages/core/src/operators/matchPath/matchPath.factory.ts
@@ -3,7 +3,7 @@ export const removeTrailingSlash = (path: string): string =>
 
 export const removeQueryParams = (path: string): string => path.split('?')[0];
 
-export const matcherFactory = (
+export const matchPathFactory = (
   matchingHistory: string[],
   pathToMatch: string,
   suffix?: string

--- a/packages/core/src/operators/matchPath/matchPath.operator.ts
+++ b/packages/core/src/operators/matchPath/matchPath.operator.ts
@@ -2,7 +2,8 @@ import * as pathToRegexp from 'path-to-regexp';
 import { Observable } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 import { HttpRequest } from '../../http.interface';
-import { matcherFactory, removeQueryParams } from './matcher.factory';
+import { isRequestNotMatched, matchGuard } from '../../util/matcher.guard';
+import { matchPathFactory, removeQueryParams } from './matchPath.factory';
 import { queryParamsFactory } from './queryParams.factory';
 import { urlParamsFactory } from './urlParams.factory';
 
@@ -11,22 +12,20 @@ type MatcherOpts = {
   combiner?: boolean;
 };
 
-const isRequestMatched = (req: HttpRequest) =>
-  !(req.matchPath && req.matchType);
-
 export const matchPath = (path: string, opts: MatcherOpts = {}) => (source$: Observable<HttpRequest>) =>
   source$.pipe(
     tap(req => (req.query = req.query || {})),
     tap(req => (req.params = req.params || {})),
     tap(req => (req.matchers = req.matchers || [])),
-    filter(isRequestMatched),
+    filter(isRequestNotMatched),
     filter(req => {
       if (path === '*') { return true; }
 
-      const matcher = matcherFactory(req.matchers!, path, opts.suffix);
+      const matcher = matchPathFactory(req.matchers!, path, opts.suffix);
       const url = removeQueryParams(req.url);
+      const isMatched = pathToRegexp(matcher).test(url);
 
-      return pathToRegexp(matcher).test(url);
+      return matchGuard(isMatched)(req);
     }),
     tap(req => (req.params = urlParamsFactory(req, path))),
     tap(req => (req.query = queryParamsFactory(req.url))),

--- a/packages/core/src/operators/matchPath/urlParams.factory.ts
+++ b/packages/core/src/operators/matchPath/urlParams.factory.ts
@@ -1,9 +1,9 @@
 import * as pathToRegexp from 'path-to-regexp';
 import { HttpRequest, RouteParameters } from '../../http.interface';
-import { matcherFactory, removeQueryParams } from './matcher.factory';
+import { matchPathFactory, removeQueryParams } from './matchPath.factory';
 
 export const urlParamsFactory = (req: HttpRequest, path: string): RouteParameters => {
-  const match = matcherFactory(req.matchers!, path);
+  const match = matchPathFactory(req.matchers!, path);
   const url = removeQueryParams(req.url);
   const params = pathToRegexp(match).exec(url);
   const routes = pathToRegexp.parse(match);

--- a/packages/core/src/operators/matchType/matchType.operator.ts
+++ b/packages/core/src/operators/matchType/matchType.operator.ts
@@ -1,9 +1,11 @@
 import { Observable } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 import { HttpMethod, HttpRequest } from '../../http.interface';
+import { isRequestNotMatched, matchGuard } from '../../util/matcher.guard';
 
 export const matchType = (method: HttpMethod | '*') => (source$: Observable<HttpRequest>) =>
   source$.pipe(
-    filter(req => req.method === method || method === '*'),
-    tap(req => req.matchType = true),
+    filter(isRequestNotMatched),
+    filter(req => matchGuard(req.method === method || method === '*')(req)),
+    tap(req => (req.matchType = true)),
   );

--- a/packages/core/src/util/matcher.guard.spec.ts
+++ b/packages/core/src/util/matcher.guard.spec.ts
@@ -1,0 +1,30 @@
+import { HttpRequest } from '../http.interface';
+import { isRequestNotMatched, matchGuard } from './matcher.guard';
+
+describe('Matcher guard', () => {
+
+  test('#isRequestNotMatched checks if request was matched', () => {
+    // given
+    const notMatchedReq = { matchType: true, matchPath: false } as HttpRequest;
+
+    // when
+    const isNotMatched = isRequestNotMatched(notMatchedReq);
+
+    // then
+    expect(isNotMatched).toBe(true);
+  });
+
+  test(`#matchGuard resets matchers if matching predicate is false and request wasn't matched`, () => {
+    // given
+    const req = { matchType: true, matchPath: false } as HttpRequest;
+    const expectedReq = { matchType: false, matchPath: false } as HttpRequest;
+
+    // when
+    const matchingResult = matchGuard(false)(req);
+
+    // then
+    expect(matchingResult).toBe(false);
+    expect(req).toEqual(expectedReq);
+  });
+
+});

--- a/packages/core/src/util/matcher.guard.ts
+++ b/packages/core/src/util/matcher.guard.ts
@@ -1,0 +1,13 @@
+import { HttpRequest } from '../http.interface';
+
+export const isRequestNotMatched = (req: HttpRequest) =>
+  !(req.matchPath && req.matchType);
+
+export const matchGuard = (isMatched: boolean) => (req: HttpRequest) => {
+  if (!isMatched && isRequestNotMatched(req)) {
+    req.matchType = false;
+    req.matchPath = false;
+  }
+
+  return isMatched;
+};


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Example:
```javascript
    const e1$: Effect = req$ => req$.pipe(
      matchPath('/test'),
      matchType('GET'),
      // ...
    );

    const e2$: Effect = req$ => req$.pipe(
      matchType('POST'),
      matchPath('/test'),
      // ...
    );
```
Lets say we have two endpoints which are listening for the same route but with different order of matchers for different methods (POST, GET). If we will send a `POST /test` the last endpoint won't be matched properly, but it should.

Issue Number: N/A


## What is the new behavior?
After each unsuccessful matching (`matchType` or `matchPath`) the `matcherGuard` should reset all matching points when the request wasn't matched. It will prevent any leftovers.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```