### PR TITLE
refactor(core): Effect metadata argument

### DIFF
--- a/packages/@integration/src/effects/api.effects.ts
+++ b/packages/@integration/src/effects/api.effects.ts
@@ -18,7 +18,7 @@ const rootValiadtor$ = requestValidator$({
 const root$ = EffectFactory
   .matchPath('/')
   .matchType('GET')
-  .use((req$, _, inject) => req$.pipe(
+  .use((req$, _, { inject }) => req$.pipe(
     use(rootValiadtor$),
     map(req => req.params.version),
     map(version => `API version: ${version}`),

--- a/packages/@integration/src/effects/calculator.ws-effects.ts
+++ b/packages/@integration/src/effects/calculator.ws-effects.ts
@@ -8,11 +8,11 @@ export const sum$: WebSocketEffect = event$ =>
     matchEvent('SUM')
   );
 
-export const add$: WebSocketEffect = (event$, client) =>
+export const add$: WebSocketEffect = (event$, ...args) =>
   event$.pipe(
     matchEvent('ADD'),
     use(eventValidator$(t.number)),
-    buffer(sum$(event$, client)),
+    buffer(sum$(event$, ...args)),
     map(events => events.reduce((a, e) => e.payload! + a, 0)),
     map(payload => ({ type: 'SUM_RESULT', payload })),
   );

--- a/packages/@integration/src/index.ts
+++ b/packages/@integration/src/index.ts
@@ -6,13 +6,13 @@ import { httpServer } from './http.listener';
 import { webSocketServer } from './ws.listener';
 import { WebSocketsToken } from './tokens';
 
-const upgrade$: ServerEffect = (event$, _, injector) =>
+const upgrade$: ServerEffect = (event$, _, { inject }) =>
   event$.pipe(
     matchEvent(ServerEvent.upgrade),
     mapToServer({
       path: '/api/:version/ws',
-      server: WebSocketsToken,
-    })(injector),
+      server: inject(WebSocketsToken),
+    }),
   );
 
 const listen$: ServerEffect = event$ =>

--- a/packages/@integration/src/index.ts
+++ b/packages/@integration/src/index.ts
@@ -27,7 +27,7 @@ export const server = createServer({
   port: 1337,
   httpListener: httpServer,
   dependencies: [
-    bind(WebSocketsToken).to(() => webSocketServer()),
+    bind(WebSocketsToken).to(webSocketServer({ noServer: true })),
   ],
   event$: (...args) => merge(
     listen$(...args),

--- a/packages/core/src/effects/effects.combiner.ts
+++ b/packages/core/src/effects/effects.combiner.ts
@@ -1,12 +1,12 @@
 import { Observable, merge } from 'rxjs';
-import { Effect } from './effects.interface';
+import { Effect, EffectMetadata } from './effects.interface';
 
 export const combineMiddlewares = <T, U>
   (...effects: Effect<T, T, U>[]) =>
-  (input$: Observable<T>, client: U, meta?: any): Observable<T> =>
-    effects.reduce((i$, effect) => effect(i$, client, meta), input$);
+  (input$: Observable<T>, client: U, meta: EffectMetadata): Observable<T> =>
+    effects.reduce((i$, effect) => effect(i$, client, meta!), input$);
 
 export const combineEffects = <T, U, V>
   (...effects: Effect<T, U, V>[]) =>
-  (input$: Observable<T>, client: V, meta?: any): Observable<U> =>
+  (input$: Observable<T>, client: V, meta: EffectMetadata): Observable<U> =>
     merge(...effects.map(effect => effect(input$, client, meta)));

--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -5,9 +5,9 @@ import { HttpError } from '../error/error.model';
 import { InjectorGetter } from '../server/server.injector';
 import { Event } from '../event/event.interface';
 
-export interface EffectMetadata<T extends Error> {
-  error?: T;
+export interface EffectMetadata<T extends Error = Error> {
   inject: InjectorGetter;
+  error?: T;
   [key: string]: any;
 }
 

--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -2,8 +2,14 @@ import * as http from 'http';
 import { Observable } from 'rxjs';
 import { HttpRequest, HttpResponse, HttpStatus, HttpHeaders } from '../http.interface';
 import { HttpError } from '../error/error.model';
-import { InjectionGetter } from '../server/server.injector';
+import { InjectorGetter } from '../server/server.injector';
 import { Event } from '../event/event.interface';
+
+export interface EffectMetadata<T extends Error> {
+  error?: T;
+  inject: InjectorGetter;
+  [key: string]: any;
+}
 
 export interface EffectHttpResponse<T = any> {
   status?: HttpStatus;
@@ -26,7 +32,7 @@ export interface Effect<
   T = HttpRequest,
   U = EffectHttpResponse,
   V = HttpResponse,
-  W = InjectionGetter,
+  W extends Error = Error,
 > {
-  (input$: Observable<T>, client: V, meta: W): Observable<U>;
+  (input$: Observable<T>, client: V, meta: EffectMetadata<W>): Observable<U>;
 }

--- a/packages/core/src/error/error.effect.ts
+++ b/packages/core/src/error/error.effect.ts
@@ -1,4 +1,4 @@
-import { map } from 'rxjs/operators';
+import { map, mapTo } from 'rxjs/operators';
 import { ErrorEffect } from '../effects/effects.interface';
 import { HttpStatus } from '../http.interface';
 import { HttpError, isHttpError } from './error.model';
@@ -18,9 +18,10 @@ const errorFactory = (status: HttpStatus, error: Error) =>
     ? { error: { status, message: error.message, data: error.data, context: error.context } }
     : { error: { status, message: error.message } };
 
-export const defaultError$: ErrorEffect<HttpError> = (req$, _, error = defaultHttpError) => req$
+export const defaultError$: ErrorEffect<HttpError> = (req$, _, meta) => req$
   .pipe(
-    map(() => {
+    mapTo(meta.error || defaultHttpError),
+    map(error => {
       const status = getStatusCode(error);
       const body = errorFactory(status, error);
       return { status, body };

--- a/packages/core/src/error/specs/error.effect.spec.ts
+++ b/packages/core/src/error/specs/error.effect.spec.ts
@@ -7,7 +7,7 @@ describe('defaultError$', () => {
   const client = createHttpResponse();
 
   test('maps HttpError', () => {
-    const incomingError = new HttpError('test-message', 400);
+    const error = new HttpError('test-message', 400);
     const outgoingResponse = {
       status: 400,
       body: { error: {
@@ -19,11 +19,11 @@ describe('defaultError$', () => {
     Marbles.assertEffect(defaultError$, [
       ['-a-', { a: incomingRequest }],
       ['-a-', { a: outgoingResponse }],
-    ], { client, meta: incomingError });
+    ], { client, meta: { error } });
   });
 
   test('maps other errors', () => {
-    const incomingError = new Error('test-message');
+    const error = new Error('test-message');
     const outgoingResponse = {
       status: 500,
       body: { error: {
@@ -35,7 +35,7 @@ describe('defaultError$', () => {
     Marbles.assertEffect(defaultError$, [
       ['-a-', { a: incomingRequest }],
       ['-a-', { a: outgoingResponse }],
-    ], { client, meta: incomingError });
+    ], { client, meta: { error } });
   });
 
   test('maps to "Internal server error" if "error" is not provided', () => {
@@ -50,6 +50,6 @@ describe('defaultError$', () => {
     Marbles.assertEffect(defaultError$, [
       ['-a-', { a: incomingRequest }],
       ['-a-', { a: outgoingResponse }],
-    ], { client });
+    ], { client, meta: {} });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,5 +12,6 @@ export * from './event/event.factory';
 export * from './event/event.interface';
 export * from './server/server.injector';
 export * from './server/server.event';
+export * from './server/server.token';
 export { createServer, CreateServerConfig } from './server/server.factory';
 export { HttpListenerConfig, httpListener } from './listener/http.listener';

--- a/packages/core/src/listener/http.listener.ts
+++ b/packages/core/src/listener/http.listener.ts
@@ -27,19 +27,19 @@ export const httpListener = ({
   const routing = factorizeRouting(effects);
   const injector = createStaticInjectionContainer();
   const defaultResponse = { status: HttpStatus.NOT_FOUND } as EffectHttpResponse;
-  const effectDefaultMeta = { inject: injector.get };
+  const defaultMetadata = { inject: injector.get };
 
   const effect$ = requestSubject$.pipe(
     mergeMap(({ req, res }) => {
       res.send = handleResponse(res)(req);
 
-      return combinedMiddlewares(of(req), res, effectDefaultMeta).pipe(
+      return combinedMiddlewares(of(req), res, defaultMetadata).pipe(
         takeWhile(() => !res.finished),
-        switchMap(resolveRouting(routing, injector.get)(res)),
+        switchMap(resolveRouting(routing, defaultMetadata)(res)),
         defaultIfEmpty(defaultResponse),
         tap(res.send),
         catchError(error =>
-          error$(of(req), res, { ...effectDefaultMeta, error }).pipe(
+          error$(of(req), res, { ...defaultMetadata, error }).pipe(
             tap(res.send),
           ),
         ),

--- a/packages/core/src/listener/http.listener.ts
+++ b/packages/core/src/listener/http.listener.ts
@@ -27,18 +27,19 @@ export const httpListener = ({
   const routing = factorizeRouting(effects);
   const injector = createStaticInjectionContainer();
   const defaultResponse = { status: HttpStatus.NOT_FOUND } as EffectHttpResponse;
+  const effectDefaultMeta = { inject: injector.get };
 
   const effect$ = requestSubject$.pipe(
     mergeMap(({ req, res }) => {
       res.send = handleResponse(res)(req);
 
-      return combinedMiddlewares(of(req), res, injector.get).pipe(
+      return combinedMiddlewares(of(req), res, effectDefaultMeta).pipe(
         takeWhile(() => !res.finished),
         switchMap(resolveRouting(routing, injector.get)(res)),
         defaultIfEmpty(defaultResponse),
         tap(res.send),
         catchError(error =>
-          error$(of(req), res, error).pipe(
+          error$(of(req), res, { ...effectDefaultMeta, error }).pipe(
             tap(res.send),
           ),
         ),

--- a/packages/core/src/router/router.resolver.ts
+++ b/packages/core/src/router/router.resolver.ts
@@ -4,7 +4,7 @@ import { HttpMethod, HttpRequest, HttpResponse } from '../http.interface';
 import { EffectHttpResponse } from '../effects/effects.interface';
 import { RouteMatched, Routing, RoutingItem } from './router.interface';
 import { queryParamsFactory } from './router.query.factory';
-import { InjectionGetter } from '../server/server.injector';
+import { InjectorGetter } from '../server/server.injector';
 export { RoutingItem };
 
 export const findRoute = (
@@ -37,7 +37,7 @@ export const findRoute = (
 };
 
 export const resolveRouting =
-  (routing: Routing, inject: InjectionGetter) =>
+  (routing: Routing, inject: InjectorGetter) =>
   (res: HttpResponse) =>
   (req: HttpRequest): Observable<EffectHttpResponse> => {
     if (res.finished) { return EMPTY; }
@@ -54,9 +54,9 @@ export const resolveRouting =
     const middleware = routeMatched.middleware;
 
     return middleware
-      ? middleware(of(req), res, inject).pipe(
+      ? middleware(of(req), res, { inject }).pipe(
           takeWhile(() => !res.finished),
-          mergeMap(req => routeMatched.effect(of(req), res, inject))
+          mergeMap(req => routeMatched.effect(of(req), res, { inject }))
         )
-      : routeMatched.effect(of(req), res, inject);
+      : routeMatched.effect(of(req), res, { inject });
   };

--- a/packages/core/src/router/router.resolver.ts
+++ b/packages/core/src/router/router.resolver.ts
@@ -1,10 +1,9 @@
 import { EMPTY, Observable, of } from 'rxjs';
 import { mergeMap, takeWhile } from 'rxjs/operators';
 import { HttpMethod, HttpRequest, HttpResponse } from '../http.interface';
-import { EffectHttpResponse } from '../effects/effects.interface';
+import { EffectHttpResponse, EffectMetadata } from '../effects/effects.interface';
 import { RouteMatched, Routing, RoutingItem } from './router.interface';
 import { queryParamsFactory } from './router.query.factory';
-import { InjectorGetter } from '../server/server.injector';
 export { RoutingItem };
 
 export const findRoute = (
@@ -37,7 +36,7 @@ export const findRoute = (
 };
 
 export const resolveRouting =
-  (routing: Routing, inject: InjectorGetter) =>
+  (routing: Routing, metadata: EffectMetadata) =>
   (res: HttpResponse) =>
   (req: HttpRequest): Observable<EffectHttpResponse> => {
     if (res.finished) { return EMPTY; }
@@ -54,9 +53,9 @@ export const resolveRouting =
     const middleware = routeMatched.middleware;
 
     return middleware
-      ? middleware(of(req), res, { inject }).pipe(
+      ? middleware(of(req), res, metadata).pipe(
           takeWhile(() => !res.finished),
-          mergeMap(req => routeMatched.effect(of(req), res, { inject }))
+          mergeMap(req => routeMatched.effect(of(req), res, metadata))
         )
-      : routeMatched.effect(of(req), res, { inject });
+      : routeMatched.effect(of(req), res, metadata);
   };

--- a/packages/core/src/router/specs/router.resolver.spec.ts
+++ b/packages/core/src/router/specs/router.resolver.spec.ts
@@ -1,5 +1,5 @@
 import { mapTo, tap, map } from 'rxjs/operators';
-import { Effect, Middleware } from '../../effects/effects.interface';
+import { Effect, Middleware, EffectMetadata } from '../../effects/effects.interface';
 import { findRoute, resolveRouting } from '../router.resolver';
 import { HttpRequest, HttpResponse, HttpMethod } from '../../http.interface';
 import { RouteMatched, Routing } from '../router.interface';
@@ -99,13 +99,14 @@ describe('#findRoute', () => {
 describe('#resolveRouting', () => {
   let router;
   let queryFactory;
-  const injector = createStaticInjectionContainer();
+  let metadata: EffectMetadata;
 
   beforeEach(() => {
     jest.unmock('../router.resolver.ts');
     jest.unmock('../router.query.factory');
     router = require('../router.resolver.ts');
     queryFactory = require('../router.query.factory');
+    metadata = { inject: createStaticInjectionContainer().get };
   });
 
   test('resolves found effect', done => {
@@ -118,7 +119,7 @@ describe('#resolveRouting', () => {
     // when
     router.findRoute = jest.fn(() => expectedMachingResult);
     queryFactory.queryParamsFactory = jest.fn(() => ({}));
-    const resolvedRoute = resolveRouting([], injector.get)(res)(req);
+    const resolvedRoute = resolveRouting([], metadata)(res)(req);
 
     // then
     resolvedRoute.subscribe(effect => {
@@ -136,7 +137,7 @@ describe('#resolveRouting', () => {
 
     // when
     router.findRoute = jest.fn(() => undefined);
-    const resolvedRoute = resolveRouting([], injector.get)(res)(req);
+    const resolvedRoute = resolveRouting([], metadata)(res)(req);
 
     // then
     resolvedRoute.subscribe(
@@ -161,7 +162,7 @@ describe('#resolveRouting', () => {
     const res = { finished: true } as HttpResponse;
 
     // when
-    const resolvedRoute = resolveRouting([], injector.get)(res)(req);
+    const resolvedRoute = resolveRouting([], metadata)(res)(req);
 
     // then
     resolvedRoute.subscribe(
@@ -192,7 +193,7 @@ describe('#resolveRouting', () => {
     // when
     router.findRoute = jest.fn(() => expectedMachingResult);
     queryFactory.queryParamsFactory = jest.fn(() => ({}));
-    const resolvedRoute = resolveRouting([], injector.get)(res)(req);
+    const resolvedRoute = resolveRouting([], metadata)(res)(req);
 
     // then
     resolvedRoute.subscribe(effect => {

--- a/packages/core/src/server/server.factory.ts
+++ b/packages/core/src/server/server.factory.ts
@@ -27,7 +27,7 @@ export const createServer = (config: CreateServerConfig) => {
   }
 
   if (event$) {
-    event$(serverEvent$, server, injector.get).subscribe();
+    event$(serverEvent$, server, { inject: injector.get }).subscribe();
   }
 
   return {

--- a/packages/core/src/server/server.factory.ts
+++ b/packages/core/src/server/server.factory.ts
@@ -5,6 +5,7 @@ import { isCloseEvent } from './server.event';
 import { subscribeServerEvents } from './server.event.subscriber';
 import { InjectionDependencies } from './server.injector';
 import { ServerEffect } from '../effects/effects.interface';
+import { httpServerToken } from './server.token';
 
 export interface CreateServerConfig {
   port?: number;
@@ -22,8 +23,10 @@ export const createServer = (config: CreateServerConfig) => {
   const server = http.createServer(httpListener);
   const serverEvent$ = eventsSubscriber(server).pipe(takeWhile(e => !isCloseEvent(e)));
 
+  injector.register(httpServerToken, () => server);
+
   if (dependencies) {
-    injector.registerAll(dependencies)(server);
+    injector.registerAll(dependencies);
   }
 
   if (event$) {

--- a/packages/core/src/server/server.injector.ts
+++ b/packages/core/src/server/server.injector.ts
@@ -1,6 +1,4 @@
-import * as http from 'http';
-
-export type Injectable = (httpServer: http.Server) => any;
+export type Injectable = (context: Injector) => any;
 export type InjectionDependencies = { token: InjectionToken, factory: Injectable }[];
 export type InjectionToken<T = any> = new() => Token<T>;
 
@@ -15,22 +13,31 @@ export class Token<T = any> {
 export class StaticInjector {
   private dependencies = new Map<InjectionToken, any>();
 
-  register = <T>(token: InjectionToken<T>, factory: Injectable) => (httpServer: http.Server) =>
-    this.dependencies.set(token, factory(httpServer))
+  register = <T>(token: InjectionToken<T>, factory: Injectable) => {
+    this.dependencies.set(token, factory(this));
+    return this;
+  }
 
-  deregister = <T>(token: InjectionToken<T>) =>
-    this.dependencies.delete(token)
+  deregister = <T>(token: InjectionToken<T>) => {
+    this.dependencies.delete(token);
+    return this;
+  }
 
-  get = <T>(token: InjectionToken<T>): T =>
-    this.dependencies.get(token)
+  get = <T>(token: InjectionToken<T>): T => {
+    return this.dependencies.get(token);
+  }
 
-  registerAll = (dependenciesToRegister: InjectionDependencies) => (httpServer: http.Server) =>
+  registerAll = (dependenciesToRegister: InjectionDependencies) => {
     dependenciesToRegister.forEach(({ token, factory }) =>
-      this.register(token, factory)(httpServer)
-    )
+      this.register(token, factory)
+    );
+    return this;
+  }
 
-  deregisterAll = () =>
-    this.dependencies.clear()
+  deregisterAll = () => {
+    this.dependencies.clear();
+    return this;
+  }
 }
 
 export const createInjectionToken = <T>() =>
@@ -38,6 +45,8 @@ export const createInjectionToken = <T>() =>
 
 export const createStaticInjectionContainer = () =>
   new StaticInjector();
+
+export type Injector = StaticInjector;
 
 export const bind = <T>(token: InjectionToken<T>) => ({
   to: (factory: Injectable) => ({ token, factory })

--- a/packages/core/src/server/server.injector.ts
+++ b/packages/core/src/server/server.injector.ts
@@ -1,49 +1,43 @@
 import * as http from 'http';
 
 export type Injectable = (httpServer: http.Server) => any;
-export type Injector = typeof createStaticInjectionContainer;
 export type InjectionDependencies = { token: InjectionToken, factory: Injectable }[];
 export type InjectionToken<T = any> = new() => Token<T>;
 
-export interface InjectionGetter {
-  <T>(key: InjectionToken<T>): T;
+export interface InjectorGetter {
+  <T>(token: InjectionToken<T>): T;
 }
 
 export class Token<T = any> {
   surrogate!: T;
 }
 
+export class StaticInjector {
+  private dependencies = new Map<InjectionToken, any>();
+
+  register = <T>(token: InjectionToken<T>, factory: Injectable) => (httpServer: http.Server) =>
+    this.dependencies.set(token, factory(httpServer))
+
+  deregister = <T>(token: InjectionToken<T>) =>
+    this.dependencies.delete(token)
+
+  get = <T>(token: InjectionToken<T>): T =>
+    this.dependencies.get(token)
+
+  registerAll = (dependenciesToRegister: InjectionDependencies) => (httpServer: http.Server) =>
+    dependenciesToRegister.forEach(({ token, factory }) =>
+      this.register(token, factory)(httpServer)
+    )
+
+  deregisterAll = () =>
+    this.dependencies.clear()
+}
+
 export const createInjectionToken = <T>() =>
   class InlineToken extends Token<T> {};
 
-export const createStaticInjectionContainer = () => {
-  const dependencies = new Map<InjectionToken, any>();
-
-  const register = <T>(token: InjectionToken<T>, factory: Injectable) => (httpServer: http.Server) =>
-    dependencies.set(token, factory(httpServer));
-
-  const deregister = <T>(token: InjectionToken<T>) =>
-    dependencies.delete(token);
-
-  const get = <T>(token: InjectionToken<T>): T =>
-    dependencies.get(token);
-
-  const registerAll = (dependenciesToRegister: InjectionDependencies) => (httpServer: http.Server) =>
-    dependenciesToRegister.forEach(({ token, factory }) =>
-      register(token, factory)(httpServer)
-    );
-
-  const deregisterAll = () =>
-    dependencies.clear();
-
-  return {
-    get,
-    register,
-    registerAll,
-    deregister,
-    deregisterAll,
-  };
-};
+export const createStaticInjectionContainer = () =>
+  new StaticInjector();
 
 export const bind = <T>(token: InjectionToken<T>) => ({
   to: (factory: Injectable) => ({ token, factory })

--- a/packages/core/src/server/server.token.ts
+++ b/packages/core/src/server/server.token.ts
@@ -1,0 +1,4 @@
+import * as http from 'http';
+import { createInjectionToken } from './server.injector';
+
+export const httpServerToken = createInjectionToken<http.Server>();

--- a/packages/core/src/server/specs/server.injector.spec.ts
+++ b/packages/core/src/server/specs/server.injector.spec.ts
@@ -1,8 +1,7 @@
-import * as http from 'http';
 import { bind, createInjectionToken, createStaticInjectionContainer } from '../server.injector';
 
 describe('#bind', () => {
-  const httpServer = {} as http.Server;
+  const injector = createStaticInjectionContainer();
 
   test('factorizes dependency', () => {
     // given
@@ -14,13 +13,11 @@ describe('#bind', () => {
 
     // then
     expect(factorizedDependency.token).toBe(Token);
-    expect(factorizedDependency.factory(httpServer)).toEqual(dependency);
+    expect(factorizedDependency.factory(injector)).toEqual(dependency);
   });
 });
 
 describe('#createStaticInjectionContainer', () => {
-  const httpServer = {} as http.Server;
-
   test('#register registers single dependency', () => {
     // given
     const dependency = { test: 'test_string' };
@@ -28,7 +25,7 @@ describe('#createStaticInjectionContainer', () => {
     const container = createStaticInjectionContainer();
 
     // when
-    container.register(Token, () => dependency)(httpServer);
+    container.register(Token, () => dependency);
 
     // then
     expect(container.get(Token)).toEqual(dependency);
@@ -49,7 +46,7 @@ describe('#createStaticInjectionContainer', () => {
       { token: Token1, factory: () => dependency1 },
       { token: Token2, factory: () => dependency2 },
       { token: Token3, factory: () => dependency3 },
-    ])(httpServer);
+    ]);
 
     // then
     expect(container.get(Token1)).toEqual(dependency1);
@@ -66,8 +63,8 @@ describe('#createStaticInjectionContainer', () => {
     const container = createStaticInjectionContainer();
 
     // when
-    container.register(Token1, () => dependency1)(httpServer);
-    container.register(Token2, () => dependency2)(httpServer);
+    container.register(Token1, () => dependency1);
+    container.register(Token2, () => dependency2);
     container.deregister(Token1);
 
     // then
@@ -82,7 +79,7 @@ describe('#createStaticInjectionContainer', () => {
     const container = createStaticInjectionContainer();
 
     // when
-    container.register(Token, () => dependency)(httpServer);
+    container.register(Token, () => dependency);
     container.deregisterAll();
 
     // then

--- a/packages/middleware-body/src/index.spec.ts
+++ b/packages/middleware-body/src/index.spec.ts
@@ -7,6 +7,7 @@ const MockReq = require('mock-req');
 
 describe('BodyParser middleware', () => {
   const injector = createStaticInjectionContainer();
+  const effectMeta = { inject: injector.get };
 
   beforeEach(() => {
     spyOn(console, 'log').and.stub();
@@ -31,7 +32,7 @@ describe('BodyParser middleware', () => {
     });
     const req$ = of(request as HttpRequest);
     const res = {} as HttpResponse;
-    const http$ = bodyParser$(req$, res, injector.get);
+    const http$ = bodyParser$(req$, res, effectMeta);
 
     http$.subscribe(data => {
       expect(data.body).toEqual({ test: 'test' });
@@ -49,7 +50,7 @@ describe('BodyParser middleware', () => {
     });
     const req$ = of(request as HttpRequest);
     const res = {} as HttpResponse;
-    const http$ = bodyParser$(req$, res, injector.get);
+    const http$ = bodyParser$(req$, res, effectMeta);
 
     http$.subscribe(data => {
       expect(data.body).toEqual({
@@ -72,7 +73,7 @@ describe('BodyParser middleware', () => {
     });
     const req$ = of(request as HttpRequest);
     const res = {} as HttpResponse;
-    const http$ = bodyParser$(req$, res, injector.get);
+    const http$ = bodyParser$(req$, res, effectMeta);
 
     http$.subscribe(
       () => {
@@ -97,7 +98,7 @@ describe('BodyParser middleware', () => {
     });
     const req$ = of(request as HttpRequest);
     const res = {} as HttpResponse;
-    const http$ = bodyParser$(req$, res, injector.get);
+    const http$ = bodyParser$(req$, res, effectMeta);
 
     http$.subscribe(data => {
       expect(data.body).toEqual('test');
@@ -115,7 +116,7 @@ describe('BodyParser middleware', () => {
     });
     const req$ = of(request as HttpRequest);
     const res = {} as HttpResponse;
-    const http$ = bodyParser$(req$, res, injector.get);
+    const http$ = bodyParser$(req$, res, effectMeta);
 
     http$.subscribe(
       () => {

--- a/packages/middleware-io/test/io-ws.integration.spec.ts
+++ b/packages/middleware-io/test/io-ws.integration.spec.ts
@@ -1,5 +1,6 @@
 import { createWebSocketsTestBed } from '@marblejs/websockets/dist/+internal';
 import { app } from './io-ws.integration';
+import { createStaticInjectionContainer, httpServerToken } from '@marblejs/core';
 
 describe('@marblejs/middleware-io - WebSocket integration', () => {
   const testBed = createWebSocketsTestBed();
@@ -13,9 +14,10 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
     const event = JSON.stringify({ type: 'POST_USER', payload: user });
     const httpServer = testBed.getServer();
     const targetClient = testBed.getClient();
+    const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
 
     // when
-    app(httpServer);
+    app()(injector);
     targetClient.once('open', () => targetClient.send(event));
 
     // then
@@ -29,6 +31,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
     // given
     const httpServer = testBed.getServer();
     const targetClient = testBed.getClient();
+    const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
     const user = { id: 'id', age: '100', };
     const event = JSON.stringify({ type: 'POST_USER', payload: user });
     const expectedError = {
@@ -40,7 +43,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
     };
 
     // when
-    app(httpServer);
+    app()(injector);
     targetClient.once('open', () => targetClient.send(event));
 
     // then

--- a/packages/middleware-joi/test/unit/body.spec.ts
+++ b/packages/middleware-joi/test/unit/body.spec.ts
@@ -5,7 +5,7 @@ import { bodyParser$ } from '@marblejs/middleware-body';
 const MockReq = require('mock-req');
 
 describe('Joi middleware - Body', () => {
-  const injector = createStaticInjectionContainer();
+  const metadata = { inject: createStaticInjectionContainer().get };
 
   it('should throws an error if dont pass a required field', done => {
     expect.assertions(2);
@@ -24,7 +24,7 @@ describe('Joi middleware - Body', () => {
       })
     };
 
-    const http$ = bodyParser$(req$, res, injector.get);
+    const http$ = bodyParser$(req$, res, metadata);
     const valid$ = validator$(schema)(http$);
 
     valid$.subscribe(
@@ -60,7 +60,7 @@ describe('Joi middleware - Body', () => {
       })
     };
 
-    const http$ = bodyParser$(req$, res, injector.get);
+    const http$ = bodyParser$(req$, res, metadata);
     const valid$ = validator$(schema)(http$);
 
     valid$.subscribe(
@@ -96,7 +96,7 @@ describe('Joi middleware - Body', () => {
       })
     };
 
-    const http$ = bodyParser$(req$, res, injector.get);
+    const http$ = bodyParser$(req$, res, metadata);
     const valid$ = validator$(schema, { allowUnknown: true })(http$);
 
     valid$.subscribe(data => {

--- a/packages/middleware-jwt/src/spec/jwt.middleware.spec.ts
+++ b/packages/middleware-jwt/src/spec/jwt.middleware.spec.ts
@@ -16,6 +16,7 @@ describe('JWT middleware', () => {
   let utilModule;
   let factoryModule;
   const injector = createStaticInjectionContainer();
+  const effectMeta = { inject: injector.get };
 
   beforeEach(() => {
     jest.unmock('../jwt.util.ts');
@@ -43,7 +44,7 @@ describe('JWT middleware', () => {
     utilModule.parseAuthorizationHeader = jest.fn(() => mockedToken);
     factoryModule.verifyToken$ = jest.fn(() => () => of(mockedTokenPayload));
 
-    const middleware$ = authorize$({ secret: mockedSecret }, verifyPayload$)(req$, res, injector.get);
+    const middleware$ = authorize$({ secret: mockedSecret }, verifyPayload$)(req$, res, effectMeta);
 
     // then
     middleware$.subscribe(
@@ -74,7 +75,7 @@ describe('JWT middleware', () => {
     utilModule.parseAuthorizationHeader = jest.fn(() => mockedToken);
     factoryModule.verifyToken$ = jest.fn(() => () => throwError(expectedError));
 
-    const middleware$ = authorize$({ secret: mockedSecret }, verifyPayload$)(req$, res, injector.get);
+    const middleware$ = authorize$({ secret: mockedSecret }, verifyPayload$)(req$, res, effectMeta);
 
     // then
     middleware$.subscribe(
@@ -106,7 +107,7 @@ describe('JWT middleware', () => {
     utilModule.parseAuthorizationHeader = jest.fn(() => mockedToken);
     factoryModule.verifyToken$ = jest.fn(() => () => of(mockedTokenPayload));
 
-    const middleware$ = authorize$({ secret: mockedSecret }, verifyPayload$)(req$, res, injector.get);
+    const middleware$ = authorize$({ secret: mockedSecret }, verifyPayload$)(req$, res, effectMeta);
 
     // then
     middleware$.subscribe(

--- a/packages/websockets/src/effects/ws-effects.interface.ts
+++ b/packages/websockets/src/effects/ws-effects.interface.ts
@@ -1,5 +1,5 @@
 import * as http from 'http';
-import { Event } from '@marblejs/core';
+import { Event, EffectMetadata } from '@marblejs/core';
 import { Observable } from 'rxjs';
 import { MarbleWebSocketClient } from '../websocket.interface';
 
@@ -22,7 +22,7 @@ export interface WebSocketEffect<
   T = Event,
   U = Event,
   V = MarbleWebSocketClient,
-  W = any,
+  W extends Error = Error,
 > {
-  (input$: Observable<T>, client: V, meta?: W): Observable<U>;
+  (input$: Observable<T>, client: V, meta: EffectMetadata<W>): Observable<U>;
 }

--- a/packages/websockets/src/error/specs/ws-error.effect.spec.ts
+++ b/packages/websockets/src/error/specs/ws-error.effect.spec.ts
@@ -19,7 +19,7 @@ describe('error$', () => {
     Marbles.assertEffect(error$, [
       ['--a--', { a: incomingEvent }],
       ['--b--', { b: outgoingEvent }],
-    ], { meta: error });
+    ], { meta: { error } });
   });
 
   test('returns stream of error events for undefined error object', () => {
@@ -32,7 +32,7 @@ describe('error$', () => {
     Marbles.assertEffect(error$, [
       ['--a--', { a: incomingEvent }],
       ['--b--', { b: outgoingEvent }],
-    ], { meta: error });
+    ], { meta: { error } });
   });
 
   test('returns stream of error events for undefined event object', () => {
@@ -45,6 +45,6 @@ describe('error$', () => {
     Marbles.assertEffect(error$, [
       ['--a--', { a: incomingEvent }],
       ['--b--', { b: outgoingEvent }],
-    ], { meta: error });
+    ], { meta: { error } });
   });
 });

--- a/packages/websockets/src/error/specs/ws-error.handler.spec.ts
+++ b/packages/websockets/src/error/specs/ws-error.handler.spec.ts
@@ -1,10 +1,16 @@
-import { EventError } from '@marblejs/core';
+import { EventError, createStaticInjectionContainer, EffectMetadata } from '@marblejs/core';
 import { mapTo } from 'rxjs/operators';
 import { handleEffectsError } from '../ws-error.handler';
 import { MarbleWebSocketClient } from '../../websocket.interface';
 import { WebSocketErrorEffect } from '../../effects/ws-effects.interface';
 
 describe('#handleEffectsError', () => {
+  let defaultMetadata: EffectMetadata;
+
+  beforeEach(() => {
+    defaultMetadata = { inject: createStaticInjectionContainer().get };
+  });
+
   test('handles error if error$ is defined', () => {
     // given
     const client = { sendResponse: jest.fn() } as any as MarbleWebSocketClient;
@@ -14,7 +20,7 @@ describe('#handleEffectsError', () => {
     );
 
     // when
-    handleEffectsError(client, error$)(error);
+    handleEffectsError(defaultMetadata, client, error$)(error);
 
     // then
     expect(client.sendResponse).toHaveBeenCalled();
@@ -26,7 +32,7 @@ describe('#handleEffectsError', () => {
     const error = new EventError({ type: 'EVENT' }, '');
 
     // when
-    handleEffectsError(client, undefined)(error);
+    handleEffectsError(defaultMetadata, client, undefined)(error);
 
     // then
     expect(client.sendResponse).not.toHaveBeenCalled();

--- a/packages/websockets/src/error/ws-error.effect.ts
+++ b/packages/websockets/src/error/ws-error.effect.ts
@@ -8,7 +8,7 @@ const errorFactory = (message: string | undefined, data: any | undefined) => ({
   message, data,
 });
 
-export const error$: WebSocketErrorEffect<EventError> = (event$, _, error) =>
+export const error$: WebSocketErrorEffect<EventError> = (event$, _, { error }) =>
   event$.pipe(
     map(event => ({
       type: event ? event.type : DEFAULT_ERROR_CHANNEL,

--- a/packages/websockets/src/error/ws-error.handler.ts
+++ b/packages/websockets/src/error/ws-error.handler.ts
@@ -1,13 +1,14 @@
 import { of } from 'rxjs';
-import { EventError } from '@marblejs/core';
+import { EventError, EffectMetadata } from '@marblejs/core';
 import { MarbleWebSocketClient } from '../websocket.interface';
 import { WebSocketErrorEffect } from '../effects/ws-effects.interface';
 
 export const handleEffectsError = <IncomingError extends EventError>(
+  metadata: EffectMetadata,
   client: MarbleWebSocketClient,
   error$: WebSocketErrorEffect<IncomingError, any, any> | undefined,
 ) => (error: IncomingError) => {
   if (error$) {
-    error$(of(error.event), client, error).subscribe(client.sendResponse);
+    error$(of(error.event), client, { ...metadata, error }).subscribe(client.sendResponse);
   }
 };

--- a/packages/websockets/src/listener/specs/websocket.listener.spec.ts
+++ b/packages/websockets/src/listener/specs/websocket.listener.spec.ts
@@ -1,4 +1,4 @@
-import { Event, EventError } from '@marblejs/core';
+import { Event, EventError, createStaticInjectionContainer, httpServerToken } from '@marblejs/core';
 import { throwError, fromEvent, forkJoin } from 'rxjs';
 import { tap, map, mergeMap, first, toArray, take } from 'rxjs/operators';
 import { webSocketListener } from '../websocket.listener';
@@ -18,12 +18,13 @@ describe('WebSocket listener', () => {
       // given
       const targetClient = testBed.getClient(0);
       const httpServer = testBed.getServer();
+      const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
       const echo$: WebSocketEffect = event$ => event$;
       const event = JSON.stringify({ type: 'EVENT', payload: 'test' });
       const webSocketServer = webSocketListener({ effects: [echo$] });
 
       // when
-      webSocketServer(httpServer);
+      webSocketServer()(injector);
       targetClient.once('open', () => targetClient.send(event));
 
       // then
@@ -41,10 +42,11 @@ describe('WebSocket listener', () => {
       const event = JSON.stringify({ type: 'EVENT', payload: 'test' });
       const webSocketServer = webSocketListener({ effects: [echo$] });
       const httpServer = testBed.getServer();
+      const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
       const targetClient = testBed.getClient(0);
 
       // when
-      webSocketServer(httpServer);
+      webSocketServer()(injector);
       targetClient.on('open', () => targetClient.send(event));
 
       // then
@@ -62,9 +64,10 @@ describe('WebSocket listener', () => {
       // given
       const echo$: WebSocketEffect = event$ => event$;
       const event = JSON.stringify({ type: 'EVENT', payload: 'test' });
-      const webSocketServer = webSocketListener({ effects: [echo$] })();
-      const targetClient = testBed.getClient(0);
       const httpServer = testBed.getServer();
+      const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
+      const webSocketServer = webSocketListener({ effects: [echo$] })({ noServer: true })(injector);
+      const targetClient = testBed.getClient(0);
 
       // when
       httpServer.on('upgrade', (request, socket, head) => {
@@ -93,13 +96,14 @@ describe('WebSocket listener', () => {
       );
       const targetClient = testBed.getClient(0);
       const httpServer = testBed.getServer();
+      const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
       const webSocketServer = webSocketListener({
         effects: [e$],
         middlewares: [m$, m$, m$],
       });
 
       // when
-      webSocketServer(httpServer);
+      webSocketServer()(injector);
       targetClient.once('open', () => targetClient.send(incomingEvent));
 
       // then
@@ -118,10 +122,11 @@ describe('WebSocket listener', () => {
       });
       const targetClient = testBed.getClient(0);
       const httpServer = testBed.getServer();
+      const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
       const webSocketServer = webSocketListener();
 
       // when
-      webSocketServer(httpServer);
+      webSocketServer()(injector);
       targetClient.once('open', () => {
         targetClient.send(incomingEvent);
         targetClient.send(incomingEvent);
@@ -146,10 +151,11 @@ describe('WebSocket listener', () => {
       );
       const targetClient = testBed.getClient(0);
       const httpServer = testBed.getServer();
+      const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
       const webSocketServer = webSocketListener({ effects: [effect$] });
 
       // when
-      webSocketServer(httpServer);
+      webSocketServer()(injector);
       targetClient.once('open', () => {
         targetClient.send(incomingEvent);
         targetClient.send(incomingEvent);
@@ -172,9 +178,10 @@ describe('WebSocket listener', () => {
       const webSocketServer = webSocketListener({ connection$ });
       const targetClient = testBed.getClient(0);
       const httpServer = testBed.getServer();
+      const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
 
       // when
-      webSocketServer(httpServer);
+      webSocketServer()(injector);
       targetClient.once('open', () => targetClient.send('test'));
 
       // then
@@ -205,9 +212,10 @@ describe('WebSocket listener', () => {
       );
       const httpServer = testBed.getServer();
       const webSocketServer = webSocketListener({ effects: [effect$], eventTransformer });
+      const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
 
       // when
-      webSocketServer(httpServer);
+      webSocketServer()(injector);
       targetClient.once('open', () => {
         targetClient.send(Buffer.from(decodedMessage));
       });

--- a/packages/websockets/src/operators/mapToServer/mapToServer.operator.spec.ts
+++ b/packages/websockets/src/operators/mapToServer/mapToServer.operator.spec.ts
@@ -1,10 +1,9 @@
 import { Marbles, createHttpRequest } from '@marblejs/core/dist/+internal';
-import { ServerEffect, createInjectionToken, ServerEvent, ServerEventType, matchEvent } from '@marblejs/core';
+import { ServerEffect, ServerEvent, ServerEventType, matchEvent } from '@marblejs/core';
 import { mapToServer, UpgradeEvent } from './mapToServer.operator';
 
 describe('#mapToServer operator', () => {
   let webSocketServerMock;
-  let injectorMock;
   let socketMock;
   let bufferMock;
 
@@ -15,7 +14,6 @@ describe('#mapToServer operator', () => {
       handleUpgrade: jest.fn((req, socket, head, done) => done()),
       emit: jest.fn(),
     };
-    injectorMock = jest.fn(() => webSocketServerMock);
   });
 
   test('connects socket to httpServer', () => {
@@ -30,20 +28,20 @@ describe('#mapToServer operator', () => {
     };
 
     // when
-    const effect$: ServerEffect = (event$, _, inject) =>
+    const effect$: ServerEffect = event$ =>
       event$.pipe(
         matchEvent(ServerEvent.upgrade),
         mapToServer(
-          { path: '/test_1', server: createInjectionToken() },
-          { path: '/test_2', server: createInjectionToken() },
-        )(inject),
+          { path: '/test_1', server: webSocketServerMock },
+          { path: '/test_2', server: webSocketServerMock },
+        ),
       );
 
     // then
     Marbles.assertEffect(effect$, [
       ['--a--', { a: incomingEvent }],
       ['-----', {}],
-    ], { meta: injectorMock });
+    ]);
 
     expect(webSocketServerMock.handleUpgrade).toHaveBeenCalledTimes(1);
     expect(webSocketServerMock.emit).toHaveBeenCalledTimes(1);
@@ -62,20 +60,20 @@ describe('#mapToServer operator', () => {
     };
 
     // when
-    const effect$: ServerEffect = (event$, _, inject) =>
+    const effect$: ServerEffect = event$ =>
       event$.pipe(
         matchEvent(ServerEvent.upgrade),
         mapToServer(
-          { path: '/test_1', server: createInjectionToken() },
-          { path: '/test_2', server: createInjectionToken() },
-        )(inject),
+          { path: '/test_1', server: webSocketServerMock },
+          { path: '/test_2', server: webSocketServerMock },
+        ),
       );
 
     // then
     Marbles.assertEffect(effect$, [
       ['--a--', { a: incomingEvent }],
       ['-----', {}],
-    ], { meta: injectorMock });
+    ]);
 
     expect(webSocketServerMock.handleUpgrade).not.toHaveBeenCalled();
     expect(webSocketServerMock.emit).not.toHaveBeenCalled();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- In Marble.js v1 the third Effect argument (metadata) wasn't used often. The PR introduces a refactored way, where the third argument is a common `EffectMetadata` object which can contain eventual `error` object or contextual `injector`.
- Shareable injection container
- The `http.Server` instance is registered to the injection container during `httpListener` bootstrapping, it can be easily retrieved via container.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```