### PR TITLE
feat(core, websockets): Effects output stream

### DIFF
--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -29,6 +29,9 @@ export interface ErrorEffect<T extends Error = HttpError>
 export interface ServerEffect<T extends Event = Event>
   extends Effect<T, any, http.Server> {}
 
+export interface OutputEffect<T extends EffectHttpResponse = EffectHttpResponse>
+  extends Effect<T, EffectHttpResponse> {}
+
 export interface Effect<
   T = HttpRequest,
   U = EffectHttpResponse,

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -44,11 +44,6 @@ export enum HttpMethodType {
 
 export type HttpMethod = keyof typeof HttpMethodType;
 
-export type Http = {
-  req: HttpRequest;
-  res: HttpResponse;
-};
-
 export enum HttpStatus {
   CONTINUE = 100,
   SWITCHING_PROTOCOLS = 101,

--- a/packages/core/src/listener/http.listener.ts
+++ b/packages/core/src/listener/http.listener.ts
@@ -1,9 +1,9 @@
 import { IncomingMessage, OutgoingMessage } from 'http';
 import { of, Subject } from 'rxjs';
-import { catchError, defaultIfEmpty, mergeMap, switchMap, tap, takeWhile } from 'rxjs/operators';
+import { catchError, defaultIfEmpty, mergeMap, tap, takeWhile } from 'rxjs/operators';
 import { combineMiddlewares } from '../effects/effects.combiner';
-import { EffectHttpResponse, Middleware, ErrorEffect } from '../effects/effects.interface';
-import { Http, HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
+import { EffectHttpResponse, Middleware, ErrorEffect, OutputEffect } from '../effects/effects.interface';
+import { HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
 import { handleResponse } from '../response/response.handler';
 import { RouteEffect, RouteEffectGroup } from '../router/router.interface';
 import { resolveRouting } from '../router/router.resolver';
@@ -16,39 +16,38 @@ export interface HttpListenerConfig {
   middlewares?: Middleware[];
   effects: (RouteEffect | RouteEffectGroup)[];
   error$?: ErrorEffect;
+  output$?: OutputEffect;
 }
 
 export const httpListener = ({
   middlewares = [],
   effects,
   error$ = defaultError$,
+  output$ = out$ => out$,
 }: HttpListenerConfig) => {
-  const requestSubject$ = new Subject<Http>();
+  const requestSubject$ = new Subject<{ req: HttpRequest; res: HttpResponse; }>();
   const combinedMiddlewares = combineMiddlewares(...middlewares);
   const routing = factorizeRouting(effects);
   const injector = createStaticInjectionContainer();
   const defaultMetadata = createEffectMetadata({ inject: injector.get });
   const defaultResponse = { status: HttpStatus.NOT_FOUND } as EffectHttpResponse;
 
-  const effect$ = requestSubject$.pipe(
-    mergeMap(({ req, res }) => {
-      res.send = handleResponse(res)(req);
-
-      return combinedMiddlewares(of(req), res, defaultMetadata).pipe(
-        takeWhile(() => !res.finished),
-        switchMap(resolveRouting(routing, defaultMetadata)(res)),
-        defaultIfEmpty(defaultResponse),
-        tap(res.send),
-        catchError(error =>
-          error$(of(req), res, createEffectMetadata({ ...defaultMetadata, error })).pipe(
-            tap(res.send),
-          ),
+  requestSubject$.pipe(
+    tap(({ req, res }) => res.send = handleResponse(res)(req)),
+    mergeMap(({ req, res }) => combinedMiddlewares(of(req), res, defaultMetadata).pipe(
+      takeWhile(() => !res.finished),
+      mergeMap(resolveRouting(routing, defaultMetadata)(res)),
+      defaultIfEmpty(defaultResponse),
+      mergeMap(out => output$(of(out), res, defaultMetadata)),
+      tap(res.send),
+      catchError(error =>
+        error$(of(req), res, createEffectMetadata({ ...defaultMetadata, error })).pipe(
+          mergeMap(out => output$(of(out), res, createEffectMetadata({ ...defaultMetadata, error }))),
+          tap(res.send),
         ),
-      );
-    }),
-  );
-
-  effect$.subscribe();
+      ),
+    )),
+  ).subscribe();
 
   const httpServer = (req: IncomingMessage, res: OutgoingMessage) => requestSubject$.next({
     req: req as HttpRequest,

--- a/packages/core/src/response/responseContentType.factory.ts
+++ b/packages/core/src/response/responseContentType.factory.ts
@@ -7,12 +7,9 @@ export const DEFAULT_CONTENT_TYPE = ContentType.APPLICATION_JSON;
 
 export const getMimeType = (body: any, path: string) => {
   const mimeFromBuffer = Buffer.isBuffer(body) && fileType(body);
-
-  if (mimeFromBuffer) {
-    return mimeFromBuffer.mime;
-  }
-
-  return mime.getType(path) || DEFAULT_CONTENT_TYPE;
+  return mimeFromBuffer
+    ? mimeFromBuffer.mime
+    : mime.getType(path) || DEFAULT_CONTENT_TYPE;
 };
 
 export const contentTypeFactory = (data: {

--- a/packages/websockets/src/effects/ws-effects.interface.ts
+++ b/packages/websockets/src/effects/ws-effects.interface.ts
@@ -18,6 +18,10 @@ export interface WebSocketConnectionEffect<
   T extends http.IncomingMessage = http.IncomingMessage
 > extends WebSocketEffect<T, T, MarbleWebSocketClient> {}
 
+export interface WebSocketOutputEffect<
+  T extends Event = Event
+> extends WebSocketEffect<T, Event> {}
+
 export interface WebSocketEffect<
   T = Event,
   U = Event,


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
> [...] response interceptor to modify certain type of responses for various reasons. Such as when Accept header is application/vnd.api+json, so maybe there is a stream of outgoing message which can be use to adjust the response accordingly. The API endpoint should worry only about resource being worked on. The exact data sent over wire or its representation is orthogonal to the API endpoint. Or in other case, when RouteEffect sends _404_ as a status code. It will be intercepted by common code that will send appropriate message depending upon the Accept header. 
@mistyharsh <<

Issue Number: #83

## What is the new behavior?
The API design shouldn't define any sort of additional post-Effect middlwares. In order to have a consistent API and preserve stream-like nature of the framework, each listener (HTTP, WebSockets) should expose an additional output stream where the developer can adjust the outputted `EffectResponse` accordingly to the needs.

**HTTP:**
```typescript
const httpServer = httpListener({
  middlewares: [ ... ],
  effects: [ ... ],
  output$: out$ => out$.pipe(
    // intercept Effect response and adjust it to your needs accordingly ☺️
  ),
});
```

**WebSockets:**
```typescript
const webSocketServer = webSocketListener({
  middlewares: [ ... ],
  effects: [ ... ],
  output$: out$ => out$.pipe(
    // intercept Effect response and adjust it to your needs accordingly ☺️
  ),
});
```
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```