### PR TITLE
fix(core): fixed problem with path concatenation combined with wildcard sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,20 +39,7 @@ For the latest updates, documentation, change log, and release information visit
 
 ## <a name="examples"></a> Examples
 
-To view the example project structure, clone the **Marble.js** repository and install the dependencies:
-
-```bash
-$ git clone git://github.com/marblejs/marble.git
-$ cd marble
-$ npm i
-$ cd example
-```
-
-To run example just execute following command inside root repository folder:
-
-```bash
-$ yarn start
-```
+To view the example project structure, visit the [example](https://github.com/marblejs/example) repository.
 
 ## <a name="roadmap"></a> Roadmap
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,6 @@ module.exports = {
     '@example',
     '@integration',
     '\\+internal/testing',
-    '\\+internal/fp'
   ],
   collectCoverageFrom : ['packages/**/*.ts'],
   moduleFileExtensions: [

--- a/packages/@integration/test/integration.spec.ts
+++ b/packages/@integration/test/integration.spec.ts
@@ -20,8 +20,7 @@ describe('API integration', () => {
       .get('/api/v2')
       .expect(200, '"API version: v2"'));
 
-  // @TODO: fix an error with `*` after placeholder path
-  xtest('GET: /api/v1/foo triggers 404 effect', async () =>
+  test('GET: /api/v1/foo triggers 404 effect', async () =>
     request(app)
       .get('/api/v1/foo')
       .expect(404, {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,8 @@
   },
   "devDependencies": {
     "@types/file-type": "^5.2.1",
-    "@types/mime": "^2.0.0"
+    "@types/mime": "^2.0.0",
+    "webpack": "^4.17.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/+internal/fp/maybe.ts
+++ b/packages/core/src/+internal/fp/maybe.ts
@@ -1,18 +1,20 @@
 import { Functor } from './functor';
 
+export type Nullable<T> = T | null | undefined;
+
 export interface MaybeCases<T, U> {
   some: (t: T) => U;
   none: () => U;
 }
 
 export class Maybe<T> implements Functor<T> {
-  private constructor(private value: T | null | undefined) {}
+  private constructor(private value: Nullable<T>) {}
 
   private static some = <T>(value: T) => new Maybe(value);
 
   private static none = <T>() => new Maybe<T>(null);
 
-  static of = <T>(value: T) =>
+  static of = <T>(value: Nullable<T>) =>
     value
       ? Maybe.some(value)
       : Maybe.none<T>()

--- a/packages/core/src/+internal/fp/spec/compose.spec.ts
+++ b/packages/core/src/+internal/fp/spec/compose.spec.ts
@@ -1,0 +1,33 @@
+import { compose } from '../compose';
+
+describe('#compose', () => {
+  test('works correctly with more than 2 functions', () => {
+    // given
+    const add = (a: number) => (b: number) => b + a;
+    const substract = (a: number) => (b: number) => b - a;
+    const multiply = (a: number) => (b: number) => b * a;
+
+    // when
+    const result = compose(
+      multiply(2),
+      substract(2),
+      add(1),
+    )(10);
+
+    // then
+    expect(result).toEqual(18);
+  });
+
+  test('works correctly with 1 function', () => {
+    // given
+    const add = (a: number) => (b: number) => b + a;
+
+    // when
+    const result = compose(
+      add(1),
+    )(10);
+
+    // then
+    expect(result).toEqual(11);
+  });
+});

--- a/packages/core/src/+internal/fp/spec/maybe.spec.ts
+++ b/packages/core/src/+internal/fp/spec/maybe.spec.ts
@@ -1,0 +1,121 @@
+import { Maybe } from '../maybe';
+
+const increment = (v: number) => v + 1;
+
+describe('Maybe monad', () => {
+
+  describe('#valueOr', () => {
+    test('returns a defined value if Some', () => {
+      const value = Maybe.of(2)
+        .valueOr(0);
+
+      expect(value).toEqual(2);
+    });
+
+    test('returns provided default if None', () => {
+      const value = Maybe.of<number>(undefined)
+        .valueOr(0);
+
+      expect(value).toEqual(0);
+    });
+  });
+
+  describe('#valueOrCompute', () => {
+    test('returns a defined value if Some', () => {
+      const value = Maybe.of(2)
+        .valueOrCompute(() => 3);
+
+      expect(value).toEqual(2);
+    });
+
+    test('returns provided default if None', () => {
+      const value = Maybe.of<number>(undefined)
+        .valueOrCompute(() => 3);
+
+      expect(value).toEqual(3);
+    });
+  });
+
+
+  describe('#valueOrThrow', () => {
+    test('returns value if is Some', () => {
+      const value = () => Maybe.of(2)
+        .valueOrThrow();
+
+      expect(() => value()).not.toThrowError();
+      expect(value()).toEqual(2);
+    });
+
+    test('throws default error if None', () => {
+      const value = () => Maybe.of<number>(undefined)
+        .valueOrThrow();
+
+      expect(() => value()).toThrowError(new Error('No value is available'));
+    });
+
+    test('throws defined error if None', () => {
+      const value = () => Maybe.of<number>(undefined)
+        .valueOrThrow(new Error('test'));
+
+      expect(() => value()).toThrowError(new Error('test'));
+    });
+  });
+
+  describe('#map', () => {
+    test('maps value if Some', () => {
+      const value = Maybe.of(2)
+        .map(increment)
+        .valueOr(0);
+
+      expect(value).toEqual(3);
+    });
+
+    test('returns default if None', () => {
+      const value = Maybe.of<number>(undefined)
+        .map(increment)
+        .valueOr(0);
+
+      expect(value).toEqual(0);
+    });
+  });
+
+  describe('#flatMap', () => {
+    test('flattens Some monad and returns value', () => {
+      const value = Maybe.of(2)
+        .flatMap(v => Maybe.of('test'))
+        .valueOr('');
+
+      expect(value).toEqual('test');
+    });
+
+    test('flattens None monad and returns default', () => {
+      const value = Maybe.of<number>(undefined)
+        .flatMap(v => Maybe.of('test'))
+        .valueOr('test');
+
+      expect(value).toEqual('test');
+    });
+  });
+
+  describe('#caseOf', () => {
+    test('matches Some monad and returns value', () => {
+      const value = Maybe.of(2)
+        .caseOf({
+          some: v => v + 1,
+          none: () => 0,
+        });
+
+      expect(value).toEqual(3);
+    });
+
+    test('matches None monad and default value', () => {
+      const value = Maybe.of<number>(undefined)
+        .caseOf({
+          some: v => v + 1,
+          none: () => 0,
+        });
+
+      expect(value).toEqual(0);
+    });
+  });
+});

--- a/packages/core/src/router/router.factory.ts
+++ b/packages/core/src/router/router.factory.ts
@@ -20,17 +20,17 @@ export const factorizeRouting = (
   const routing: Routing = [];
 
   routes.forEach(route => {
-    const concatedPath = parentPath + '/' + route.path;
+    const concatenatedPath = parentPath + '/' + route.path;
 
     if (isRouteEffectGroup(route)) {
       return routing.push(...factorizeRouting(
         route.effects,
         [...middleware, ...route.middlewares],
-        concatedPath,
+        concatenatedPath,
       ));
     }
 
-    const { regExp, parameters } = factorizeRegExpWithParams(concatedPath);
+    const { regExp, parameters } = factorizeRegExpWithParams(concatenatedPath);
     const foundRoute = routing.find(route => route.regExp.source === regExp.source);
     const method: RoutingMethod = {
       effect: route.effect,

--- a/packages/core/src/router/router.factory.ts
+++ b/packages/core/src/router/router.factory.ts
@@ -20,15 +20,17 @@ export const factorizeRouting = (
   const routing: Routing = [];
 
   routes.forEach(route => {
+    const concatedPath = parentPath + '/' + route.path;
+
     if (isRouteEffectGroup(route)) {
       return routing.push(...factorizeRouting(
         route.effects,
         [...middleware, ...route.middlewares],
-        parentPath + route.path,
+        concatedPath,
       ));
     }
 
-    const { regExp, parameters } = factorizeRegExpWithParams(parentPath + route.path);
+    const { regExp, parameters } = factorizeRegExpWithParams(concatedPath);
     const foundRoute = routing.find(route => route.regExp.source === regExp.source);
     const method: RoutingMethod = {
       effect: route.effect,

--- a/packages/core/src/router/specs/router.factory.spec.ts
+++ b/packages/core/src/router/specs/router.factory.spec.ts
@@ -15,27 +15,31 @@ describe('Router factory', () => {
   test('#factorizeRouting factorizes routing with nested groups', () => {
     // given
     const m$: Middleware = req$ => req$;
-    const e$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
+    const e1$: Effect = req$ => req$.pipe(mapTo({ body: 'test1' }));
+    const e2$: Effect = req$ => req$.pipe(mapTo({ body: 'test2' }));
+    const e3$: Effect = req$ => req$.pipe(mapTo({ body: 'test3' }));
+    const e4$: Effect = req$ => req$.pipe(mapTo({ body: 'test4' }));
+    const e5$: Effect = req$ => req$.pipe(mapTo({ body: 'test5' }));
 
     const routeGroupNested: RouteEffectGroup = {
       path: '/nested',
-      effects: [{ path: '/', method: 'GET', effect: e$ }],
+      effects: [{ path: '/', method: 'GET', effect: e5$ }],
       middlewares: [m$],
     };
 
     const routeGroup: RouteEffectGroup = {
       path: '/:id',
       effects: [
-        { path: '/', method: 'GET', effect: e$ },
-        { path: '/', method: 'POST', effect: e$ },
+        { path: '/', method: 'GET', effect: e2$ },
+        { path: '/', method: 'POST', effect: e3$ },
         routeGroupNested,
-        { path: '*', method: '*', effect: e$ },
+        { path: '*', method: '*', effect: e4$ },
       ],
       middlewares: [m$],
     };
 
     const routing: (RouteEffect | RouteEffectGroup)[] = [
-      { path: '/', method: 'GET', effect: e$ },
+      { path: '/', method: 'GET', effect: e1$ },
       routeGroup,
     ];
 
@@ -47,22 +51,22 @@ describe('Router factory', () => {
     expect(factorizedRouting).toEqual([
       {
         regExp: /^\/?$/,
-        methods: { GET: { effect: e$, middleware: undefined, parameters: undefined } },
+        methods: { GET: { effect: e1$, middleware: undefined, parameters: undefined } },
       },
       {
         regExp: /^\/([^\/]+)\/?$/,
         methods: {
-          GET: { middleware: m$, effect: e$, parameters: ['id'] },
-          POST: { middleware: m$, effect: e$, parameters: ['id'] },
+          GET: { middleware: m$, effect: e2$, parameters: ['id'] },
+          POST: { middleware: m$, effect: e3$, parameters: ['id'] },
         },
       },
       {
         regExp: /^\/([^\/]+)\/nested\/?$/,
-        methods: { GET: { middleware: m$, effect: e$, parameters: ['id'] } },
+        methods: { GET: { middleware: m$, effect: e5$, parameters: ['id'] } },
       },
       {
         regExp: /^\/([^\/]+)\/.*?$/,
-        methods: { '*': { middleware: m$, effect: e$, parameters: ['id'] } },
+        methods: { '*': { middleware: m$, effect: e4$, parameters: ['id'] } },
       },
     ] as Routing);
   });

--- a/packages/core/src/router/urlParams.factory.ts
+++ b/packages/core/src/router/urlParams.factory.ts
@@ -15,6 +15,7 @@ export const factorizeRegExpWithParams = (path: string): ParametricRegExp => {
     .replace(/([?./\\()[\]{}^$])/g, '\\$1') /* Escape all regex characters */
     .replace(pathParameters, `([^\\/]+)`) /* Translate all path parameters to regex groups */
     .replace(/\*/g, '.*?')  /* Translate all stars to a wildcard */
+    .replace(/\/{2,}/g, '/') /* Remove duplicated backslashes */
     .replace(/([/\\])$/, '$1?'); /* Last slash/backslash is always optional */
 
   return {

--- a/packages/middleware-body/package.json
+++ b/packages/middleware-body/package.json
@@ -35,7 +35,8 @@
     "rxjs": "~6.1.0"
   },
   "devDependencies": {
-    "@marblejs/core": "^1.0.0-rc.1"
+    "@marblejs/core": "^1.0.0-rc.1",
+    "webpack": "^4.17.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/middleware-joi/package.json
+++ b/packages/middleware-joi/package.json
@@ -48,7 +48,8 @@
   "devDependencies": {
     "@marblejs/core": "^1.0.0-rc.1",
     "@marblejs/middleware-body": "^1.0.0-rc.1",
-    "@types/joi": "^13.0.8"
+    "@types/joi": "^13.0.8",
+    "webpack": "^4.17.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -39,7 +39,8 @@
   },
   "devDependencies": {
     "@marblejs/core": "^1.0.0-rc.1",
-    "@types/chalk": "^2.2.0"
+    "@types/chalk": "^2.2.0",
+    "webpack": "^4.17.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Test cases
```

## What is the current behavior?
- `factorizeRouting()` incorrectly concatenates wildcard endpoint when combined with parametrized route, which results in the following concatenated string: `/api/:version*`.  See example below 👇 

```javascript
const notFound$ = EffectFactory
  .matchPath('*')
  .matchType('*')
  .use(req$ => req$.pipe(
    switchMap(() =>
      throwError(new HttpError('Route not found', HttpStatus.NOT_FOUND))
    )
  ));

export const api$ = combineRoutes(
  '/api/:version',
  [ notFound$ ],
);
```

## What is the new behavior?
- Added test cases for `compose` and `Maybe` monad
- Added `webpack` `devDependecy` for each package
- Corrected `factorizeRouting()` path concatenation

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
