### PR TITLE
fix(core, middleware-body): incorrectly parsed querystrings

### DIFF
--- a/packages/@integration/test/integration.spec.ts
+++ b/packages/@integration/test/integration.spec.ts
@@ -98,6 +98,15 @@ describe('API integration', () => {
       .send({ user: { id: 'test_id' } })
       .expect(200, { data: { user: { id: 'test_id' } } }));
 
+  // tslint:disable-next-line:max-line-length
+  test(`parses POST ${ContentType.APPLICATION_X_WWW_FORM_URLENCODED} body and echoes back for secured route: /api/v1/user`, async () =>
+    request(server)
+      .post('/api/v1/user')
+      .set('Authorization', 'Bearer FAKE')
+      .set('Content-Type', ContentType.APPLICATION_X_WWW_FORM_URLENCODED)
+      .send({ user: { id: 'test_id' } })
+      .expect(200, { data: { user: { id: 'test_id' } } }));
+
   test(`returns static file as ${ContentType.TEXT_HTML}: /api/v1/static/index.html`, async () =>
     request(server)
       .get('/api/v1/static/index.html')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,11 +35,13 @@
     "rxjs": "~6.3.3"
   },
   "dependencies": {
+    "@types/qs": "^6.5.1",
     "chalk": "~2.4.1",
     "file-type": "^8.0.0",
+    "fp-ts": "1.12.2",
     "mime": "^2.3.1",
     "path-to-regexp": "^2.4.0",
-    "fp-ts": "1.12.2"
+    "qs": "^6.6.0"
   },
   "devDependencies": {
     "@types/file-type": "^5.2.1",

--- a/packages/core/src/router/router.query.factory.ts
+++ b/packages/core/src/router/router.query.factory.ts
@@ -1,37 +1,8 @@
-import * as querystring from 'querystring';
-import { getHead } from '../+internal';
+import * as qs from 'qs';
 import { QueryParameters } from '../http.interface';
 import { fromNullable } from 'fp-ts/lib/Option';
 
-const getNestedQueryParam = (params: Object) => (key: string): QueryParameters => {
-  const paramValue = params[key];
-  const nestedKeys = /\[.*]/.exec(key);
-
-  return fromNullable(nestedKeys)
-    .chain(getHead)
-    .map(_ => _.replace(/\[/g, ''))
-    .map(_ => _.split(']'))
-    .map(_ => _.filter(v => v.length > 0))
-    .map(_ => _.reduceRight(
-      (value, key) => ({ [key]: value }),
-      paramValue,
-    ))
-    .chain(nestedQueryObject => fromNullable(nestedKeys)
-      .chain(getHead)
-      .map(head => key.replace(head, ''))
-      .map(key => ({ [key]: nestedQueryObject }))
-    )
-    .getOrElse({ [key]: paramValue });
-};
-
-const extractNestedQueryParams = (queryParams: Object): QueryParameters =>
-  Object.assign(
-    {},
-    ...Object.keys(queryParams).map(getNestedQueryParam(queryParams))
-  );
-
 export const queryParamsFactory = (queryParams: string | undefined | null): QueryParameters =>
   fromNullable(queryParams)
-    .map(querystring.parse)
-    .map(extractNestedQueryParams)
+    .map(qs.parse)
     .getOrElse({});

--- a/packages/middleware-body/package.json
+++ b/packages/middleware-body/package.json
@@ -35,7 +35,9 @@
     "rxjs": "~6.3.3"
   },
   "dependencies": {
+    "@types/qs": "^6.5.1",
     "@types/type-is": "~1.6.2",
+    "qs": "^6.6.0",
     "type-is": "~1.6.16"
   },
   "devDependencies": {

--- a/packages/middleware-body/src/parsers/url.body.parser.ts
+++ b/packages/middleware-body/src/parsers/url.body.parser.ts
@@ -1,13 +1,5 @@
-import { compose } from '@marblejs/core/dist/+internal';
+import * as qs from 'qs';
 import { RequestBodyParser } from '../body.model';
 
-const decodeComponent = (urlEncoded: string) => urlEncoded
-  .split('&')
-  .map(x => x.split('='))
-  .reduce((data, [key, value]) => ({
-    ...data,
-    [key]: isNaN(+value) ? value : +value,
-  }), {});
-
 export const urlEncodedParser: RequestBodyParser = _ => body =>
-  compose(decodeComponent, decodeURIComponent)(body.toString());
+  qs.parse(body.toString());

--- a/packages/middleware-body/test/bodyParser.integration.spec.ts
+++ b/packages/middleware-body/test/bodyParser.integration.spec.ts
@@ -3,29 +3,29 @@ import * as request from 'supertest';
 import { app } from './bodyParser.integration';
 
 describe('@marblejs/middleware-body - integration', () => {
-  const body = { id: 'id', name: 'name', age: 100 };
-  const text = 'test message';
-
   describe('POST /default-parser', () => {
 
     test(`parses ${ContentType.APPLICATION_JSON} content-type`, async () =>
       request(app)
         .post('/default-parser')
         .set({ 'Content-Type': ContentType.APPLICATION_JSON })
-        .send(body)
-        .expect(200, body)
+        .send({ id: 'id', name: 'name', age: 100 })
+        .expect(200, { id: 'id', name: 'name', age: 100 })
     );
 
     test(`parses ${ContentType.APPLICATION_X_WWW_FORM_URLENCODED} content-type`, async () =>
       request(app)
         .post('/default-parser')
         .set({ 'Content-Type': ContentType.APPLICATION_X_WWW_FORM_URLENCODED })
-        .send(body)
-        .expect(200, body)
+        .send({ id: 'id', name: 'name', age: 100 })
+        .expect(200, { id: 'id', name: 'name', age: '100' })
     );
   });
 
   describe('POST /multiple-parsers', () => {
+    const body = { id: 'id', name: 'name', age: 100 };
+    const text = 'test message';
+
     test(`parses ${ContentType.APPLICATION_JSON} content-type`, async () =>
       request(app)
         .post('/multiple-parsers')
@@ -42,7 +42,7 @@ describe('@marblejs/middleware-body - integration', () => {
         .expect(200, body)
     );
 
-    test(`parses custom ${ContentType.APPLICATION_VND_API_JSON} content-type`, async () =>
+    test(`parses ${ContentType.APPLICATION_VND_API_JSON} content-type`, async () =>
       request(app)
         .post('/multiple-parsers')
         .set({ 'Content-Type': ContentType.APPLICATION_VND_API_JSON })
@@ -50,7 +50,7 @@ describe('@marblejs/middleware-body - integration', () => {
         .expect(200, body)
     );
 
-    test(`parses custom ${ContentType.TEXT_PLAIN} content-type`, async () =>
+    test(`parses ${ContentType.TEXT_PLAIN} content-type`, async () =>
       request(app)
         .post('/multiple-parsers')
         .set({ 'Content-Type': ContentType.TEXT_PLAIN })
@@ -58,7 +58,7 @@ describe('@marblejs/middleware-body - integration', () => {
         .expect(200, `"${text}"`)
     );
 
-    test(`parses custom ${ContentType.APPLICATION_OCTET_STREAM} content-type`, async () =>
+    test(`parses ${ContentType.APPLICATION_OCTET_STREAM} content-type`, async () =>
       request(app)
         .post('/multiple-parsers')
         .set({ 'Content-Type': ContentType.APPLICATION_OCTET_STREAM })

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,6 +684,11 @@
   version "10.12.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.15.tgz#20e85651b62fd86656e57c9c9bc771ab1570bc59"
 
+"@types/qs@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.5.1.tgz#a38f69c62528d56ba7bd1f91335a8004988d72f7"
+  integrity sha512-mNhVdZHdtKHMMxbqzNK3RzkBcN1cux3AvuCYGTvjEIQT2uheH3eCAyYsbMbh2Bq8nXkeOWs1kyDiF7geWRFQ4Q==
+
 "@types/superagent@*":
   version "3.8.5"
   resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-3.8.5.tgz#a8eb8ec5bce0234e50d6b8bee1941b5bb5686e2d"
@@ -5060,7 +5065,7 @@ q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
-qs@^6.5.1:
+qs@^6.5.1, qs@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- `@marblejs/core` - the query parser cannot parse complex URL encoded strings, like:
```
foo[bar1][baz]=test1'
foo[bar2][baz]=test2'
```
- `@marblejs/middlware-body` - URL parser incorectly decodes complex `application/x-www-form-urlencoded` strings like:
```
foo[bar1][baz]=test1'
foo[bar2][baz]=test2'
```
or 
```
foo=some=value&which&is=complex
```

## What is the new behavior?
- `@marblejs/core` - integration with `qs` library (a querystring parser with nesting support)
- `@marblejs/middlware-body` - ☝️

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```