### PR TITLE
feat(core): EffectMetadata initiator

### DIFF
--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -5,13 +5,14 @@ export interface EffectLike {
   (input$: Observable<any>, ...args: any[]): Observable<any>;
 }
 
-export interface Effect<I, O, C, E extends Error = Error> {
-  (input$: Observable<I>, client: C, meta: EffectMetadata<E>): Observable<O>;
+export interface Effect<I, O, Client, Err extends Error = Error, Initiator = any> {
+  (input$: Observable<I>, client: Client, meta: EffectMetadata<Err, Initiator>): Observable<O>;
 }
 
-export interface EffectMetadata<T extends Error = Error> {
+export interface EffectMetadata<Err extends Error = Error, Initiator = any> {
   ask: ContextProvider;
   scheduler: SchedulerLike;
-  error?: T;
+  error?: Err;
+  initiator?: Initiator;
   [key: string]: any;
 }

--- a/packages/core/src/effects/effectsMetadata.factory.ts
+++ b/packages/core/src/effects/effectsMetadata.factory.ts
@@ -3,10 +3,16 @@ import { AsyncScheduler } from 'rxjs/internal/scheduler/AsyncScheduler';
 import { SchedulerLike } from 'rxjs';
 import { ContextProvider } from '../context/context.factory';
 
-export const createEffectMetadata = <T extends SchedulerLike, U extends Error>(
-  metadata: { ask: ContextProvider, scheduler?: T, error?: U; }
-): EffectMetadata<U> => ({
+export const createEffectMetadata = <Scheduler extends SchedulerLike, Err extends Error, Initiator = any>(
+  metadata: {
+    ask: ContextProvider,
+    scheduler?: Scheduler,
+    error?: Err;
+    initiator?: Initiator;
+  },
+): EffectMetadata<Err, Initiator> => ({
   ask: metadata.ask,
   scheduler: metadata.scheduler || AsyncScheduler as any,
   error: metadata.error,
+  initiator: metadata.initiator,
 });

--- a/packages/core/src/effects/http-effects.interface.ts
+++ b/packages/core/src/effects/http-effects.interface.ts
@@ -26,8 +26,9 @@ export interface HttpOutputEffect<T extends HttpEffectResponse = HttpEffectRespo
   extends HttpEffect<T, HttpEffectResponse> {}
 
 export interface HttpEffect<
-  T = HttpRequest,
-  U = HttpEffectResponse,
-  V = HttpResponse,
-  W extends Error = Error,
-> extends Effect<T, U, V, W> {}
+  I = HttpRequest,
+  O = HttpEffectResponse,
+  Client = HttpResponse,
+  Err extends Error = Error,
+  Initiator = HttpRequest,
+> extends Effect<I, O, Client, Err, Initiator> {}

--- a/packages/core/src/listener/http.listener.ts
+++ b/packages/core/src/listener/http.listener.ts
@@ -44,7 +44,7 @@ export const httpListener = ({
         takeWhile(() => !res.finished),
         mergeMap(resolveRouting(routing, defaultMetadata)(res)),
         defaultIfEmpty(defaultResponse),
-        mergeMap(out => output$(of(out), res, defaultMetadata)),
+        mergeMap(out => output$(of(out), res, createEffectMetadata({ ...defaultMetadata, initiator: req }))),
         tap(res.send),
         catchError(error =>
           error$(of(req), res, createEffectMetadata({ ...defaultMetadata, error })).pipe(


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- A developer is not able to grab the initial `request` object from inside `OutputEffect`

Issue Number: #122 

## What is the new behavior?
- A developer is able to grab the initial `request` from `EffectMetadata.initiator`:
```typescript
const output$: HttpOutputEffect = (res$, _, { initiator }) =>
  res$.pipe(
    // do something with response
  );
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```