### PR TITLE
imp(core, websockets): Effect interface naming

### DIFF
--- a/packages/@integration/src/effects/calculator.ws-effects.ts
+++ b/packages/@integration/src/effects/calculator.ws-effects.ts
@@ -1,14 +1,14 @@
 import { use, matchEvent } from '@marblejs/core';
-import { WebSocketEffect } from '@marblejs/websockets';
+import { WsEffect } from '@marblejs/websockets';
 import { t, eventValidator$ } from '@marblejs/middleware-io';
 import { buffer, map } from 'rxjs/operators';
 
-export const sum$: WebSocketEffect = event$ =>
+export const sum$: WsEffect = event$ =>
   event$.pipe(
     matchEvent('SUM')
   );
 
-export const add$: WebSocketEffect = (event$, ...args) =>
+export const add$: WsEffect = (event$, ...args) =>
   event$.pipe(
     matchEvent('ADD'),
     use(eventValidator$(t.number)),

--- a/packages/@integration/src/index.ts
+++ b/packages/@integration/src/index.ts
@@ -1,4 +1,4 @@
-import { createServer, matchEvent, ServerEvent, ServerEffect, bind } from '@marblejs/core';
+import { createServer, matchEvent, ServerEvent, HttpServerEffect, bind } from '@marblejs/core';
 import { mapToServer } from '@marblejs/websockets';
 import { merge } from 'rxjs';
 import { tap, map } from 'rxjs/operators';
@@ -6,7 +6,7 @@ import { httpServer } from './http.listener';
 import { webSocketServer } from './ws.listener';
 import { WebSocketsToken } from './tokens';
 
-const upgrade$: ServerEffect = (event$, _, { inject }) =>
+const upgrade$: HttpServerEffect = (event$, _, { inject }) =>
   event$.pipe(
     matchEvent(ServerEvent.upgrade),
     mapToServer({
@@ -15,7 +15,7 @@ const upgrade$: ServerEffect = (event$, _, { inject }) =>
     }),
   );
 
-const listen$: ServerEffect = event$ =>
+const listen$: HttpServerEffect = event$ =>
   event$.pipe(
     matchEvent(ServerEvent.listen),
     map(event => event.payload),

--- a/packages/@integration/src/middlewares/auth.middleware.ts
+++ b/packages/@integration/src/middlewares/auth.middleware.ts
@@ -1,9 +1,9 @@
-import { HttpError, HttpStatus, HttpMiddleware } from '@marblejs/core';
+import { HttpError, HttpStatus, HttpMiddlewareEffect } from '@marblejs/core';
 import { iif, of, throwError } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { isAuthorized } from '../fakes/auth.fake';
 
-export const authorize$: HttpMiddleware = req$ =>
+export const authorize$: HttpMiddlewareEffect = req$ =>
   req$.pipe(
     switchMap(req => iif(
       () => !isAuthorized(req),

--- a/packages/@integration/src/middlewares/auth.middleware.ts
+++ b/packages/@integration/src/middlewares/auth.middleware.ts
@@ -1,9 +1,9 @@
-import { HttpError, HttpStatus, Middleware } from '@marblejs/core';
+import { HttpError, HttpStatus, HttpMiddleware } from '@marblejs/core';
 import { iif, of, throwError } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { isAuthorized } from '../fakes/auth.fake';
 
-export const authorize$: Middleware = req$ =>
+export const authorize$: HttpMiddleware = req$ =>
   req$.pipe(
     switchMap(req => iif(
       () => !isAuthorized(req),

--- a/packages/@integration/src/ws.listener.ts
+++ b/packages/@integration/src/ws.listener.ts
@@ -1,9 +1,9 @@
-import { webSocketListener, WebSocketConnectionError, WebSocketConnectionEffect } from '@marblejs/websockets';
+import { webSocketListener, WebSocketConnectionError, WsConnectionEffect } from '@marblejs/websockets';
 import { iif, throwError, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { add$ } from './effects/calculator.ws-effects';
 
-const connection$: WebSocketConnectionEffect = req$ =>
+const connection$: WsConnectionEffect = req$ =>
   req$.pipe(
     mergeMap(req => iif(
       () => req.headers.upgrade !== 'websocket',

--- a/packages/core/src/effects/effects.factory.ts
+++ b/packages/core/src/effects/effects.factory.ts
@@ -1,5 +1,5 @@
 import { HttpMethod, HttpMethodType } from '../http.interface';
-import { Effect } from './effects.interface';
+import { HttpEffect } from './effects.interface';
 import { RouteEffect } from '../router/router.interface';
 import { coreErrorFactory, CoreErrorOptions } from '../error/error.factory';
 import { getArrayFromEnum } from '../+internal';
@@ -32,7 +32,7 @@ export namespace EffectFactory {
     return { use: use(path)(method) };
   };
 
-  const use = (path: string) => (method: HttpMethod) => (effect: Effect): RouteEffect => {
+  const use = (path: string) => (method: HttpMethod) => (effect: HttpEffect): RouteEffect => {
     if (!effect) {
       throw coreErrorFactory('Effect needs to be provided', coreErrorOptions);
     }

--- a/packages/core/src/effects/effects.factory.ts
+++ b/packages/core/src/effects/effects.factory.ts
@@ -1,5 +1,5 @@
 import { HttpMethod, HttpMethodType } from '../http.interface';
-import { HttpEffect } from './effects.interface';
+import { HttpEffect } from './http-effects.interface';
 import { RouteEffect } from '../router/router.interface';
 import { coreErrorFactory, CoreErrorOptions } from '../error/error.factory';
 import { getArrayFromEnum } from '../+internal';

--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -5,42 +5,46 @@ import { HttpError } from '../error/error.model';
 import { InjectorGetter } from '../server/server.injector';
 import { Event } from '../event/event.interface';
 
-export interface EffectMetadata<T extends Error = Error> {
-  inject: InjectorGetter;
-  scheduler: SchedulerLike;
-  error?: T;
-  [key: string]: any;
-}
-
-export interface EffectHttpResponse<T = any> {
+export interface HttpEffectResponse<T = any> {
   status?: HttpStatus;
   headers?: HttpHeaders;
   body?: T;
 }
 
-export interface Middleware<
+export interface HttpMiddleware<
   I extends HttpRequest = HttpRequest,
   O extends HttpRequest = HttpRequest,
-> extends Effect<I, O> {}
+> extends HttpEffect<I, O> {}
 
-export interface ErrorEffect<T extends Error = HttpError>
-  extends Effect<HttpRequest, EffectHttpResponse, HttpResponse, T> {}
+export interface HttpErrorEffect<T extends Error = HttpError>
+  extends HttpEffect<HttpRequest, HttpEffectResponse, HttpResponse, T> {}
 
-export interface ServerEffect<T extends Event = Event>
-  extends Effect<T, any, http.Server> {}
+export interface HttpServerEffect<T extends Event = Event>
+  extends HttpEffect<T, any, http.Server> {}
 
-export interface OutputEffect<T extends EffectHttpResponse = EffectHttpResponse>
-  extends Effect<T, EffectHttpResponse> {}
+export interface HttpOutputEffect<T extends HttpEffectResponse = HttpEffectResponse>
+  extends HttpEffect<T, HttpEffectResponse> {}
 
-export interface Effect<
+export interface HttpEffect<
   T = HttpRequest,
-  U = EffectHttpResponse,
+  U = HttpEffectResponse,
   V = HttpResponse,
   W extends Error = Error,
-> {
-  (input$: Observable<T>, client: V, meta: EffectMetadata<W>): Observable<U>;
-}
+> extends Effect<T, U, V, W> {}
+
+// common effect interfaces
 
 export interface EffectLike {
   (input$: Observable<any>, ...args: any[]): Observable<any>;
+}
+
+export interface Effect<I, O, C, E extends Error = Error> {
+  (input$: Observable<I>, client: C, meta: EffectMetadata<E>): Observable<O>;
+}
+
+export interface EffectMetadata<T extends Error = Error> {
+  inject: InjectorGetter;
+  scheduler: SchedulerLike;
+  error?: T;
+  [key: string]: any;
 }

--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -1,38 +1,5 @@
-import * as http from 'http';
 import { Observable, SchedulerLike } from 'rxjs';
-import { HttpRequest, HttpResponse, HttpStatus, HttpHeaders } from '../http.interface';
-import { HttpError } from '../error/error.model';
 import { InjectorGetter } from '../server/server.injector';
-import { Event } from '../event/event.interface';
-
-export interface HttpEffectResponse<T = any> {
-  status?: HttpStatus;
-  headers?: HttpHeaders;
-  body?: T;
-}
-
-export interface HttpMiddleware<
-  I extends HttpRequest = HttpRequest,
-  O extends HttpRequest = HttpRequest,
-> extends HttpEffect<I, O> {}
-
-export interface HttpErrorEffect<T extends Error = HttpError>
-  extends HttpEffect<HttpRequest, HttpEffectResponse, HttpResponse, T> {}
-
-export interface HttpServerEffect<T extends Event = Event>
-  extends HttpEffect<T, any, http.Server> {}
-
-export interface HttpOutputEffect<T extends HttpEffectResponse = HttpEffectResponse>
-  extends HttpEffect<T, HttpEffectResponse> {}
-
-export interface HttpEffect<
-  T = HttpRequest,
-  U = HttpEffectResponse,
-  V = HttpResponse,
-  W extends Error = Error,
-> extends Effect<T, U, V, W> {}
-
-// common effect interfaces
 
 export interface EffectLike {
   (input$: Observable<any>, ...args: any[]): Observable<any>;

--- a/packages/core/src/effects/http-effects.interface.ts
+++ b/packages/core/src/effects/http-effects.interface.ts
@@ -1,0 +1,32 @@
+import * as http from 'http';
+import { HttpRequest, HttpResponse, HttpStatus, HttpHeaders } from '../http.interface';
+import { HttpError } from '../error/error.model';
+import { Event } from '../event/event.interface';
+import { Effect } from './effects.interface';
+
+export interface HttpEffectResponse<T = any> {
+  status?: HttpStatus;
+  headers?: HttpHeaders;
+  body?: T;
+}
+
+export interface HttpMiddleware<
+  I extends HttpRequest = HttpRequest,
+  O extends HttpRequest = HttpRequest,
+> extends HttpEffect<I, O> {}
+
+export interface HttpErrorEffect<T extends Error = HttpError>
+  extends HttpEffect<HttpRequest, HttpEffectResponse, HttpResponse, T> {}
+
+export interface HttpServerEffect<T extends Event = Event>
+  extends HttpEffect<T, any, http.Server> {}
+
+export interface HttpOutputEffect<T extends HttpEffectResponse = HttpEffectResponse>
+  extends HttpEffect<T, HttpEffectResponse> {}
+
+export interface HttpEffect<
+  T = HttpRequest,
+  U = HttpEffectResponse,
+  V = HttpResponse,
+  W extends Error = Error,
+> extends Effect<T, U, V, W> {}

--- a/packages/core/src/effects/http-effects.interface.ts
+++ b/packages/core/src/effects/http-effects.interface.ts
@@ -10,7 +10,7 @@ export interface HttpEffectResponse<T = any> {
   body?: T;
 }
 
-export interface HttpMiddleware<
+export interface HttpMiddlewareEffect<
   I extends HttpRequest = HttpRequest,
   O extends HttpRequest = HttpRequest,
 > extends HttpEffect<I, O> {}

--- a/packages/core/src/effects/specs/effects.combiner.spec.ts
+++ b/packages/core/src/effects/specs/effects.combiner.spec.ts
@@ -1,14 +1,14 @@
 import { tap, mapTo, filter } from 'rxjs/operators';
-import { Middleware, Effect } from '../effects.interface';
+import { HttpMiddleware, HttpEffect } from '../effects.interface';
 import { combineMiddlewares, combineEffects } from '../effects.combiner';
 import { Marbles, createHttpRequest } from '../../+internal';
 
 describe('#combineMiddlewares', () => {
   test('combines middlewares into one stream', () => {
     // given
-    const a$: Middleware = req$ => req$.pipe(tap(req => { req.test = 1; }));
-    const b$: Middleware = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
-    const c$: Middleware = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
+    const a$: HttpMiddleware = req$ => req$.pipe(tap(req => { req.test = 1; }));
+    const b$: HttpMiddleware = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
+    const c$: HttpMiddleware = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
     const incomingRequest = createHttpRequest({ url: '/' });
     const outgoingRequest = createHttpRequest({ url: '/', test: 3 });
 
@@ -41,9 +41,9 @@ describe('#combineMiddlewares', () => {
 describe('#combineEffects', () => {
   test('combines effects into multiple streams', () => {
     // given
-    const a$: Effect = req$ => req$.pipe(filter(req => req.url === '/a'), mapTo({ body: 'a' }));
-    const b$: Effect = req$ => req$.pipe(filter(req => req.url === '/b'), mapTo({ body: 'b' }));
-    const c$: Effect = req$ => req$.pipe(filter(req => req.url === '/c'), mapTo({ body: 'c' }));
+    const a$: HttpEffect = req$ => req$.pipe(filter(req => req.url === '/a'), mapTo({ body: 'a' }));
+    const b$: HttpEffect = req$ => req$.pipe(filter(req => req.url === '/b'), mapTo({ body: 'b' }));
+    const c$: HttpEffect = req$ => req$.pipe(filter(req => req.url === '/c'), mapTo({ body: 'c' }));
     const a = createHttpRequest({ url: '/a' });
     const b = createHttpRequest({ url: '/b' });
     const c = createHttpRequest({ url: '/c' });

--- a/packages/core/src/effects/specs/effects.combiner.spec.ts
+++ b/packages/core/src/effects/specs/effects.combiner.spec.ts
@@ -1,5 +1,5 @@
 import { tap, mapTo, filter } from 'rxjs/operators';
-import { HttpMiddleware, HttpEffect } from '../effects.interface';
+import { HttpMiddleware, HttpEffect } from '../http-effects.interface';
 import { combineMiddlewares, combineEffects } from '../effects.combiner';
 import { Marbles, createHttpRequest } from '../../+internal';
 

--- a/packages/core/src/effects/specs/effects.combiner.spec.ts
+++ b/packages/core/src/effects/specs/effects.combiner.spec.ts
@@ -1,14 +1,14 @@
 import { tap, mapTo, filter } from 'rxjs/operators';
-import { HttpMiddleware, HttpEffect } from '../http-effects.interface';
+import { HttpMiddlewareEffect, HttpEffect } from '../http-effects.interface';
 import { combineMiddlewares, combineEffects } from '../effects.combiner';
 import { Marbles, createHttpRequest } from '../../+internal';
 
 describe('#combineMiddlewares', () => {
   test('combines middlewares into one stream', () => {
     // given
-    const a$: HttpMiddleware = req$ => req$.pipe(tap(req => { req.test = 1; }));
-    const b$: HttpMiddleware = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
-    const c$: HttpMiddleware = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
+    const a$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => { req.test = 1; }));
+    const b$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
+    const c$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
     const incomingRequest = createHttpRequest({ url: '/' });
     const outgoingRequest = createHttpRequest({ url: '/', test: 3 });
 

--- a/packages/core/src/effects/specs/effects.factory.spec.ts
+++ b/packages/core/src/effects/specs/effects.factory.spec.ts
@@ -1,5 +1,5 @@
 import { mapTo } from 'rxjs/operators';
-import { HttpEffect } from '../effects.interface';
+import { HttpEffect } from '../http-effects.interface';
 import { EffectFactory } from '../effects.factory';
 import { HttpMethod } from '../../http.interface';
 

--- a/packages/core/src/effects/specs/effects.factory.spec.ts
+++ b/packages/core/src/effects/specs/effects.factory.spec.ts
@@ -1,5 +1,5 @@
 import { mapTo } from 'rxjs/operators';
-import { Effect } from '../effects.interface';
+import { HttpEffect } from '../effects.interface';
 import { EffectFactory } from '../effects.factory';
 import { HttpMethod } from '../../http.interface';
 
@@ -20,7 +20,7 @@ describe('EffectFactory', () => {
 
   test('factorizes RouteConfig', () => {
     // given
-    const effect$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
+    const effect$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
     const path = '/foo';
     const method = 'GET';
 

--- a/packages/core/src/error/error.effect.ts
+++ b/packages/core/src/error/error.effect.ts
@@ -1,5 +1,5 @@
 import { map, mapTo } from 'rxjs/operators';
-import { ErrorEffect } from '../effects/effects.interface';
+import { HttpErrorEffect } from '../effects/effects.interface';
 import { HttpStatus } from '../http.interface';
 import { HttpError, isHttpError } from './error.model';
 
@@ -18,7 +18,7 @@ const errorFactory = (status: HttpStatus, error: Error) =>
     ? { error: { status, message: error.message, data: error.data, context: error.context } }
     : { error: { status, message: error.message } };
 
-export const defaultError$: ErrorEffect<HttpError> = (req$, _, meta) => req$
+export const defaultError$: HttpErrorEffect<HttpError> = (req$, _, meta) => req$
   .pipe(
     mapTo(meta.error || defaultHttpError),
     map(error => {

--- a/packages/core/src/error/error.effect.ts
+++ b/packages/core/src/error/error.effect.ts
@@ -1,5 +1,5 @@
 import { map, mapTo } from 'rxjs/operators';
-import { HttpErrorEffect } from '../effects/effects.interface';
+import { HttpErrorEffect } from '../effects/http-effects.interface';
 import { HttpStatus } from '../http.interface';
 import { HttpError, isHttpError } from './error.model';
 

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import { Observable } from 'rxjs';
-import { EffectHttpResponse } from './effects/effects.interface';
+import { HttpEffectResponse } from './effects/effects.interface';
 
 export interface HttpRequest<
   TBody = unknown,
@@ -24,7 +24,7 @@ export interface QueryParameters {
 }
 
 export interface HttpResponse extends http.ServerResponse {
-  send: (response: EffectHttpResponse) => Observable<never>;
+  send: (response: HttpEffectResponse) => Observable<never>;
 }
 
 export interface HttpHeaders extends http.OutgoingHttpHeaders {}

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import { Observable } from 'rxjs';
-import { HttpEffectResponse } from './effects/effects.interface';
+import { HttpEffectResponse } from './effects/http-effects.interface';
 
 export interface HttpRequest<
   TBody = unknown,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export { combineRoutes } from './router/router.combiner';
 export { combineEffects, combineMiddlewares } from './effects/effects.combiner';
 export { createEffectMetadata } from './effects/effectsMetadata.factory';
 export * from './effects/effects.interface';
+export * from './effects/http-effects.interface';
 export * from './router/router.interface';
 export * from './operators';
 export * from './http.interface';

--- a/packages/core/src/listener/http.listener.spec.ts
+++ b/packages/core/src/listener/http.listener.spec.ts
@@ -3,7 +3,7 @@ import { of, throwError } from 'rxjs';
 import { mapTo, switchMap } from 'rxjs/operators';
 import { httpListener } from './http.listener';
 import { EffectFactory } from '../effects/effects.factory';
-import { Middleware } from '../effects/effects.interface';
+import { HttpMiddleware } from '../effects/effects.interface';
 
 describe('Http listener', () => {
   let effectsCombiner;
@@ -16,7 +16,7 @@ describe('Http listener', () => {
     .matchType('GET')
     .use(req$ => req$.pipe(mapTo( {} )));
 
-  const middleware$: Middleware = req$ => req$;
+  const middleware$: HttpMiddleware = req$ => req$;
 
   beforeEach(() => {
     jest.unmock('../error/error.effect.ts');

--- a/packages/core/src/listener/http.listener.spec.ts
+++ b/packages/core/src/listener/http.listener.spec.ts
@@ -3,7 +3,7 @@ import { of, throwError } from 'rxjs';
 import { mapTo, switchMap } from 'rxjs/operators';
 import { httpListener } from './http.listener';
 import { EffectFactory } from '../effects/effects.factory';
-import { HttpMiddleware } from '../effects/effects.interface';
+import { HttpMiddleware } from '../effects/http-effects.interface';
 
 describe('Http listener', () => {
   let effectsCombiner;

--- a/packages/core/src/listener/http.listener.spec.ts
+++ b/packages/core/src/listener/http.listener.spec.ts
@@ -3,7 +3,7 @@ import { of, throwError } from 'rxjs';
 import { mapTo, switchMap } from 'rxjs/operators';
 import { httpListener } from './http.listener';
 import { EffectFactory } from '../effects/effects.factory';
-import { HttpMiddleware } from '../effects/http-effects.interface';
+import { HttpMiddlewareEffect } from '../effects/http-effects.interface';
 
 describe('Http listener', () => {
   let effectsCombiner;
@@ -16,7 +16,7 @@ describe('Http listener', () => {
     .matchType('GET')
     .use(req$ => req$.pipe(mapTo( {} )));
 
-  const middleware$: HttpMiddleware = req$ => req$;
+  const middleware$: HttpMiddlewareEffect = req$ => req$;
 
   beforeEach(() => {
     jest.unmock('../error/error.effect.ts');

--- a/packages/core/src/listener/http.listener.ts
+++ b/packages/core/src/listener/http.listener.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, OutgoingMessage } from 'http';
 import { of, Subject } from 'rxjs';
 import { catchError, defaultIfEmpty, mergeMap, tap, takeWhile } from 'rxjs/operators';
 import { combineMiddlewares } from '../effects/effects.combiner';
-import { EffectHttpResponse, Middleware, ErrorEffect, OutputEffect } from '../effects/effects.interface';
+import { HttpEffectResponse, HttpMiddleware, HttpErrorEffect, HttpOutputEffect } from '../effects/effects.interface';
 import { HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
 import { handleResponse } from '../response/response.handler';
 import { RouteEffect, RouteEffectGroup } from '../router/router.interface';
@@ -13,10 +13,10 @@ import { createStaticInjectionContainer } from '../server/server.injector';
 import { createEffectMetadata } from '../effects/effectsMetadata.factory';
 
 export interface HttpListenerConfig {
-  middlewares?: Middleware[];
+  middlewares?: HttpMiddleware[];
   effects: (RouteEffect | RouteEffectGroup)[];
-  error$?: ErrorEffect;
-  output$?: OutputEffect;
+  error$?: HttpErrorEffect;
+  output$?: HttpOutputEffect;
 }
 
 export const httpListener = ({
@@ -30,7 +30,7 @@ export const httpListener = ({
   const routing = factorizeRouting(effects);
   const injector = createStaticInjectionContainer();
   const defaultMetadata = createEffectMetadata({ inject: injector.get });
-  const defaultResponse = { status: HttpStatus.NOT_FOUND } as EffectHttpResponse;
+  const defaultResponse = { status: HttpStatus.NOT_FOUND } as HttpEffectResponse;
 
   requestSubject$.pipe(
     tap(({ req, res }) => res.send = handleResponse(res)(req)),

--- a/packages/core/src/listener/http.listener.ts
+++ b/packages/core/src/listener/http.listener.ts
@@ -4,7 +4,7 @@ import { catchError, defaultIfEmpty, mergeMap, tap, takeWhile } from 'rxjs/opera
 import { combineMiddlewares } from '../effects/effects.combiner';
 import {
   HttpEffectResponse,
-  HttpMiddleware,
+  HttpMiddlewareEffect,
   HttpErrorEffect,
   HttpOutputEffect,
 } from '../effects/http-effects.interface';
@@ -18,7 +18,7 @@ import { createStaticInjectionContainer } from '../server/server.injector';
 import { createEffectMetadata } from '../effects/effectsMetadata.factory';
 
 export interface HttpListenerConfig {
-  middlewares?: HttpMiddleware[];
+  middlewares?: HttpMiddlewareEffect[];
   effects: (RouteEffect | RouteEffectGroup)[];
   error$?: HttpErrorEffect;
   output$?: HttpOutputEffect;

--- a/packages/core/src/listener/http.listener.ts
+++ b/packages/core/src/listener/http.listener.ts
@@ -2,7 +2,12 @@ import { IncomingMessage, OutgoingMessage } from 'http';
 import { of, Subject } from 'rxjs';
 import { catchError, defaultIfEmpty, mergeMap, tap, takeWhile } from 'rxjs/operators';
 import { combineMiddlewares } from '../effects/effects.combiner';
-import { HttpEffectResponse, HttpMiddleware, HttpErrorEffect, HttpOutputEffect } from '../effects/effects.interface';
+import {
+  HttpEffectResponse,
+  HttpMiddleware,
+  HttpErrorEffect,
+  HttpOutputEffect,
+} from '../effects/http-effects.interface';
 import { HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
 import { handleResponse } from '../response/response.handler';
 import { RouteEffect, RouteEffectGroup } from '../router/router.interface';

--- a/packages/core/src/operators/switchToProtocol/switchToProtocol.operator.spec.ts
+++ b/packages/core/src/operators/switchToProtocol/switchToProtocol.operator.spec.ts
@@ -1,4 +1,4 @@
-import { HttpEffect } from '../../effects/effects.interface';
+import { HttpEffect } from '../../effects/http-effects.interface';
 import { HttpStatus } from '../../http.interface';
 import { createHttpRequest, Marbles } from '../../+internal/testing';
 import { switchToProtocol } from './switchToProtocol.operator';

--- a/packages/core/src/operators/switchToProtocol/switchToProtocol.operator.spec.ts
+++ b/packages/core/src/operators/switchToProtocol/switchToProtocol.operator.spec.ts
@@ -1,4 +1,4 @@
-import { Effect } from '../../effects/effects.interface';
+import { HttpEffect } from '../../effects/effects.interface';
 import { HttpStatus } from '../../http.interface';
 import { createHttpRequest, Marbles } from '../../+internal/testing';
 import { switchToProtocol } from './switchToProtocol.operator';
@@ -29,7 +29,7 @@ describe('#switchToProtocol operator', () => {
     };
 
     // when
-    const effect$: Effect = req$ =>
+    const effect$: HttpEffect = req$ =>
       req$.pipe(
         switchToProtocol('websocket'),
       );

--- a/packages/core/src/operators/use/use.operator.spec.ts
+++ b/packages/core/src/operators/use/use.operator.spec.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 import { tap, map } from 'rxjs/operators';
 import { Marbles } from '../../+internal';
-import { HttpEffect } from '../../effects/effects.interface';
+import { HttpEffect } from '../../effects/http-effects.interface';
 import { HttpRequest } from '../../http.interface';
 import { use } from './use.operator';
 

--- a/packages/core/src/operators/use/use.operator.spec.ts
+++ b/packages/core/src/operators/use/use.operator.spec.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 import { tap, map } from 'rxjs/operators';
 import { Marbles } from '../../+internal';
-import { Effect } from '../../effects/effects.interface';
+import { HttpEffect } from '../../effects/effects.interface';
 import { HttpRequest } from '../../http.interface';
 import { use } from './use.operator';
 
@@ -14,7 +14,7 @@ describe('#use operator', () => {
         tap(req => req.body++)
       );
 
-    const effect$: Effect<HttpRequest<number>> = req$ => req$.pipe(
+    const effect$: HttpEffect<HttpRequest<number>> = req$ => req$.pipe(
       use(m$),
       use(m$),
     );
@@ -51,7 +51,7 @@ describe('#use operator', () => {
         tap(req => req.user = { id: 'test_id' }),
       ) as Observable<AuthorizedHttpRequest & T>;
 
-    const effect$: Effect = req$ =>
+    const effect$: HttpEffect = req$ =>
       req$.pipe(
         use(m1$),
         use(m2$),

--- a/packages/core/src/response/response.handler.ts
+++ b/packages/core/src/response/response.handler.ts
@@ -1,10 +1,10 @@
 import { EMPTY } from 'rxjs';
-import { EffectHttpResponse } from '../effects/effects.interface';
+import { HttpEffectResponse } from '../effects/effects.interface';
 import { HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
 import { bodyFactory } from './responseBody.factory';
 import { headersFactory } from './responseHeaders.factory';
 
-export const handleResponse = (res: HttpResponse) => (req: HttpRequest) => (effect: EffectHttpResponse) => {
+export const handleResponse = (res: HttpResponse) => (req: HttpRequest) => (effect: HttpEffectResponse) => {
   if (res.finished) { return EMPTY; }
 
   const status = effect.status || HttpStatus.OK;

--- a/packages/core/src/response/response.handler.ts
+++ b/packages/core/src/response/response.handler.ts
@@ -1,5 +1,5 @@
 import { EMPTY } from 'rxjs';
-import { HttpEffectResponse } from '../effects/effects.interface';
+import { HttpEffectResponse } from '../effects/http-effects.interface';
 import { HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
 import { bodyFactory } from './responseBody.factory';
 import { headersFactory } from './responseHeaders.factory';

--- a/packages/core/src/router/router.factory.ts
+++ b/packages/core/src/router/router.factory.ts
@@ -1,4 +1,4 @@
-import { Middleware } from '../effects/effects.interface';
+import { HttpMiddleware } from '../effects/effects.interface';
 import { combineMiddlewares } from '../effects/effects.combiner';
 import { isRouteEffectGroup } from './router.helpers';
 import {
@@ -12,7 +12,7 @@ import { factorizeRegExpWithParams } from './router.params.factory';
 
 export const factorizeRouting = (
   routes: (RouteEffect | RouteEffectGroup)[],
-  middlewares: Middleware[] = [],
+  middlewares: HttpMiddleware[] = [],
   parentPath = '',
 ): Routing => {
   const routing: Routing = [];

--- a/packages/core/src/router/router.factory.ts
+++ b/packages/core/src/router/router.factory.ts
@@ -1,4 +1,4 @@
-import { HttpMiddleware } from '../effects/effects.interface';
+import { HttpMiddleware } from '../effects/http-effects.interface';
 import { combineMiddlewares } from '../effects/effects.combiner';
 import { isRouteEffectGroup } from './router.helpers';
 import {

--- a/packages/core/src/router/router.factory.ts
+++ b/packages/core/src/router/router.factory.ts
@@ -1,4 +1,4 @@
-import { HttpMiddleware } from '../effects/http-effects.interface';
+import { HttpMiddlewareEffect } from '../effects/http-effects.interface';
 import { combineMiddlewares } from '../effects/effects.combiner';
 import { isRouteEffectGroup } from './router.helpers';
 import {
@@ -12,7 +12,7 @@ import { factorizeRegExpWithParams } from './router.params.factory';
 
 export const factorizeRouting = (
   routes: (RouteEffect | RouteEffectGroup)[],
-  middlewares: HttpMiddleware[] = [],
+  middlewares: HttpMiddlewareEffect[] = [],
   parentPath = '',
 ): Routing => {
   const routing: Routing = [];

--- a/packages/core/src/router/router.interface.ts
+++ b/packages/core/src/router/router.interface.ts
@@ -1,23 +1,23 @@
 import { HttpMethod, HttpRequest } from '../http.interface';
-import { HttpEffect, HttpMiddleware, HttpEffectResponse } from '../effects/http-effects.interface';
+import { HttpEffect, HttpMiddlewareEffect, HttpEffectResponse } from '../effects/http-effects.interface';
 
 // Route
 export interface RouteEffect<T extends HttpRequest = HttpRequest> {
   path: string;
   method: HttpMethod;
   effect: HttpEffect<T, HttpEffectResponse>;
-  middleware?: HttpMiddleware;
+  middleware?: HttpMiddlewareEffect;
 }
 
 export interface RouteEffectGroup {
   path: string;
-  middlewares: HttpMiddleware[];
+  middlewares: HttpMiddlewareEffect[];
   effects: (RouteEffect | RouteEffectGroup)[];
 }
 
 // Combiner
 export interface RouteCombinerConfig {
-  middlewares?: HttpMiddleware[];
+  middlewares?: HttpMiddlewareEffect[];
   effects: (RouteEffect | RouteEffectGroup)[];
 }
 
@@ -30,7 +30,7 @@ export interface ParametricRegExp {
 
 export interface RoutingMethod {
   parameters?: string[] | undefined;
-  middleware?: HttpMiddleware | undefined;
+  middleware?: HttpMiddlewareEffect | undefined;
   effect: HttpEffect;
 }
 
@@ -41,7 +41,7 @@ export interface RoutingItem {
 }
 
 export interface RouteMatched {
-  middleware?: HttpMiddleware | undefined;
+  middleware?: HttpMiddlewareEffect | undefined;
   effect: HttpEffect;
   params: Record<string, string>;
 }

--- a/packages/core/src/router/router.interface.ts
+++ b/packages/core/src/router/router.interface.ts
@@ -1,5 +1,5 @@
 import { HttpMethod, HttpRequest } from '../http.interface';
-import { HttpEffect, HttpMiddleware, HttpEffectResponse } from '../effects/effects.interface';
+import { HttpEffect, HttpMiddleware, HttpEffectResponse } from '../effects/http-effects.interface';
 
 // Route
 export interface RouteEffect<T extends HttpRequest = HttpRequest> {

--- a/packages/core/src/router/router.interface.ts
+++ b/packages/core/src/router/router.interface.ts
@@ -1,23 +1,23 @@
 import { HttpMethod, HttpRequest } from '../http.interface';
-import { Effect, Middleware, EffectHttpResponse } from '../effects/effects.interface';
+import { HttpEffect, HttpMiddleware, HttpEffectResponse } from '../effects/effects.interface';
 
 // Route
 export interface RouteEffect<T extends HttpRequest = HttpRequest> {
   path: string;
   method: HttpMethod;
-  effect: Effect<T, EffectHttpResponse>;
-  middleware?: Middleware;
+  effect: HttpEffect<T, HttpEffectResponse>;
+  middleware?: HttpMiddleware;
 }
 
 export interface RouteEffectGroup {
   path: string;
-  middlewares: Middleware[];
+  middlewares: HttpMiddleware[];
   effects: (RouteEffect | RouteEffectGroup)[];
 }
 
 // Combiner
 export interface RouteCombinerConfig {
-  middlewares?: Middleware[];
+  middlewares?: HttpMiddleware[];
   effects: (RouteEffect | RouteEffectGroup)[];
 }
 
@@ -30,8 +30,8 @@ export interface ParametricRegExp {
 
 export interface RoutingMethod {
   parameters?: string[] | undefined;
-  middleware?: Middleware | undefined;
-  effect: Effect;
+  middleware?: HttpMiddleware | undefined;
+  effect: HttpEffect;
 }
 
 export interface RoutingItem {
@@ -41,8 +41,8 @@ export interface RoutingItem {
 }
 
 export interface RouteMatched {
-  middleware?: Middleware | undefined;
-  effect: Effect;
+  middleware?: HttpMiddleware | undefined;
+  effect: HttpEffect;
   params: Record<string, string>;
 }
 

--- a/packages/core/src/router/router.resolver.ts
+++ b/packages/core/src/router/router.resolver.ts
@@ -1,7 +1,8 @@
 import { EMPTY, Observable, of } from 'rxjs';
 import { mergeMap, takeWhile } from 'rxjs/operators';
 import { HttpMethod, HttpRequest, HttpResponse } from '../http.interface';
-import { HttpEffectResponse, EffectMetadata } from '../effects/effects.interface';
+import { EffectMetadata } from '../effects/effects.interface';
+import { HttpEffectResponse } from '../effects/http-effects.interface';
 import { RouteMatched, Routing, RoutingItem } from './router.interface';
 import { queryParamsFactory } from './router.query.factory';
 export { RoutingItem };

--- a/packages/core/src/router/router.resolver.ts
+++ b/packages/core/src/router/router.resolver.ts
@@ -1,7 +1,7 @@
 import { EMPTY, Observable, of } from 'rxjs';
 import { mergeMap, takeWhile } from 'rxjs/operators';
 import { HttpMethod, HttpRequest, HttpResponse } from '../http.interface';
-import { EffectHttpResponse, EffectMetadata } from '../effects/effects.interface';
+import { HttpEffectResponse, EffectMetadata } from '../effects/effects.interface';
 import { RouteMatched, Routing, RoutingItem } from './router.interface';
 import { queryParamsFactory } from './router.query.factory';
 export { RoutingItem };
@@ -38,7 +38,7 @@ export const findRoute = (
 export const resolveRouting =
   (routing: Routing, metadata: EffectMetadata) =>
   (res: HttpResponse) =>
-  (req: HttpRequest): Observable<EffectHttpResponse> => {
+  (req: HttpRequest): Observable<HttpEffectResponse> => {
     if (res.finished) { return EMPTY; }
 
     const [urlPath, urlQuery] = req.url.split('?');

--- a/packages/core/src/router/specs/router.combiner.spec.ts
+++ b/packages/core/src/router/specs/router.combiner.spec.ts
@@ -1,7 +1,7 @@
 import { mapTo } from 'rxjs/operators';
 import { combineRoutes } from '../router.combiner';
 import { EffectFactory } from '../../effects/effects.factory';
-import { HttpMiddleware, HttpEffect } from '../../effects/effects.interface';
+import { HttpMiddleware, HttpEffect } from '../../effects/http-effects.interface';
 
 describe('#combineRoutes', () => {
   test('factorizes combined routes for effects only', () => {

--- a/packages/core/src/router/specs/router.combiner.spec.ts
+++ b/packages/core/src/router/specs/router.combiner.spec.ts
@@ -1,7 +1,7 @@
 import { mapTo } from 'rxjs/operators';
 import { combineRoutes } from '../router.combiner';
 import { EffectFactory } from '../../effects/effects.factory';
-import { HttpMiddleware, HttpEffect } from '../../effects/http-effects.interface';
+import { HttpMiddlewareEffect, HttpEffect } from '../../effects/http-effects.interface';
 
 describe('#combineRoutes', () => {
   test('factorizes combined routes for effects only', () => {
@@ -27,8 +27,8 @@ describe('#combineRoutes', () => {
     const a$ = EffectFactory.matchPath('/a').matchType('GET').use(effect$);
     const b$ = EffectFactory.matchPath('/b').matchType('GET').use(effect$);
 
-    const m1$: HttpMiddleware = req$ => req$;
-    const m2$: HttpMiddleware = req$ => req$;
+    const m1$: HttpMiddlewareEffect = req$ => req$;
+    const m2$: HttpMiddlewareEffect = req$ => req$;
 
     // when
     const combiner = combineRoutes('/test', {

--- a/packages/core/src/router/specs/router.combiner.spec.ts
+++ b/packages/core/src/router/specs/router.combiner.spec.ts
@@ -1,7 +1,7 @@
 import { mapTo } from 'rxjs/operators';
 import { combineRoutes } from '../router.combiner';
 import { EffectFactory } from '../../effects/effects.factory';
-import { Middleware } from '../../effects/effects.interface';
+import { HttpMiddleware, HttpEffect } from '../../effects/effects.interface';
 
 describe('#combineRoutes', () => {
   test('factorizes combined routes for effects only', () => {
@@ -23,12 +23,12 @@ describe('#combineRoutes', () => {
 
   test('factorizes combined routes for effects with middlewares', () => {
     // given
-    const effect$ = req$ => req$.pipe(mapTo({}));
+    const effect$: HttpEffect = req$ => req$.pipe(mapTo({}));
     const a$ = EffectFactory.matchPath('/a').matchType('GET').use(effect$);
     const b$ = EffectFactory.matchPath('/b').matchType('GET').use(effect$);
 
-    const m1$: Middleware = req$ => req$;
-    const m2$: Middleware = req$ => req$;
+    const m1$: HttpMiddleware = req$ => req$;
+    const m2$: HttpMiddleware = req$ => req$;
 
     // when
     const combiner = combineRoutes('/test', {

--- a/packages/core/src/router/specs/router.factory.spec.ts
+++ b/packages/core/src/router/specs/router.factory.spec.ts
@@ -1,5 +1,5 @@
 import { mapTo } from 'rxjs/operators';
-import { HttpEffect, HttpMiddleware } from '../../effects/http-effects.interface';
+import { HttpEffect, HttpMiddlewareEffect } from '../../effects/http-effects.interface';
 import { RouteEffect, RouteEffectGroup, Routing } from '../router.interface';
 import { factorizeRouting } from '../router.factory';
 
@@ -13,7 +13,7 @@ describe('#factorizeRouting', () => {
 
   test('factorizes routing with nested groups', () => {
     // given
-    const m$: HttpMiddleware = req$ => req$;
+    const m$: HttpMiddlewareEffect = req$ => req$;
     const e1$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test1' }));
     const e2$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test2' }));
     const e3$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test3' }));

--- a/packages/core/src/router/specs/router.factory.spec.ts
+++ b/packages/core/src/router/specs/router.factory.spec.ts
@@ -1,5 +1,5 @@
 import { mapTo } from 'rxjs/operators';
-import { Effect, Middleware } from '../../effects/effects.interface';
+import { HttpEffect, HttpMiddleware } from '../../effects/effects.interface';
 import { RouteEffect, RouteEffectGroup, Routing } from '../router.interface';
 import { factorizeRouting } from '../router.factory';
 
@@ -13,12 +13,12 @@ describe('#factorizeRouting', () => {
 
   test('factorizes routing with nested groups', () => {
     // given
-    const m$: Middleware = req$ => req$;
-    const e1$: Effect = req$ => req$.pipe(mapTo({ body: 'test1' }));
-    const e2$: Effect = req$ => req$.pipe(mapTo({ body: 'test2' }));
-    const e3$: Effect = req$ => req$.pipe(mapTo({ body: 'test3' }));
-    const e4$: Effect = req$ => req$.pipe(mapTo({ body: 'test4' }));
-    const e5$: Effect = req$ => req$.pipe(mapTo({ body: 'test5' }));
+    const m$: HttpMiddleware = req$ => req$;
+    const e1$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test1' }));
+    const e2$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test2' }));
+    const e3$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test3' }));
+    const e4$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test4' }));
+    const e5$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test5' }));
 
     const routeGroupNested: RouteEffectGroup = {
       path: '/nested',
@@ -76,7 +76,7 @@ describe('#factorizeRouting', () => {
 
   test('throws error if route is redefined', () => {
     // given
-    const e$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
+    const e$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
 
     const route1: RouteEffect = { path: '/test', method: 'GET', effect: e$ };
     const route2: RouteEffect = { path: '/test', method: 'GET', effect: e$ };

--- a/packages/core/src/router/specs/router.factory.spec.ts
+++ b/packages/core/src/router/specs/router.factory.spec.ts
@@ -1,5 +1,5 @@
 import { mapTo } from 'rxjs/operators';
-import { HttpEffect, HttpMiddleware } from '../../effects/effects.interface';
+import { HttpEffect, HttpMiddleware } from '../../effects/http-effects.interface';
 import { RouteEffect, RouteEffectGroup, Routing } from '../router.interface';
 import { factorizeRouting } from '../router.factory';
 

--- a/packages/core/src/router/specs/router.resolver.spec.ts
+++ b/packages/core/src/router/specs/router.resolver.spec.ts
@@ -1,5 +1,5 @@
 import { mapTo, tap, map } from 'rxjs/operators';
-import { Effect, Middleware, EffectMetadata } from '../../effects/effects.interface';
+import { HttpEffect, HttpMiddleware, EffectMetadata } from '../../effects/effects.interface';
 import { findRoute, resolveRouting } from '../router.resolver';
 import { HttpRequest, HttpResponse, HttpMethod } from '../../http.interface';
 import { RouteMatched, Routing } from '../router.interface';
@@ -9,10 +9,10 @@ import { createEffectMetadata } from '../../effects/effectsMetadata.factory';
 describe('#findRoute', () => {
   test('finds route inside collection', () => {
     // given
-    const e1$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
-    const e2$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
-    const e3$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
-    const e4$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
+    const e1$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
+    const e2$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
+    const e3$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
+    const e4$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
 
     const routing: Routing = [
       {
@@ -47,7 +47,7 @@ describe('#findRoute', () => {
 
   test('finds parametrized route inside collection', () => {
     // given
-    const e$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
+    const e$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
 
     const routing: Routing = [{
       regExp: /^\/group\/([^\/]+)\/foo$/,
@@ -67,8 +67,8 @@ describe('#findRoute', () => {
 
   test('matches wildcard route if doesn\'t found proper route', () => {
     // given
-    const e1$: Effect = req$ => req$.pipe(mapTo({ body: 'e1' }));
-    const e2$: Effect = req$ => req$.pipe(mapTo({ body: 'e2' }));
+    const e1$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'e1' }));
+    const e2$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'e2' }));
 
     const routing: Routing = [
       {
@@ -112,7 +112,7 @@ describe('#resolveRouting', () => {
 
   test('resolves found effect', done => {
     // given
-    const effect$: Effect = req$ => req$.pipe(mapTo({ body: 'test' }));
+    const effect$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
     const expectedMachingResult: RouteMatched = { effect: effect$, params: {} };
     const req = { url: '/', method: 'GET', query: {}, params: {} } as HttpRequest;
     const res = {} as HttpResponse;
@@ -184,8 +184,8 @@ describe('#resolveRouting', () => {
 
   test('applies middlewares to found effect', done => {
     // given
-    const middleware$: Middleware = req$ => req$.pipe(tap(req => req.test = 'test' ));
-    const effect$: Effect = req$ => req$.pipe(map(req => ({ body: req.test }) ));
+    const middleware$: HttpMiddleware = req$ => req$.pipe(tap(req => req.test = 'test' ));
+    const effect$: HttpEffect = req$ => req$.pipe(map(req => ({ body: req.test }) ));
 
     const expectedMachingResult: RouteMatched = { middleware: middleware$, effect: effect$, params: {} };
     const req = { url: '/', method: 'GET', query: {}, params: {} } as HttpRequest;

--- a/packages/core/src/router/specs/router.resolver.spec.ts
+++ b/packages/core/src/router/specs/router.resolver.spec.ts
@@ -1,5 +1,5 @@
 import { mapTo, tap, map } from 'rxjs/operators';
-import { HttpEffect, HttpMiddleware } from '../../effects/http-effects.interface';
+import { HttpEffect, HttpMiddlewareEffect } from '../../effects/http-effects.interface';
 import { EffectMetadata } from '../../effects/effects.interface';
 import { findRoute, resolveRouting } from '../router.resolver';
 import { HttpRequest, HttpResponse, HttpMethod } from '../../http.interface';
@@ -185,7 +185,7 @@ describe('#resolveRouting', () => {
 
   test('applies middlewares to found effect', done => {
     // given
-    const middleware$: HttpMiddleware = req$ => req$.pipe(tap(req => req.test = 'test' ));
+    const middleware$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => req.test = 'test' ));
     const effect$: HttpEffect = req$ => req$.pipe(map(req => ({ body: req.test }) ));
 
     const expectedMachingResult: RouteMatched = { middleware: middleware$, effect: effect$, params: {} };

--- a/packages/core/src/router/specs/router.resolver.spec.ts
+++ b/packages/core/src/router/specs/router.resolver.spec.ts
@@ -1,5 +1,6 @@
 import { mapTo, tap, map } from 'rxjs/operators';
-import { HttpEffect, HttpMiddleware, EffectMetadata } from '../../effects/effects.interface';
+import { HttpEffect, HttpMiddleware } from '../../effects/http-effects.interface';
+import { EffectMetadata } from '../../effects/effects.interface';
 import { findRoute, resolveRouting } from '../router.resolver';
 import { HttpRequest, HttpResponse, HttpMethod } from '../../http.interface';
 import { RouteMatched, Routing } from '../router.interface';

--- a/packages/core/src/server/server.factory.ts
+++ b/packages/core/src/server/server.factory.ts
@@ -4,7 +4,7 @@ import { httpListener } from '../listener/http.listener';
 import { isCloseEvent } from './server.event';
 import { subscribeServerEvents } from './server.event.subscriber';
 import { InjectionDependencies } from './server.injector';
-import { ServerEffect } from '../effects/effects.interface';
+import { HttpServerEffect } from '../effects/effects.interface';
 import { httpServerToken } from './server.token';
 import { createEffectMetadata } from '../effects/effectsMetadata.factory';
 
@@ -12,7 +12,7 @@ export interface CreateServerConfig {
   port?: number;
   hostname?: string;
   httpListener: ReturnType<typeof httpListener>;
-  event$?: ServerEffect;
+  event$?: HttpServerEffect;
   dependencies?: InjectionDependencies;
 }
 

--- a/packages/core/src/server/server.factory.ts
+++ b/packages/core/src/server/server.factory.ts
@@ -4,7 +4,7 @@ import { httpListener } from '../listener/http.listener';
 import { isCloseEvent } from './server.event';
 import { subscribeServerEvents } from './server.event.subscriber';
 import { InjectionDependencies } from './server.injector';
-import { HttpServerEffect } from '../effects/effects.interface';
+import { HttpServerEffect } from '../effects/http-effects.interface';
 import { httpServerToken } from './server.token';
 import { createEffectMetadata } from '../effects/effectsMetadata.factory';
 

--- a/packages/middleware-body/src/index.ts
+++ b/packages/middleware-body/src/index.ts
@@ -1,4 +1,4 @@
-import { HttpError, HttpRequest, HttpStatus, Middleware } from '@marblejs/core';
+import { HttpError, HttpRequest, HttpStatus, HttpMiddleware } from '@marblejs/core';
 import { ContentType } from '@marblejs/core/dist/+internal';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, map, switchMap, tap, toArray, mapTo } from 'rxjs/operators';
@@ -44,7 +44,7 @@ const getBody = (req: HttpRequest) =>
     })
   );
 
-export const bodyParser$: Middleware = req$ =>
+export const bodyParser$: HttpMiddleware = req$ =>
   req$.pipe(
     switchMap(req =>
       PARSEABLE_METHODS.includes(req.method)

--- a/packages/middleware-body/src/index.ts
+++ b/packages/middleware-body/src/index.ts
@@ -1,4 +1,4 @@
-import { HttpError, HttpRequest, HttpStatus, HttpMiddleware } from '@marblejs/core';
+import { HttpError, HttpRequest, HttpStatus, HttpMiddlewareEffect } from '@marblejs/core';
 import { ContentType } from '@marblejs/core/dist/+internal';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, map, switchMap, tap, toArray, mapTo } from 'rxjs/operators';
@@ -44,7 +44,7 @@ const getBody = (req: HttpRequest) =>
     })
   );
 
-export const bodyParser$: HttpMiddleware = req$ =>
+export const bodyParser$: HttpMiddlewareEffect = req$ =>
   req$.pipe(
     switchMap(req =>
       PARSEABLE_METHODS.includes(req.method)

--- a/packages/middleware-io/test/io-ws.integration.ts
+++ b/packages/middleware-io/test/io-ws.integration.ts
@@ -1,5 +1,5 @@
 import { use, matchEvent } from '@marblejs/core';
-import { webSocketListener, WebSocketEffect } from '@marblejs/websockets';
+import { webSocketListener, WsEffect } from '@marblejs/websockets';
 import { map } from 'rxjs/operators';
 import { eventValidator$, t } from '../src';
 
@@ -8,7 +8,7 @@ const user = t.type({
   age: t.number,
 });
 
-const postUser$: WebSocketEffect = event$ =>
+const postUser$: WsEffect = event$ =>
   event$.pipe(
     matchEvent('POST_USER'),
     use(eventValidator$(user)),

--- a/packages/middleware-jwt/src/jwt.middleware.ts
+++ b/packages/middleware-jwt/src/jwt.middleware.ts
@@ -1,6 +1,6 @@
 import { throwError, of, Observable } from 'rxjs';
 import { map, flatMap, catchError, tap } from 'rxjs/operators';
-import { HttpError, HttpStatus, HttpMiddleware, HttpRequest } from '@marblejs/core';
+import { HttpError, HttpStatus, HttpMiddlewareEffect, HttpRequest } from '@marblejs/core';
 import { parseAuthorizationHeader } from './jwt.util';
 import { verifyToken$, VerifyOptions } from './jwt.factory';
 
@@ -11,7 +11,7 @@ const assignPayloadToRequest = (req: HttpRequest) => (payload: object) => req.us
 export const authorize$ = (
   config: AuthorizeMiddlewareConfig,
   verifyPayload$: (payload: any) => Observable<object>,
-): HttpMiddleware => req$ =>
+): HttpMiddlewareEffect => req$ =>
   req$.pipe(
     flatMap(req => of(req).pipe(
       map(parseAuthorizationHeader),

--- a/packages/middleware-jwt/src/jwt.middleware.ts
+++ b/packages/middleware-jwt/src/jwt.middleware.ts
@@ -1,6 +1,6 @@
 import { throwError, of, Observable } from 'rxjs';
 import { map, flatMap, catchError, tap } from 'rxjs/operators';
-import { HttpError, HttpStatus, Middleware, HttpRequest } from '@marblejs/core';
+import { HttpError, HttpStatus, HttpMiddleware, HttpRequest } from '@marblejs/core';
 import { parseAuthorizationHeader } from './jwt.util';
 import { verifyToken$, VerifyOptions } from './jwt.factory';
 
@@ -11,7 +11,7 @@ const assignPayloadToRequest = (req: HttpRequest) => (payload: object) => req.us
 export const authorize$ = (
   config: AuthorizeMiddlewareConfig,
   verifyPayload$: (payload: any) => Observable<object>,
-): Middleware => req$ =>
+): HttpMiddleware => req$ =>
   req$.pipe(
     flatMap(req => of(req).pipe(
       map(parseAuthorizationHeader),

--- a/packages/middleware-logger/src/logger.middleware.ts
+++ b/packages/middleware-logger/src/logger.middleware.ts
@@ -1,4 +1,4 @@
-import { Middleware } from '@marblejs/core';
+import { HttpMiddleware } from '@marblejs/core';
 import { timestamp, tap, map } from 'rxjs/operators';
 import { LoggerOptions } from './logger.model';
 import { loggerHandler } from './logger.handler';
@@ -8,13 +8,13 @@ import { loggerHandler } from './logger.handler';
  * [#2] will be deleted in version 2.0,
  * [#3] use loggerWithOpts$ instead,
  */
-export const logger$: Middleware = (req$, res, injector) => {
+export const logger$: HttpMiddleware = (req$, res, injector) => {
   // tslint:disable-next-line:max-line-length
   console.warn('Deprecation warning: logger$ is deprecated since v1.2 and will be removed in v2.0. Use loggerWithOpts$ instead.');
   return loggerWithOpts$()(req$, res, injector);
 };
 
-export const loggerWithOpts$ = (opts: LoggerOptions = {}): Middleware => (req$, res) =>
+export const loggerWithOpts$ = (opts: LoggerOptions = {}): HttpMiddleware => (req$, res) =>
   req$.pipe(
     timestamp(),
     tap(loggerHandler(res, opts)),

--- a/packages/middleware-logger/src/logger.middleware.ts
+++ b/packages/middleware-logger/src/logger.middleware.ts
@@ -1,4 +1,4 @@
-import { HttpMiddleware } from '@marblejs/core';
+import { HttpMiddlewareEffect } from '@marblejs/core';
 import { timestamp, tap, map } from 'rxjs/operators';
 import { LoggerOptions } from './logger.model';
 import { loggerHandler } from './logger.handler';
@@ -8,13 +8,13 @@ import { loggerHandler } from './logger.handler';
  * [#2] will be deleted in version 2.0,
  * [#3] use loggerWithOpts$ instead,
  */
-export const logger$: HttpMiddleware = (req$, res, injector) => {
+export const logger$: HttpMiddlewareEffect = (req$, res, injector) => {
   // tslint:disable-next-line:max-line-length
   console.warn('Deprecation warning: logger$ is deprecated since v1.2 and will be removed in v2.0. Use loggerWithOpts$ instead.');
   return loggerWithOpts$()(req$, res, injector);
 };
 
-export const loggerWithOpts$ = (opts: LoggerOptions = {}): HttpMiddleware => (req$, res) =>
+export const loggerWithOpts$ = (opts: LoggerOptions = {}): HttpMiddlewareEffect => (req$, res) =>
   req$.pipe(
     timestamp(),
     tap(loggerHandler(res, opts)),

--- a/packages/websockets/src/effects/ws-effects.interface.ts
+++ b/packages/websockets/src/effects/ws-effects.interface.ts
@@ -1,6 +1,5 @@
 import * as http from 'http';
-import { Event, EffectMetadata } from '@marblejs/core';
-import { Observable } from 'rxjs';
+import { Event, Effect } from '@marblejs/core';
 import { MarbleWebSocketClient } from '../websocket.interface';
 
 export interface WebSocketMiddleware<
@@ -27,6 +26,4 @@ export interface WebSocketEffect<
   U = Event,
   V = MarbleWebSocketClient,
   W extends Error = Error,
-> {
-  (input$: Observable<T>, client: V, meta: EffectMetadata<W>): Observable<U>;
-}
+> extends Effect<T, U, V, W> {}

--- a/packages/websockets/src/effects/ws-effects.interface.ts
+++ b/packages/websockets/src/effects/ws-effects.interface.ts
@@ -2,7 +2,7 @@ import * as http from 'http';
 import { Event, Effect } from '@marblejs/core';
 import { MarbleWebSocketClient } from '../websocket.interface';
 
-export interface WsMiddleware<
+export interface WsMiddlewareEffect<
   I = Event,
   O = Event,
 > extends WsEffect<I, O> {}

--- a/packages/websockets/src/effects/ws-effects.interface.ts
+++ b/packages/websockets/src/effects/ws-effects.interface.ts
@@ -2,26 +2,26 @@ import * as http from 'http';
 import { Event, Effect } from '@marblejs/core';
 import { MarbleWebSocketClient } from '../websocket.interface';
 
-export interface WebSocketMiddleware<
+export interface WsMiddleware<
   I = Event,
   O = Event,
-> extends WebSocketEffect<I, O> {}
+> extends WsEffect<I, O> {}
 
-export interface WebSocketErrorEffect<
+export interface WsErrorEffect<
   T extends Error = Error,
   U = Event,
   V = Event
-> extends WebSocketEffect<U, V, MarbleWebSocketClient, T> {}
+> extends WsEffect<U, V, MarbleWebSocketClient, T> {}
 
-export interface WebSocketConnectionEffect<
+export interface WsConnectionEffect<
   T extends http.IncomingMessage = http.IncomingMessage
-> extends WebSocketEffect<T, T, MarbleWebSocketClient> {}
+> extends WsEffect<T, T, MarbleWebSocketClient> {}
 
-export interface WebSocketOutputEffect<
+export interface WsOutputEffect<
   T extends Event = Event
-> extends WebSocketEffect<T, Event> {}
+> extends WsEffect<T, Event> {}
 
-export interface WebSocketEffect<
+export interface WsEffect<
   T = Event,
   U = Event,
   V = MarbleWebSocketClient,

--- a/packages/websockets/src/error/specs/ws-error.handler.spec.ts
+++ b/packages/websockets/src/error/specs/ws-error.handler.spec.ts
@@ -2,7 +2,7 @@ import { EventError, EffectMetadata, createStaticInjectionContainer, createEffec
 import { mapTo } from 'rxjs/operators';
 import { handleEffectsError } from '../ws-error.handler';
 import { MarbleWebSocketClient } from '../../websocket.interface';
-import { WebSocketErrorEffect } from '../../effects/ws-effects.interface';
+import { WsErrorEffect } from '../../effects/ws-effects.interface';
 
 describe('#handleEffectsError', () => {
   let defaultMetadata: EffectMetadata;
@@ -15,7 +15,7 @@ describe('#handleEffectsError', () => {
     // given
     const client = { sendResponse: jest.fn() } as any as MarbleWebSocketClient;
     const error = new EventError({ type: 'EVENT' }, '');
-    const error$: WebSocketErrorEffect = event$ => event$.pipe(
+    const error$: WsErrorEffect = event$ => event$.pipe(
       mapTo({ type: error.event.type, error: {} }),
     );
 

--- a/packages/websockets/src/error/specs/ws-error.provider.spec.ts
+++ b/packages/websockets/src/error/specs/ws-error.provider.spec.ts
@@ -1,5 +1,5 @@
 import { mapTo } from 'rxjs/operators';
-import { WebSocketErrorEffect } from '../../effects/ws-effects.interface';
+import { WsErrorEffect } from '../../effects/ws-effects.interface';
 import { error$ as defaultError$ } from '../ws-error.effect';
 import { provideErrorEffect } from '../ws-error.provider';
 
@@ -7,7 +7,7 @@ describe('#provideErrorEffect', () => {
   test('provides passed error$', () => {
     // given
     const transformer = undefined;
-    const error$: WebSocketErrorEffect = event$ => event$.pipe(
+    const error$: WsErrorEffect = event$ => event$.pipe(
       mapTo({ type: 'ERROR', payload: 'error' }),
     );
 

--- a/packages/websockets/src/error/ws-error.effect.ts
+++ b/packages/websockets/src/error/ws-error.effect.ts
@@ -1,6 +1,6 @@
 import { EventError } from '@marblejs/core';
 import { map } from 'rxjs/operators';
-import { WebSocketErrorEffect } from '../effects/ws-effects.interface';
+import { WsErrorEffect } from '../effects/ws-effects.interface';
 
 const DEFAULT_ERROR_CHANNEL = 'ERROR';
 
@@ -8,7 +8,7 @@ const errorFactory = (message: string | undefined, data: any | undefined) => ({
   message, data,
 });
 
-export const error$: WebSocketErrorEffect<EventError> = (event$, _, { error }) =>
+export const error$: WsErrorEffect<EventError> = (event$, _, { error }) =>
   event$.pipe(
     map(event => ({
       type: event ? event.type : DEFAULT_ERROR_CHANNEL,

--- a/packages/websockets/src/error/ws-error.handler.ts
+++ b/packages/websockets/src/error/ws-error.handler.ts
@@ -1,12 +1,12 @@
 import { of } from 'rxjs';
 import { EventError, EffectMetadata } from '@marblejs/core';
 import { MarbleWebSocketClient } from '../websocket.interface';
-import { WebSocketErrorEffect } from '../effects/ws-effects.interface';
+import { WsErrorEffect } from '../effects/ws-effects.interface';
 
 export const handleEffectsError = <IncomingError extends EventError>(
   metadata: EffectMetadata,
   client: MarbleWebSocketClient,
-  error$: WebSocketErrorEffect<IncomingError, any, any> | undefined,
+  error$: WsErrorEffect<IncomingError, any, any> | undefined,
 ) => (error: IncomingError) => {
   if (error$) {
     error$(of(error.event), client, { ...metadata, error }).subscribe(client.sendResponse);

--- a/packages/websockets/src/error/ws-error.provider.ts
+++ b/packages/websockets/src/error/ws-error.provider.ts
@@ -1,9 +1,9 @@
 import { EventTransformer } from '../transformer/transformer.inteface';
-import { WebSocketErrorEffect } from '../effects/ws-effects.interface';
+import { WsErrorEffect } from '../effects/ws-effects.interface';
 import { error$ as defaultError$ } from './ws-error.effect';
 
 export const provideErrorEffect = (
-  errorEffect: WebSocketErrorEffect<any, any, any> | undefined,
+  errorEffect: WsErrorEffect<any, any, any> | undefined,
   eventTransformer: EventTransformer<any, any> | undefined,
 ) =>
   !errorEffect && eventTransformer === undefined

--- a/packages/websockets/src/listener/specs/websocket.listener.spec.ts
+++ b/packages/websockets/src/listener/specs/websocket.listener.spec.ts
@@ -2,7 +2,7 @@ import { Event, EventError, createStaticInjectionContainer, httpServerToken } fr
 import { throwError, fromEvent, forkJoin } from 'rxjs';
 import { tap, map, mergeMap, first, toArray, take } from 'rxjs/operators';
 import { webSocketListener } from '../websocket.listener';
-import { WebSocketEffect, WebSocketMiddleware, WebSocketConnectionEffect } from '../../effects/ws-effects.interface';
+import { WsEffect, WsMiddleware, WsConnectionEffect } from '../../effects/ws-effects.interface';
 import { WebSocketConnectionError } from '../../error/ws-error.model';
 import { EventTransformer } from '../../transformer/transformer.inteface';
 import { createWebSocketsTestBed } from '../../+internal';
@@ -19,7 +19,7 @@ describe('WebSocket listener', () => {
       const targetClient = testBed.getClient(0);
       const httpServer = testBed.getServer();
       const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
-      const echo$: WebSocketEffect = event$ => event$;
+      const echo$: WsEffect = event$ => event$;
       const event = JSON.stringify({ type: 'EVENT', payload: 'test' });
       const webSocketServer = webSocketListener({ effects: [echo$] });
 
@@ -36,7 +36,7 @@ describe('WebSocket listener', () => {
 
     test('echoes back to all clients', done => {
       // given
-      const echo$: WebSocketEffect = (event$, client) => event$.pipe(
+      const echo$: WsEffect = (event$, client) => event$.pipe(
         mergeMap(client.sendBroadcastResponse),
       );
       const event = JSON.stringify({ type: 'EVENT', payload: 'test' });
@@ -62,7 +62,7 @@ describe('WebSocket listener', () => {
 
     test('echoes back on upgraded http server', done => {
       // given
-      const echo$: WebSocketEffect = event$ => event$;
+      const echo$: WsEffect = event$ => event$;
       const event = JSON.stringify({ type: 'EVENT', payload: 'test' });
       const httpServer = testBed.getServer();
       const injector = createStaticInjectionContainer().register(httpServerToken, () => httpServer);
@@ -89,8 +89,8 @@ describe('WebSocket listener', () => {
       // given
       const incomingEvent = JSON.stringify({ type: 'EVENT', payload: 0 });
       const outgoingEvent = JSON.stringify({ type: 'EVENT', payload: 3 });
-      const e$: WebSocketEffect = event$ => event$;
-      const m$: WebSocketMiddleware = event$ => event$.pipe(
+      const e$: WsEffect = event$ => event$;
+      const m$: WsMiddleware = event$ => event$.pipe(
         map(event => event as Event<number>),
         tap(event => event.payload !== undefined && event.payload++)
       );
@@ -146,7 +146,7 @@ describe('WebSocket listener', () => {
       // given
       const incomingEvent = JSON.stringify({ type: 'EVENT' });
       const outgoingEvent = JSON.stringify({ type: 'EVENT', error: { message: 'test message' } });
-      const effect$: WebSocketEffect = event$ => event$.pipe(
+      const effect$: WsEffect = event$ => event$.pipe(
         mergeMap(event => throwError(new EventError(event, 'test message'))),
       );
       const targetClient = testBed.getClient(0);
@@ -174,7 +174,7 @@ describe('WebSocket listener', () => {
     test('triggers connection error', done => {
       // given
       const error = new WebSocketConnectionError('Unauthorized', 4000);
-      const connection$: WebSocketConnectionEffect = req$ => req$.pipe(mergeMap(() => throwError(error)));
+      const connection$: WsConnectionEffect = req$ => req$.pipe(mergeMap(() => throwError(error)));
       const webSocketServer = webSocketListener({ connection$ });
       const targetClient = testBed.getClient(0);
       const httpServer = testBed.getServer();
@@ -207,7 +207,7 @@ describe('WebSocket listener', () => {
         decode: event => event,
         encode: event => event,
       };
-      const effect$: WebSocketEffect<Buffer, string> = event$ => event$.pipe(
+      const effect$: WsEffect<Buffer, string> = event$ => event$.pipe(
         map(event => event.toString('utf8'))
       );
       const httpServer = testBed.getServer();

--- a/packages/websockets/src/listener/specs/websocket.listener.spec.ts
+++ b/packages/websockets/src/listener/specs/websocket.listener.spec.ts
@@ -2,7 +2,7 @@ import { Event, EventError, createStaticInjectionContainer, httpServerToken } fr
 import { throwError, fromEvent, forkJoin } from 'rxjs';
 import { tap, map, mergeMap, first, toArray, take } from 'rxjs/operators';
 import { webSocketListener } from '../websocket.listener';
-import { WsEffect, WsMiddleware, WsConnectionEffect } from '../../effects/ws-effects.interface';
+import { WsEffect, WsMiddlewareEffect, WsConnectionEffect } from '../../effects/ws-effects.interface';
 import { WebSocketConnectionError } from '../../error/ws-error.model';
 import { EventTransformer } from '../../transformer/transformer.inteface';
 import { createWebSocketsTestBed } from '../../+internal';
@@ -90,7 +90,7 @@ describe('WebSocket listener', () => {
       const incomingEvent = JSON.stringify({ type: 'EVENT', payload: 0 });
       const outgoingEvent = JSON.stringify({ type: 'EVENT', payload: 3 });
       const e$: WsEffect = event$ => event$;
-      const m$: WsMiddleware = event$ => event$.pipe(
+      const m$: WsMiddlewareEffect = event$ => event$.pipe(
         map(event => event as Event<number>),
         tap(event => event.payload !== undefined && event.payload++)
       );

--- a/packages/websockets/src/listener/websocket.listener.ts
+++ b/packages/websockets/src/listener/websocket.listener.ts
@@ -29,12 +29,12 @@ type HandleIncomingConnection =
   (client: WS.WebSocketClient, request: http.IncomingMessage) =>  void;
 
 export interface WebSocketListenerConfig {
-  effects?: WSEffect.WebSocketEffect<any, any>[];
-  middlewares?: WSEffect.WebSocketMiddleware<any, any>[];
-  error$?: WSEffect.WebSocketErrorEffect<Error, any, any>;
+  effects?: WSEffect.WsEffect<any, any>[];
+  middlewares?: WSEffect.WsMiddleware<any, any>[];
+  error$?: WSEffect.WsErrorEffect<Error, any, any>;
   eventTransformer?: EventTransformer<Event, any>;
-  connection$?: WSEffect.WebSocketConnectionEffect;
-  output$?: WSEffect.WebSocketOutputEffect;
+  connection$?: WSEffect.WsConnectionEffect;
+  output$?: WSEffect.WsOutputEffect;
 }
 
 export const webSocketListener = (config: WebSocketListenerConfig = {}) => {

--- a/packages/websockets/src/listener/websocket.listener.ts
+++ b/packages/websockets/src/listener/websocket.listener.ts
@@ -30,7 +30,7 @@ type HandleIncomingConnection =
 
 export interface WebSocketListenerConfig {
   effects?: WSEffect.WsEffect<any, any>[];
-  middlewares?: WSEffect.WsMiddleware<any, any>[];
+  middlewares?: WSEffect.WsMiddlewareEffect<any, any>[];
   error$?: WSEffect.WsErrorEffect<Error, any, any>;
   eventTransformer?: EventTransformer<Event, any>;
   connection$?: WSEffect.WsConnectionEffect;

--- a/packages/websockets/src/operators/broadcast/broadcast.operator.spec.ts
+++ b/packages/websockets/src/operators/broadcast/broadcast.operator.spec.ts
@@ -1,7 +1,7 @@
 import { Marbles } from '@marblejs/core/dist/+internal';
 import { EMPTY } from 'rxjs';
 import { broadcast } from './broadcast.operator';
-import { WebSocketEffect } from '../../effects/ws-effects.interface';
+import { WsEffect } from '../../effects/ws-effects.interface';
 
 describe('#broadcast operator', () => {
   const client = { sendBroadcastResponse: jest.fn(() => EMPTY) };
@@ -12,7 +12,7 @@ describe('#broadcast operator', () => {
     const outgoingEvent = { type: 'TEST_EVENT_RESPONSE', payload: 'test_payload' };
 
     // when
-    const effect$: WebSocketEffect = (event$, client) =>
+    const effect$: WsEffect = (event$, client) =>
       event$.pipe(
         broadcast(client, () => outgoingEvent),
       );

--- a/packages/websockets/src/operators/mapToServer/mapToServer.operator.spec.ts
+++ b/packages/websockets/src/operators/mapToServer/mapToServer.operator.spec.ts
@@ -1,5 +1,5 @@
 import { Marbles, createHttpRequest } from '@marblejs/core/dist/+internal';
-import { ServerEffect, ServerEvent, ServerEventType, matchEvent } from '@marblejs/core';
+import { HttpServerEffect, ServerEvent, ServerEventType, matchEvent } from '@marblejs/core';
 import { mapToServer, UpgradeEvent } from './mapToServer.operator';
 
 describe('#mapToServer operator', () => {
@@ -28,7 +28,7 @@ describe('#mapToServer operator', () => {
     };
 
     // when
-    const effect$: ServerEffect = event$ =>
+    const effect$: HttpServerEffect = event$ =>
       event$.pipe(
         matchEvent(ServerEvent.upgrade),
         mapToServer(
@@ -60,7 +60,7 @@ describe('#mapToServer operator', () => {
     };
 
     // when
-    const effect$: ServerEffect = event$ =>
+    const effect$: HttpServerEffect = event$ =>
       event$.pipe(
         matchEvent(ServerEvent.upgrade),
         mapToServer(


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Naming correction
```

## What is the new behavior?
1. Corrected `Effect` naming conventions:
- **@marblejs/core**
  - `Effect` -> `HttpEffect`
  - `Middleware` -> `HttpMiddlewareEffect`
  - `ErrorEffect` -> `HttpErrorEffect`
  - `ServerEffect` -> `HttpServerEffect`
- **@marblejs/websockets**
  - `WebSocketEffect` -> `WsEffect`
  - `WebSocketMiddleware` -> `WsMiddlewareEffect`
  - `WebSocketErrorEffect` -> `WsErrrorEffect`
  - `WebSocketConnectionEffect` -> `WsConnectionEffect`

2. Created reusable `Effect` interface for extending defined protocols, like: `HttpEffect` or `WsEffect`

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

