### PR TITLE
feat(core): improved HttpRequest types inference for middlewares composition

### DIFF
--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -7,7 +7,11 @@ export interface EffectResponse {
   headers?: Record<string, string>;
 }
 
-export type Middleware = Effect<HttpRequest>;
+export type Middleware<
+  TBody = any,
+  TParams = any,
+  TQuery = any,
+> = Effect<HttpRequest<TBody, TParams, TQuery>>;
 
 export type ErrorEffect = Effect<EffectResponse, Error>;
 

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -2,17 +2,26 @@ import * as http from 'http';
 import { Observable } from 'rxjs';
 import { EffectResponse } from './effects/effects.interface';
 
-export interface HttpRequest extends http.IncomingMessage {
+export interface HttpRequest<
+  TBody = any,
+  TParams = any,
+  TQuery = any,
+> extends http.IncomingMessage {
   url: string;
   method: HttpMethod;
-  body?: any;
-  params: RouteParameters;
-  query: QueryParameters;
+  body?: TBody;
+  params: TParams;
+  query: TQuery;
   [key: string]: any;
 }
 
-export type RouteParameters = Record<string, string>;
-export type QueryParameters = Record<string, string | number | object>;
+export interface RouteParameters {
+  [key: string]: any;
+}
+
+export interface QueryParameters {
+  [key: string]: any;
+}
 
 export interface HttpResponse extends http.ServerResponse {
   send: (effect: EffectResponse) => Observable<never>;

--- a/packages/core/src/operators/use/use.operator.ts
+++ b/packages/core/src/operators/use/use.operator.ts
@@ -1,11 +1,11 @@
 import { Observable, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
-import { Effect } from '../../effects/effects.interface';
+import { Middleware } from '../../effects/effects.interface';
 import { HttpRequest, HttpResponse } from '../../http.interface';
 
-export const use =
-  (middleware: Effect<HttpRequest>, res?: HttpResponse) =>
-  (source$: Observable<HttpRequest>) =>
+export const use = <T, U, V>
+  (middleware: Middleware<T, U, V>, res?: HttpResponse) =>
+  (source$: Observable<HttpRequest>): Observable<HttpRequest<T, U, V>> =>
     source$.pipe(
       switchMap(req => middleware(of(req), res!, {}))
     );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Composed middlewares by `use` operator don't infer and return proper `HttpRequest` type. When we will modify inner `Observable` with `map` the `use` operator doesn't infer the chained middleware types properly.

Issue Number: #78 

## What is the new behavior?
`HttpRequest` is properly inferred via composed middlewares.

```typescript
const middleware$: Middleware<TBody> = req$ => req$.pipe(
  ...
);

// or

const middleware$ = (req$: Observable<HttpRequest>) => req$.pipe(
  map(req => req as HttpRequest<TBody>),
);

// then

const effect$: Effect = req$ => req$.pipe(
  use(middleware$)
  map(req => req.body). // body is type of TBody
  ...
);
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```