### PR TITLE
feat(core): introducing EffectHttpResponse type

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,20 +56,19 @@
     "rxjs": "~6.2.2"
   },
   "devDependencies": {
-    "@types/jest": "^23.3.1",
+    "@types/jest": "~23.3.10",
     "@types/supertest": "^2.0.4",
     "husky": "^0.14.0",
-    "jest": "^23.5.0",
+    "jest": "~23.6.0",
     "lerna": "~3.3.0",
-    "lint-staged": "^7.2.2",
+    "lint-staged": "~8.1.0",
     "mock-req": "^0.2.0",
     "rimraf": "^2.6.2",
-    "rxjs-compat": "^6.1.0",
     "supertest": "^3.0.0",
-    "ts-jest": "^23.1.3",
+    "ts-jest": "~23.10.5",
     "ts-loader": "^5.0.0",
-    "tslint": "~5.9.1",
-    "typescript": "~3.1.1"
+    "tslint": "~5.11.0",
+    "typescript": "~3.2.2"
   },
   "workspaces": [
     "packages/*"

--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -16,12 +16,13 @@ export interface Middleware<
 > extends Effect<I, O> {}
 
 export interface ErrorEffect<T extends Error = Error>
-  extends Effect<HttpRequest, EffectHttpResponse, T> {}
+  extends Effect<HttpRequest, EffectHttpResponse, HttpResponse, T> {}
 
 export interface Effect<
-  T extends HttpRequest = HttpRequest,
-  U extends EffectResponse | HttpRequest = EffectHttpResponse,
-  V = any
+  T = HttpRequest,
+  U = EffectHttpResponse,
+  V = HttpResponse,
+  W = any,
 > {
-  (req$: Observable<T>, res: HttpResponse, meta: V): Observable<U>;
+  (req$: Observable<T>, res: V, meta: W): Observable<U>;
 }

--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -1,10 +1,13 @@
 import { Observable } from 'rxjs';
-import { HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
+import { HttpRequest, HttpResponse, HttpStatus, HttpHeaders } from '../http.interface';
 
-export interface EffectResponse {
+export interface EffectResponse<T = any> {
+  body?: T;
+}
+
+export interface EffectHttpResponse<T = any> extends EffectResponse<T> {
   status?: HttpStatus;
-  body?: any;
-  headers?: Record<string, string>;
+  headers?: HttpHeaders;
 }
 
 export interface Middleware<
@@ -13,8 +16,12 @@ export interface Middleware<
 > extends Effect<I, O> {}
 
 export interface ErrorEffect<T extends Error = Error>
-  extends Effect<HttpRequest, EffectResponse, T> {}
+  extends Effect<HttpRequest, EffectHttpResponse, T> {}
 
-export interface Effect<T extends HttpRequest = HttpRequest, U = EffectResponse, V = any> {
+export interface Effect<
+  T extends HttpRequest = HttpRequest,
+  U extends EffectResponse | HttpRequest = EffectHttpResponse,
+  V = any
+> {
   (req$: Observable<T>, res: HttpResponse, meta: V): Observable<U>;
 }

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import { Observable } from 'rxjs';
-import { EffectResponse } from './effects/effects.interface';
+import { EffectHttpResponse } from './effects/effects.interface';
 
 export interface HttpRequest<
   TBody = any,
@@ -24,7 +24,7 @@ export interface QueryParameters {
 }
 
 export interface HttpResponse extends http.ServerResponse {
-  send: (effect: EffectResponse) => Observable<never>;
+  send: (response: EffectHttpResponse) => Observable<never>;
 }
 
 export interface HttpHeaders extends Record<string, string> {}

--- a/packages/core/src/http.listener.ts
+++ b/packages/core/src/http.listener.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, OutgoingMessage } from 'http';
 import { of, Subject } from 'rxjs';
 import { catchError, defaultIfEmpty, mergeMap, switchMap, tap, takeWhile } from 'rxjs/operators';
 import { combineMiddlewares } from './effects/effects.combiner';
-import { EffectResponse, Middleware, ErrorEffect } from './effects/effects.interface';
+import { EffectHttpResponse, Middleware, ErrorEffect } from './effects/effects.interface';
 import { errorEffectProvider } from './error/error.effect';
 import { Http, HttpRequest, HttpResponse, HttpStatus } from './http.interface';
 import { handleResponse } from './response/response.handler';
@@ -26,7 +26,7 @@ export const httpListener = ({
   const combinedMiddlewares = combineMiddlewares(middlewares);
   const routerEffects = factorizeRouting(effects);
   const providedErrorEffect = errorEffectProvider(errorEffect);
-  const defaultResponse = { status: HttpStatus.NOT_FOUND } as EffectResponse;
+  const defaultResponse = { status: HttpStatus.NOT_FOUND } as EffectHttpResponse;
 
   const effect$ = request$.pipe(
     mergeMap(({ req, res }) => {

--- a/packages/core/src/response/response.handler.ts
+++ b/packages/core/src/response/response.handler.ts
@@ -1,10 +1,10 @@
 import { EMPTY } from 'rxjs';
-import { EffectResponse } from '../effects/effects.interface';
+import { EffectHttpResponse } from '../effects/effects.interface';
 import { HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
 import { bodyFactory } from './responseBody.factory';
 import { headersFactory } from './responseHeaders.factory';
 
-export const handleResponse = (res: HttpResponse) => (req: HttpRequest) => (effect: EffectResponse) => {
+export const handleResponse = (res: HttpResponse) => (req: HttpRequest) => (effect: EffectHttpResponse) => {
   if (res.finished) { return EMPTY; }
 
   const status = effect.status || HttpStatus.OK;

--- a/packages/core/src/router/router.interface.ts
+++ b/packages/core/src/router/router.interface.ts
@@ -1,11 +1,11 @@
 import { HttpMethod, HttpRequest } from '../http.interface';
-import { Effect, Middleware, EffectResponse } from '../effects/effects.interface';
+import { Effect, Middleware, EffectHttpResponse } from '../effects/effects.interface';
 
 // Route
 export interface RouteEffect<T extends HttpRequest = HttpRequest> {
   path: string;
   method: HttpMethod;
-  effect: Effect<T, EffectResponse>;
+  effect: Effect<T, EffectHttpResponse>;
   middleware?: Middleware;
 }
 

--- a/packages/core/src/router/router.resolver.ts
+++ b/packages/core/src/router/router.resolver.ts
@@ -1,7 +1,7 @@
 import { EMPTY, Observable, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { HttpMethod, HttpRequest, HttpResponse } from '../http.interface';
-import { EffectResponse } from '../effects/effects.interface';
+import { EffectHttpResponse } from '../effects/effects.interface';
 import { RouteMatched, Routing, RoutingItem } from './router.interface';
 import { queryParamsFactory } from './router.query.factory';
 export { RoutingItem };
@@ -38,7 +38,7 @@ export const findRoute = (
 export const resolveRouting =
   (routing: Routing) =>
   (res: HttpResponse) =>
-  (req: HttpRequest): Observable<EffectResponse> => {
+  (req: HttpRequest): Observable<EffectHttpResponse> => {
     if (res.finished) { return EMPTY; }
 
     const [urlPath, urlQuery] = req.url.split('?');

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,19 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@iamstarkov/listr-update-renderer@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz#d7c48092a2dcf90fd672b6c8b458649cb350c77e"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
 "@lerna/add@^3.3.2":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.5.0.tgz#3518b3d4afc3743b7227b1ee3534114eb9575888"
@@ -565,7 +578,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/jest@^23.3.1":
+"@types/jest@~23.3.10":
   version "23.3.10"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
 
@@ -1499,6 +1512,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
 cosmiconfig@^5.0.2:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.7.tgz#39826b292ee0d78eda137dfa3173bd1c21a43b04"
@@ -1602,6 +1623,12 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  dependencies:
+    ms "^2.1.1"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -1669,6 +1696,17 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+del@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+  dependencies:
+    globby "^6.1.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    p-map "^1.1.1"
+    pify "^3.0.0"
+    rimraf "^2.2.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1834,7 +1872,7 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -1886,18 +1924,6 @@ execa@^0.10.0:
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
-execa@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -2206,6 +2232,14 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
+g-status@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/g-status/-/g-status-2.0.2.tgz#270fd32119e8fc9496f066fe5fe88e0a6bc78b97"
+  dependencies:
+    arrify "^1.0.1"
+    matcher "^1.0.0"
+    simple-git "^1.85.0"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -2343,6 +2377,16 @@ global-dirs@^0.1.0:
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 globby@^8.0.1:
   version "8.0.1"
@@ -2818,6 +2862,16 @@ is-observable@^1.1.0:
   dependencies:
     symbol-observable "^1.1.0"
 
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+  dependencies:
+    is-path-inside "^1.0.0"
+
 is-path-inside@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
@@ -3270,7 +3324,7 @@ jest-worker@^23.2.0:
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^23.5.0:
+jest@~23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
   dependencies:
@@ -3501,21 +3555,24 @@ libnpmaccess@^3.0.0:
     npm-package-arg "^6.1.0"
     npm-registry-fetch "^3.8.0"
 
-lint-staged@^7.2.2:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.3.0.tgz#90ff33e5ca61ed3dbac35b6f6502dbefdc0db58d"
+lint-staged@~8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-8.1.0.tgz#dbc3ae2565366d8f20efb9f9799d076da64863f2"
   dependencies:
+    "@iamstarkov/listr-update-renderer" "0.4.1"
     chalk "^2.3.1"
     commander "^2.14.1"
-    cosmiconfig "^5.0.2"
+    cosmiconfig "5.0.6"
     debug "^3.1.0"
     dedent "^0.7.0"
-    execa "^0.9.0"
+    del "^3.0.0"
+    execa "^1.0.0"
     find-parent-dir "^0.3.0"
+    g-status "^2.0.2"
     is-glob "^4.0.0"
     is-windows "^1.0.2"
     jest-validate "^23.5.0"
-    listr "^0.14.1"
+    listr "^0.14.2"
     lodash "^4.17.5"
     log-symbols "^2.2.0"
     micromatch "^3.1.8"
@@ -3524,7 +3581,7 @@ lint-staged@^7.2.2:
     path-is-inside "^1.0.2"
     pify "^3.0.0"
     please-upgrade-node "^3.0.2"
-    staged-git-files "1.1.1"
+    staged-git-files "1.1.2"
     string-argv "^0.0.2"
     stringify-object "^3.2.2"
 
@@ -3554,7 +3611,7 @@ listr-verbose-renderer@^0.5.0:
     date-fns "^1.27.2"
     figures "^2.0.0"
 
-listr@^0.14.1:
+listr@^0.14.2:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
   dependencies:
@@ -3765,6 +3822,12 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+matcher@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/matcher/-/matcher-1.1.1.tgz#51d8301e138f840982b338b116bb0c09af62c1c2"
+  dependencies:
+    escape-string-regexp "^1.0.4"
 
 math-random@^1.0.1:
   version "1.0.1"
@@ -4975,7 +5038,7 @@ retry@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -4996,10 +5059,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
-
-rxjs-compat@^6.1.0:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/rxjs-compat/-/rxjs-compat-6.3.3.tgz#2ab3b9ac0dac0c073749d55fef9c03ea1df2045c"
 
 rxjs@^6.1.0, rxjs@^6.3.3:
   version "6.3.3"
@@ -5103,6 +5162,12 @@ shellwords@^0.1.1:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-git@^1.85.0:
+  version "1.107.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.107.0.tgz#12cffaf261c14d6f450f7fdb86c21ccee968b383"
+  dependencies:
+    debug "^4.0.1"
 
 sisteransi@^0.1.1:
   version "0.1.1"
@@ -5274,9 +5339,9 @@ stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
 
-staged-git-files@1.1.1:
-  version "1.1.1"
-  resolved "http://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz#37c2218ef0d6d26178b1310719309a16a59f8f7b"
+staged-git-files@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.2.tgz#4326d33886dc9ecfa29a6193bf511ba90a46454b"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -5603,7 +5668,7 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-ts-jest@^23.1.3:
+ts-jest@~23.10.5:
   version "23.10.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.10.5.tgz#cdb550df4466a30489bf70ba867615799f388dd5"
   dependencies:
@@ -5644,9 +5709,9 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
-tslint@~5.9.1:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+tslint@~5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -5659,9 +5724,9 @@ tslint@~5.9.1:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.8.0"
-    tsutils "^2.12.1"
+    tsutils "^2.27.2"
 
-tsutils@^2.12.1:
+tsutils@^2.27.2:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   dependencies:
@@ -5691,9 +5756,9 @@ typescript@~3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
-typescript@~3.1.1:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+typescript@~3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- `EffectResponse` interface is restricted only to HTTP protocol. It should be only represented as a base type which could be used outside, eg. in websockets protocol.

## What is the new behavior?
- The basic `Effect` generic interface extends `EffectResponse` defaulting to `EffectHttpResponse` type - because we are targeting HTTP protocol by default. From now it allows us to build Effects, not restricted only to HTTP protocol. 

```typescript
export interface EffectResponse<T = any> {
  body?: T;
}

export interface EffectHttpResponse<T = any> extends EffectResponse<T> {
  status?: HttpStatus;
  headers?: HttpHeaders;
}
```
- removed bumped-up `lint-staged` to version `8.1.0` 👉  removed `rxjs-compat`
- added support for TypeScript v3.2.2

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```