### PR TITLE
imp(core, middleware-joi, @integration): improved type-inference of combined middlewares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ package-lock.json
 # remove from npm package
 # --------------------------------------------------
 packages/**/*.spec.js
-packages/**/*.d.ts
 
 # --------------------------------------------------
 # Dependency directories

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,10 @@ module.exports = {
   ],
   globals: {
     'ts-jest': {
-      tsConfigFile: './tsconfig.json',
-    }
+      tsConfig: './tsconfig.test.json',
+      diagnostics: {
+        ignoreCodes: [2300],
+      },
+    },
   },
 };

--- a/packages/@integration/package.json
+++ b/packages/@integration/package.json
@@ -23,6 +23,7 @@
     "@marblejs/core": "^1.2.1",
     "@marblejs/middleware-body": "^1.2.1",
     "@marblejs/middleware-logger": "^1.2.1",
+    "@marblejs/middleware-joi": "^1.2.1",
     "@types/node": "^10.1.2",
     "rxjs": "~6.2.2",
     "typescript": "~3.0.3"

--- a/packages/@integration/src/effects/static.effects.ts
+++ b/packages/@integration/src/effects/static.effects.ts
@@ -1,19 +1,26 @@
 import * as path from 'path';
-import { EffectFactory, combineRoutes } from '@marblejs/core';
+import { EffectFactory, combineRoutes, use } from '@marblejs/core';
+import { validator$, Joi } from '@marblejs/middleware-joi';
 import { readFile } from '@marblejs/core/dist/+internal';
-import { map, switchMap } from 'rxjs/operators';
+import { map, mergeMap } from 'rxjs/operators';
 
 const STATIC_PATH = path.resolve(__dirname, '../../../../assets');
+
+const getFileValidator$ = validator$({
+  params: {
+    dir: Joi.string().required(),
+  },
+}, { allowUnknown: true });
 
 const getFile$ = EffectFactory
   .matchPath('/:dir*')
   .matchType('GET')
-  .use(req$ => req$
-    .pipe(
-      map(req => req.params!.dir as string),
-      switchMap(readFile(STATIC_PATH)),
-      map(body => ({ body }))
-    ));
+  .use(req$ => req$.pipe(
+    use(getFileValidator$),
+    map(req => req.params.dir),
+    mergeMap(readFile(STATIC_PATH)),
+    map(body => ({ body }))
+  ));
 
 export const static$ = combineRoutes(
   '/static',

--- a/packages/@integration/src/effects/user.effects.ts
+++ b/packages/@integration/src/effects/user.effects.ts
@@ -11,6 +11,14 @@ const getUserValidator$ = validator$({
   },
 }, { allowUnknown: true });
 
+const postUserValidator$ = validator$({
+  body: {
+    user: Joi.object({
+      id: Joi.string().required(),
+    })
+  },
+});
+
 const getUserList$ = EffectFactory
   .matchPath('/')
   .matchType('GET')
@@ -38,9 +46,10 @@ const postUser$ = EffectFactory
   .matchPath('/')
   .matchType('POST')
   .use(req$ => req$.pipe(
+    use(postUserValidator$),
     map(req => req.body),
     mergeMap(Dao.postUser),
-    map(response => ({ body: response })),
+    map(body => ({ body })),
   ));
 
 export const user$ = combineRoutes('/user', {

--- a/packages/@integration/src/fakes/dao.fake.ts
+++ b/packages/@integration/src/fakes/dao.fake.ts
@@ -1,4 +1,4 @@
-import { of, iif, throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 export namespace Dao {
 

--- a/packages/@integration/src/fakes/dao.fake.ts
+++ b/packages/@integration/src/fakes/dao.fake.ts
@@ -13,7 +13,7 @@ export namespace Dao {
       ? of({ id, firstName: 'Bob', lastName: 'Collins' })
       : throwError(new Error());
 
-  export const postUser = (data: any) => of({
+  export const postUser = <T>(data: T) => of({
     data,
   });
 

--- a/packages/@integration/test/integration.spec.ts
+++ b/packages/@integration/test/integration.spec.ts
@@ -73,8 +73,8 @@ describe('API integration', () => {
     request(app)
       .post('/api/v1/user')
       .set('Authorization', 'Bearer FAKE')
-      .send({ test: 'test' })
-      .expect(200, { data: {test: 'test' } }));
+      .send({ user: { id: 'test_id' } })
+      .expect(200, { data: { user: { id: 'test_id' } } }));
 
   test(`returns static file as ${ContentType.TEXT_HTML}: /api/v1/static/index.html`, async () =>
     request(app)

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -3,9 +3,9 @@ import { Observable } from 'rxjs';
 import { EffectHttpResponse } from './effects/effects.interface';
 
 export interface HttpRequest<
-  TBody = any,
-  TParams = any,
-  TQuery = any,
+  TBody = unknown,
+  TParams = unknown,
+  TQuery = unknown,
 > extends http.IncomingMessage {
   url: string;
   method: HttpMethod;

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -9,7 +9,7 @@ export interface HttpRequest<
 > extends http.IncomingMessage {
   url: string;
   method: HttpMethod;
-  body?: TBody;
+  body: TBody;
   params: TParams;
   query: TQuery;
   [key: string]: any;

--- a/packages/core/src/operators/use/use.operator.spec.ts
+++ b/packages/core/src/operators/use/use.operator.spec.ts
@@ -1,26 +1,86 @@
-import { tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { tap, map } from 'rxjs/operators';
 import { Marbles } from '../../+internal';
-import { Middleware } from '../../effects/effects.interface';
+import { Middleware, Effect } from '../../effects/effects.interface';
 import { HttpRequest } from '../../http.interface';
 import { use } from './use.operator';
 
-const createMockReq = (test = 0) => ({ test } as any as HttpRequest);
+const createMockReq = (obj: Record<string, any>) => (obj as any as HttpRequest);
 
-const middleware$: Middleware = req$ =>
-  req$.pipe(tap(req => req.test++));
+describe('use.operator', () => {
+  test('applies middlewares to the request pipeline', () => {
+    const middleware$: Middleware<HttpRequest<number>> = req$ =>
+      req$.pipe(tap(req => req.body!++ ));
 
-describe('Use operator', () => {
-
-  it('applies middlewares to the request pipeline', () => {
     const operators = [
       use(middleware$),
       use(middleware$)
     ];
 
     Marbles.assert(operators, [
-      ['-a---', { a: createMockReq() }],
-      ['-a---', { a: createMockReq(2) }],
+      ['-a---', { a: createMockReq({ body: 0 }) }],
+      ['-a---', { a: createMockReq({ body: 2 }) }],
     ]);
   });
 
+  test('infers types from composed middlewares', () => {
+    interface AuthorizedHttpRequest extends HttpRequest {
+      user: { id: string };
+    }
+
+    const m1$ = <_ extends HttpRequest>(req$: Observable<HttpRequest>):
+      Observable<HttpRequest<{ test: string }, unknown, unknown>> =>
+        req$.pipe(
+          tap(req => req.body = { test: 'test' }),
+        );
+
+    const m2$ = <_ extends HttpRequest>(req$: Observable<HttpRequest>):
+      Observable<HttpRequest<unknown, { test: boolean }, unknown>> =>
+        req$.pipe(
+          tap(req => req.params.test = true),
+        );
+
+    const m3$ = <_ extends HttpRequest>(req$: Observable<HttpRequest>):
+      Observable<HttpRequest<unknown, unknown, { test: number }>> =>
+        req$.pipe(
+          tap(req => req.query.test = 3),
+        );
+
+    const m4$ = <_ extends HttpRequest>(req$: Observable<HttpRequest>):
+      Observable<AuthorizedHttpRequest> =>
+        req$.pipe(
+          tap(req => req.user = { id: 'test_id' }),
+        );
+
+    const effect$: Effect = req$ => req$.pipe(
+      use(m1$),
+      use(m2$),
+      use(m3$),
+      use(m4$),
+      tap(req => req.body!.test as string),
+      tap(req => req.params.test as boolean),
+      tap(req => req.query.test as number),
+      tap(req => req.user.id as string),
+      map(req => ({ body: {
+        body: req.body,
+        params: req.params,
+        query: req.query,
+        user: req.user,
+      }})),
+    );
+
+    const expectedResult = {
+      body: {
+        body:   { test: 'test' },
+        params: { test: true },
+        query:  { test: 3 },
+        user:   { id: 'test_id' },
+      }
+    };
+
+    Marbles.assertEffect(effect$, [
+      ['-a---', { a: createMockReq({ params: {}, query: {} }) }],
+      ['-a---', { a: expectedResult }],
+    ]);
+  });
 });

--- a/packages/core/src/operators/use/use.operator.spec.ts
+++ b/packages/core/src/operators/use/use.operator.spec.ts
@@ -10,7 +10,7 @@ const createMockReq = (obj: Record<string, any>) => (obj as any as HttpRequest);
 describe('use.operator', () => {
   test('applies middlewares to the request pipeline', () => {
     const middleware$: Middleware<HttpRequest<number>> = req$ =>
-      req$.pipe(tap(req => req.body!++ ));
+      req$.pipe(tap(req => req.body++ ));
 
     const operators = [
       use(middleware$),
@@ -57,7 +57,7 @@ describe('use.operator', () => {
       use(m2$),
       use(m3$),
       use(m4$),
-      tap(req => req.body!.test as string),
+      tap(req => req.body.test as string),
       tap(req => req.params.test as boolean),
       tap(req => req.query.test as number),
       tap(req => req.user.id as string),

--- a/packages/core/src/operators/use/use.operator.ts
+++ b/packages/core/src/operators/use/use.operator.ts
@@ -5,7 +5,7 @@ import { HttpRequest, HttpResponse } from '../../http.interface';
 
 export const use = <I extends HttpRequest, O extends HttpRequest>
   (middleware: Middleware<I, O>, res?: HttpResponse) =>
-  (source$: Observable<I>): Observable<O> =>
+  (source$: Observable<I>) =>
     source$.pipe(
-      switchMap(req => middleware(of(req), res!, {}))
+      switchMap(req => middleware(of(req), res!, {}) as Observable<I & O>)
     );

--- a/packages/core/src/operators/use/use.operator.ts
+++ b/packages/core/src/operators/use/use.operator.ts
@@ -7,5 +7,5 @@ export const use = <I extends HttpRequest, O extends HttpRequest>
   (middleware: Middleware<I, O>, res?: HttpResponse) =>
   (source$: Observable<I>) =>
     source$.pipe(
-      switchMap(req => middleware(of(req), res!, {}) as Observable<I & O>)
+      switchMap(req => middleware(of(req), res!, {}) as Observable<O>)
     );

--- a/packages/middleware-joi/package.json
+++ b/packages/middleware-joi/package.json
@@ -42,7 +42,7 @@
     "rxjs": "~6.2.2"
   },
   "dependencies": {
-    "joi": "14.0.6",
+    "joi": "~14.3.0",
     "@types/joi": "^14.0.0"
   },
   "devDependencies": {

--- a/packages/middleware-joi/src/validator.interface.ts
+++ b/packages/middleware-joi/src/validator.interface.ts
@@ -1,4 +1,16 @@
-import 'joi';
+import * as Joi from 'joi';
+import { Schema } from './validator.schema';
+
+export type ExtractedSchema<SchemaToExtract extends Schema> = {
+  [K1 in keyof SchemaToExtract]:
+    SchemaToExtract[K1] extends undefined
+      ? unknown
+      : { [K2 in keyof SchemaToExtract[K1]]: Joi.ExtractType<SchemaToExtract[K1][K2]> }
+};
+
+export type ExtractedBody<T extends Schema> = ExtractedSchema<T>['body'];
+export type ExtractedParams<T extends Schema> = ExtractedSchema<T>['params'];
+export type ExtractedQuery<T extends Schema> = ExtractedSchema<T>['query'];
 
 declare module 'joi' {
   // Object Schema
@@ -23,5 +35,5 @@ declare module 'joi' {
       U extends null ? Record<string, any> : { [K in keyof U]: ExtractType<U[K]> } :
     T extends ArraySchema<infer U> ?
       U extends null ? any[] : U[] :
-    any;
+    unknown;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
     ],
     "baseUrl": "."
   },
-  "exclude": [
-    "**/*.d.ts"
+  "include": [
+    "./packages/**/*.ts",
+    "./packages/**/*.d.ts",
+    "./packages/**/*.json"
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmitOnError": false
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3331,9 +3331,9 @@ jest@~23.6.0:
     import-local "^1.0.0"
     jest-cli "^23.6.0"
 
-joi@14.0.6:
-  version "14.0.6"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-14.0.6.tgz#8c72314af6dba13ca48028a4f0af992ddc5a7472"
+joi@~14.3.0:
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-14.3.0.tgz#55f7c5caa8256de74ccb12eb22ab1c19eea02db3"
   dependencies:
     hoek "6.x.x"
     isemail "3.x.x"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- `@marblejs/core` - `use` operator can't properly infer combined, chained middlewares, like:

```typescript
const m1$: Middleware = req$ =>
  req$.pipe(
    tap(req => req.body = { test: 'test' }),
  );

const m2$: Middleware = req$ =>
  req$.pipe(
    tap(req => req.params = { test: true }),
  );

// then

const effect$: Effect = req$ =>
  req$.pipe(
    use(m1$),
    use(m2$),
    tap(req => req.body.test),    // body.test === "any"
    tap(req => req.params.test),  // params.test === "any"
    // ...
  );
```
Issue Number: #78

## What is the new behavior?
- `@marblejs/core` - from now `use` operator will be able to infer combined middlewares by merging two or more consecutive middlewares (the type inference and merging should be done in middleware definition) , eg.

```typescript
const m1$ = <T extends HttpRequest>(req$: Observable<T>) =>
    req$.pipe(
      tap(req => req.body = { test: 'test' }),
    ) as  Observable<HttpRequest<{ test: string }, T['params'], T['query']>>;

const m2$ = <T extends HttpRequest>(req$: Observable<T>) =>
    req$.pipe(
      tap(req => req.params = { test: true }),
    ) as Observable<HttpRequest<T['body'], { test: boolean }, T['query']>>;

const effect$: Effect = req$ =>
  req$.pipe(
    use(m1$),
    use(m2$),
    tap(req => req.body.test),     // body.test === "string"
    tap(req => req.params.test),   // params.test === "boolean"
    // ...
  );
```
As you can see the new improved middleware type declaration requires to omit `Middleware` type alias in place of direct function type declaration for incoming and outgoing parameters. The `<_ extends HttpRequest>` thing is required by TS to trigger type inference.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

In order to achieve improved type inference (which in general is one of our main goals for `2.0` release), the `HttpReqest.body`, `HttpReqest.params`, `HttpReqest.query` have to be of `unknown` type by default. This way forces developers to use validation middlewares like eg. `@marblejs/middleware-joi`, which makes our Effects more bulletproof by validating incoming HttpRequest parameters.