### PR TITLE
feat: `EffectFactory` validation + dedicated `CoreError` stack traces

### DIFF
--- a/packages/core/src/effects/effects.factory.ts
+++ b/packages/core/src/effects/effects.factory.ts
@@ -1,15 +1,43 @@
-import { HttpMethod } from '../http.interface';
+import { HttpMethod, HttpMethodType } from '../http.interface';
 import { Effect, EffectResponse } from './effects.interface';
 import { RouteEffect } from '../router/router.interface';
+import { coreErrorFactory, CoreErrorOptions } from '../error/error.factory';
+import { getArrayFromEnum } from '../util/array.util';
 
 export namespace EffectFactory {
 
-  export const matchPath = (path: string) => ({
-    matchType: (method: HttpMethod) => ({
-      use: (effect: Effect<EffectResponse>): RouteEffect => ({
-        path, method, effect
-      }),
-    }),
-  });
+  const httpMethods = getArrayFromEnum(HttpMethodType);
+  const coreErrorOptions: CoreErrorOptions =  { contextMethod: 'EffectFactory' };
+
+  export const matchPath = (path: string) => {
+    if (!path) {
+      throw coreErrorFactory('Path cannot be empty', coreErrorOptions);
+    }
+
+    return { matchType: matchType(path) };
+  };
+
+  const matchType = (path: string) => (method: HttpMethod) => {
+    if (!method) {
+      throw coreErrorFactory('HttpMethod needs to be defined', coreErrorOptions);
+    }
+
+    if (!httpMethods.includes(method)) {
+      throw coreErrorFactory(
+        `HttpMethod needs to be one of the following: ${httpMethods}`,
+        coreErrorOptions,
+      );
+    }
+
+    return { use: use(path)(method) };
+  };
+
+  const use = (path: string) => (method: HttpMethod) => (effect: Effect<EffectResponse>): RouteEffect => {
+    if (!effect) {
+      throw coreErrorFactory('Effect needs to be provided', coreErrorOptions);
+    }
+
+    return { path, method, effect };
+  };
 
 }

--- a/packages/core/src/effects/specs/effects.factory.spec.ts
+++ b/packages/core/src/effects/specs/effects.factory.spec.ts
@@ -49,7 +49,7 @@ describe('EffectFactory', () => {
     expect(effectFactoryFn).toThrowError(expectedError);
   });
 
-  test('throws an error if "mathod" is not provided', () => {
+  test('throws an error if "method" is not provided', () => {
     // given
     expectedError = new Error('HttpMethod needs to be defined');
 
@@ -62,7 +62,7 @@ describe('EffectFactory', () => {
     expect(effectFactoryFn).toThrowError(expectedError);
   });
 
-  test('throws an error if provided "mathod" is not included in the list', () => {
+  test('throws an error if provided "method" is not included in the list', () => {
     // given
     expectedError = new Error(
       'HttpMethod needs to be one of the following: POST,PUT,PATCH,GET,HEAD,DELETE,CONNECT,OPTIONS,TRACE,*'

--- a/packages/core/src/effects/specs/effects.factory.spec.ts
+++ b/packages/core/src/effects/specs/effects.factory.spec.ts
@@ -1,10 +1,24 @@
 import { mapTo } from 'rxjs/operators';
 import { Effect } from '../effects.interface';
 import { EffectFactory } from '../effects.factory';
+import { HttpMethod } from '../../http.interface';
 
-describe('Effects factory', () => {
+describe('EffectFactory', () => {
 
-  test('#effect factorizes RouteConfig', () => {
+  let expectedError: Error;
+  let coreError;
+
+  beforeEach(() => {
+    jest.unmock('../../error/error.factory.ts');
+    coreError = require('../../error/error.factory.ts');
+    coreError.coreErrorFactory = jest.fn(() => expectedError);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('factorizes RouteConfig', () => {
     // given
     const effect$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
     const path = '/foo';
@@ -22,6 +36,59 @@ describe('Effects factory', () => {
       method: 'GET',
       effect: effect$,
     });
+  });
+
+  test('throws an error if "path" is not provided', () => {
+    // given
+    expectedError = new Error('Path cannot be empty');
+
+    // when
+    const effectFactoryFn = () => EffectFactory.matchPath(undefined);
+
+    // then
+    expect(effectFactoryFn).toThrowError(expectedError);
+  });
+
+  test('throws an error if "mathod" is not provided', () => {
+    // given
+    expectedError = new Error('HttpMethod needs to be defined');
+
+    // when
+    const effectFactoryFn = () => EffectFactory
+      .matchPath('/')
+      .matchType(undefined);
+
+    // then
+    expect(effectFactoryFn).toThrowError(expectedError);
+  });
+
+  test('throws an error if provided "mathod" is not included in the list', () => {
+    // given
+    expectedError = new Error(
+      'HttpMethod needs to be one of the following: POST,PUT,PATCH,GET,HEAD,DELETE,CONNECT,OPTIONS,TRACE,*'
+    );
+
+    // when
+    const effectFactoryFn = () => EffectFactory
+      .matchPath('/')
+      .matchType('TEST' as HttpMethod);
+
+    // then
+    expect(effectFactoryFn).toThrowError(expectedError);
+  });
+
+  test('throws an error if "effect" is not provided', () => {
+    // given
+    expectedError = new Error('Effect needs to be provided');
+
+    // when
+    const effectFactoryFn = () => EffectFactory
+      .matchPath('/')
+      .matchType('GET')
+      .use(undefined);
+
+    // then
+    expect(effectFactoryFn).toThrowError(expectedError);
   });
 
 });

--- a/packages/core/src/error/error.effect.ts
+++ b/packages/core/src/error/error.effect.ts
@@ -17,9 +17,9 @@ const errorFactory = (message: string, status: HttpStatus, data?: any) => ({
   error: { status, message, data }
 });
 
-export const error$: Effect<EffectResponse, ThrownError> = (request$, response, error) => request$
+export const error$: Effect<EffectResponse, ThrownError> = (request$, _, error) => request$
   .pipe(
-    map(req => {
+    map(() => {
       const { message, data } = error;
       const status = getStatusCode(error);
       const body = errorFactory(message, status, data);

--- a/packages/core/src/error/error.factory.ts
+++ b/packages/core/src/error/error.factory.ts
@@ -1,0 +1,34 @@
+import chalk from 'chalk';
+import { CoreError } from './error.model';
+
+export type CoreErrorOptions = {
+  contextMethod: string;
+  contextPackage?: string;
+};
+
+export const coreErrorStackTraceFactory = (opts: CoreErrorOptions) => (message: string, stack: NodeJS.CallSite[]) => {
+  const [method, file] = stack;
+  const [line, col] = [file.getLineNumber() || 0, file.getColumnNumber() || 0];
+  const packageName = opts.contextPackage || '@marblejs/core';
+  const methodName = opts.contextMethod + ' : ' + (method.getMethodName() || '-');
+  const fileName = file.getFileName() || '';
+
+  return `
+    ${chalk.red(`${packageName} error:`)}
+
+      🚨  ${message}
+
+      👉  ${chalk.yellow.bold(methodName)}
+        @ file: ${chalk.underline(fileName)}
+        @ line: [${line.toString()}:${col.toString()}]
+  `;
+};
+
+export const coreErrorFactory = (message: string, opts: CoreErrorOptions) =>
+  new CoreError(
+    message || 'Something is not right...',
+    {
+      stackTraceFactory: coreErrorStackTraceFactory(opts),
+      context: coreErrorFactory,
+    }
+  );

--- a/packages/core/src/error/error.factory.ts
+++ b/packages/core/src/error/error.factory.ts
@@ -6,22 +6,28 @@ export type CoreErrorOptions = {
   contextPackage?: string;
 };
 
+export const stringifyStackTrace = (stackTrace: NodeJS.CallSite[]) =>
+  stackTrace
+    .map(s => chalk.gray(`    @ ${s}`))
+    .join('\n  ');
+
 export const coreErrorStackTraceFactory = (opts: CoreErrorOptions) => (message: string, stack: NodeJS.CallSite[]) => {
-  const [method, file] = stack;
+  const [method, file, ...restStack] = stack;
   const [line, col] = [file.getLineNumber() || 0, file.getColumnNumber() || 0];
   const packageName = opts.contextPackage || '@marblejs/core';
   const methodName = opts.contextMethod + ' : ' + (method.getMethodName() || '-');
   const fileName = file.getFileName() || '';
 
   return `
-    ${chalk.red(`${packageName} error:`)}
+  ${chalk.red(`${packageName} error:`)}
 
-      🚨  ${message}
+  🚨  ${message}
 
-      👉  ${chalk.yellow.bold(methodName)}
-        @ file: ${chalk.underline(fileName)}
-        @ line: [${line.toString()}:${col.toString()}]
-  `;
+  👉  ${chalk.yellow.bold(methodName)}
+    @ file: ${chalk.underline(fileName)}
+    @ line: [${line.toString()}:${col.toString()}]
+
+  ${stringifyStackTrace(restStack)}\n`;
 };
 
 export const coreErrorFactory = (message: string, opts: CoreErrorOptions) =>

--- a/packages/core/src/error/error.model.ts
+++ b/packages/core/src/error/error.model.ts
@@ -16,5 +16,20 @@ export class HttpError extends ExtendableError {
   }
 }
 
+export class CoreError extends ExtendableError {
+  constructor(
+    public readonly message: string,
+    options: {
+      stackTraceFactory: (message: string, stack: NodeJS.CallSite[]) => string,
+      context: any,
+    }
+  ) {
+    super('CoreError', message);
+
+    Error.prepareStackTrace = (_, stack) => options.stackTraceFactory(message, stack);
+    Error.captureStackTrace(this, options.context);
+  }
+}
+
 export const isHttpError = (error: Error): error is HttpError =>
   error.name === 'HttpError';

--- a/packages/core/src/error/specs/error.factory.spec.ts
+++ b/packages/core/src/error/specs/error.factory.spec.ts
@@ -1,0 +1,101 @@
+import { CoreErrorOptions, coreErrorFactory, coreErrorStackTraceFactory } from '../error.factory';
+
+const getMockedStackTrace = (opts: any = {}) => [
+  { getMethodName: jest.fn(() => opts.methodName) },
+  {
+    getFileName: jest.fn(() => opts.filename),
+    getLineNumber: jest.fn(() => opts.lineNumber),
+    getColumnNumber: jest.fn(() => opts.columnNumber),
+  },
+] as any as NodeJS.CallSite[];
+
+describe('Error factory', () => {
+
+  describe('#coreErrorStackTraceFactory', () => {
+    test('factorizes stack trace', () => {
+      // given
+      const message = 'test-message';
+      const stack = getMockedStackTrace({
+        lineNumber: 1,
+        columnNumber: 2,
+        methodName: 'test-method',
+        filename: 'test-filename',
+      });
+      const options: CoreErrorOptions = {
+        contextMethod: 'test-context-method',
+        contextPackage: 'test-context-package',
+      };
+
+      // when
+      const factorizedStackTrace = coreErrorStackTraceFactory(options)(message, stack);
+
+      // then
+      expect(factorizedStackTrace.includes('test-context-package')).toEqual(true);
+      expect(factorizedStackTrace.includes('test-message')).toEqual(true);
+      expect(factorizedStackTrace.includes('test-context-method : test-method'));
+      expect(factorizedStackTrace.includes('test-filename')).toEqual(true);
+      expect(factorizedStackTrace.includes('[1:2]')).toEqual(true);
+    });
+
+    test('factorizes stack trace with undefined attributes', () => {
+      // given
+      const message = 'test-message';
+      const stack = getMockedStackTrace({
+        lineNumber: undefined,
+        columnNumber: undefined,
+        methodName: undefined,
+        filename: undefined,
+      });
+      const options: CoreErrorOptions = {
+        contextMethod: 'test-context-method',
+      };
+
+      // when
+      const factorizedStackTrace = coreErrorStackTraceFactory(options)(message, stack);
+
+      // then
+      expect(factorizedStackTrace.includes('@marblejs/core')).toEqual(true);
+      expect(factorizedStackTrace.includes('test-message')).toEqual(true);
+      expect(factorizedStackTrace.includes('test-context-method : -')).toEqual(true);
+      expect(factorizedStackTrace.includes('[0:0]')).toEqual(true);
+    });
+  });
+
+  describe('#coreErrorFactory', () => {
+    beforeEach(() => {
+      jest.unmock('../error.factory.ts');
+      require('../error.factory.ts').coreErrorStackTraceFactory = jest.fn(() => jest.fn());
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test('factorizes CoreError', () => {
+      // given
+      const message = 'test-message';
+      const options = {} as CoreErrorOptions;
+
+      // when
+      const factorizedError = coreErrorFactory(message, options);
+
+      // then
+      expect(factorizedError).toBeDefined();
+      expect(factorizedError.message).toEqual(message);
+    });
+
+    test('factorizes CoreError when message is empty', () => {
+      // given
+      const message = '';
+      const options = {} as CoreErrorOptions;
+
+      // when
+      const factorizedError = coreErrorFactory(message, options);
+
+      // then
+      expect(factorizedError).toBeDefined();
+      expect(factorizedError.message).toEqual('Something is not right...');
+    });
+  });
+
+});

--- a/packages/core/src/error/specs/error.factory.spec.ts
+++ b/packages/core/src/error/specs/error.factory.spec.ts
@@ -1,4 +1,4 @@
-import { CoreErrorOptions, coreErrorFactory, coreErrorStackTraceFactory } from '../error.factory';
+import { CoreErrorOptions, coreErrorFactory, coreErrorStackTraceFactory, stringifyStackTrace } from '../error.factory';
 
 const getMockedStackTrace = (opts: any = {}) => [
   { getMethodName: jest.fn(() => opts.methodName) },
@@ -10,6 +10,23 @@ const getMockedStackTrace = (opts: any = {}) => [
 ] as any as NodeJS.CallSite[];
 
 describe('Error factory', () => {
+
+  describe('#stringifyStackTrace', () => {
+    test('stringifies stack trace', () => {
+      // given
+      const stackTrace = ['1', '2', '3'] as any as NodeJS.CallSite[];
+
+      // when
+      // jest.spyOn(chalk, 'gray');
+      const stringifiedStackTrace = stringifyStackTrace(stackTrace);
+
+      // then
+      expect(stringifiedStackTrace).toBeDefined();
+      expect(stringifiedStackTrace).toContain('@ 1');
+      expect(stringifiedStackTrace).toContain('@ 2');
+      expect(stringifiedStackTrace).toContain('@ 3');
+    });
+  });
 
   describe('#coreErrorStackTraceFactory', () => {
     test('factorizes stack trace', () => {

--- a/packages/core/src/error/specs/error.model.spec.ts
+++ b/packages/core/src/error/specs/error.model.spec.ts
@@ -1,21 +1,49 @@
-import { ExtendableError, HttpError, isHttpError } from '../error.model';
+import { ExtendableError, HttpError, isHttpError, CoreError } from '../error.model';
 
-describe('Error', () => {
+describe('Error model', () => {
 
-  it('#ExtendableError creates error object', () => {
+  beforeEach(() => {
+    jest.spyOn(Error, 'captureStackTrace');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('#ExtendableError creates error object', () => {
     const error = new ExtendableError('TestError', 'test-message');
+
     expect(error.name).toBe('TestError');
     expect(error.message).toBe('test-message');
   });
 
-  it('#HttpError creates error object', () => {
+  test('#HttpError creates error object', () => {
     const error = new HttpError('test-message', 200);
+
     expect(error.name).toBe('HttpError');
     expect(error.status).toBe(200);
     expect(error.message).toBe('test-message');
   });
 
-  it('#isHttpError detects HttpError type', () => {
+  test('#CoreError creates error object', () => {
+    // given
+    const stackTraceFactory = jest.fn();
+    const error = new CoreError('test-message', {
+      context: {},
+      stackTraceFactory,
+    });
+
+    // when
+    Error.prepareStackTrace(error, []);
+
+    // then
+    expect(error.name).toBe('CoreError');
+    expect(error.message).toBe('test-message');
+    expect(Error.captureStackTrace).toHaveBeenCalled();
+    expect(stackTraceFactory).toHaveBeenCalledWith('test-message', []);
+  });
+
+  test('#isHttpError detects HttpError type', () => {
     const httpError = new HttpError('test-message', 200);
     const otherError = new Error();
 

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -20,17 +20,20 @@ export interface HttpResponse extends http.ServerResponse {
 
 export type HttpHeaders = Record<string, string>;
 
-export type HttpMethod =
-  | 'POST'
-  | 'PUT'
-  | 'PATCH'
-  | 'GET'
-  | 'HEAD'
-  | 'DELETE'
-  | 'CONNECT'
-  | 'OPTIONS'
-  | 'TRACE'
-  | '*';
+export enum HttpMethodType {
+  POST,
+  PUT,
+  PATCH,
+  GET,
+  HEAD,
+  DELETE,
+  CONNECT,
+  OPTIONS,
+  TRACE,
+  '*',
+}
+
+export type HttpMethod = keyof typeof HttpMethodType;
 
 export type Http = {
   req: HttpRequest;

--- a/packages/core/src/util/array.util.ts
+++ b/packages/core/src/util/array.util.ts
@@ -1,0 +1,2 @@
+export const getArrayFromEnum = (E: Object) =>
+  Object.keys(E).filter(key => typeof E[key as any] === 'number');


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
For non-TypeScript developers there is not any sort of validation made during app startup, eg. `EffectFactory` methods are not validated if developer will provide wrong `HttpMethod` to the `matchType` method.

Issue Number: https://github.com/marblejs/marble/projects/1#card-11043276

## What is the new behavior?
- refactored `EffectFactory` builder
- added validation for `EffectFactory` methods
- introduced dedicated `CoreError` error type used for throwing an package related error messages, eg. for notifying non-TypeScript developers if they will make a mistake in the method arguments

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Example

<img width="1061" alt="zrzut ekranu 2018-08-24 o 22 50 35" src="https://user-images.githubusercontent.com/7793430/44607342-744d1b00-a7f0-11e8-9f0a-c6d100191b96.png">
