### PR TITLE
feat(core): access server event stream via Context API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,5 +17,6 @@ export * from './context/context.factory';
 export * from './context/context.token.factory';
 export * from './server/server.event';
 export * from './server/server.interface';
+export * from './server/server.tokens';
 export { createServer } from './server/server.factory';
 export { HttpListenerConfig, httpListener } from './listener/http.listener';

--- a/packages/core/src/server/server.factory.ts
+++ b/packages/core/src/server/server.factory.ts
@@ -4,27 +4,29 @@ import { Subject } from 'rxjs';
 import { takeWhile } from 'rxjs/operators';
 import { isCloseEvent, AllServerEvents } from './server.event';
 import { subscribeServerEvents } from './server.event.subscriber';
-import { createContext, lookup, registerAll } from '../context/context.factory';
+import { createContext, lookup, registerAll, bindTo } from '../context/context.factory';
 import { createEffectMetadata } from '../effects/effectsMetadata.factory';
 import { CreateServerConfig, Server } from './server.interface';
+import { serverEvent$ } from './server.tokens';
 
 const DEFAULT_HOSTNAME = '127.0.0.1';
 
 export const createServer = (config: CreateServerConfig): Server => {
   const { httpListener, event$, port, hostname, dependencies = [], options = {} } = config;
-  const serverEvent$ = new Subject<AllServerEvents>();
+  const serverEventSubject = new Subject<AllServerEvents>();
+  const boundServerEvent$ = bindTo(serverEvent$)(() => serverEventSubject.asObservable());
+  const context = registerAll([ boundServerEvent$, ...dependencies ])(createContext());
 
-  const context = registerAll(dependencies)(createContext());
   const httpListenerWithContext = httpListener.run(context);
   const server = options.httpsOptions
     ? https.createServer(options.httpsOptions, httpListenerWithContext)
     : http.createServer(httpListenerWithContext);
 
-  subscribeServerEvents(hostname || DEFAULT_HOSTNAME)(serverEvent$)(server);
+  subscribeServerEvents(hostname || DEFAULT_HOSTNAME)(serverEventSubject)(server);
 
   if (event$) {
     const metadata = createEffectMetadata({ ask: lookup(context) });
-    event$(serverEvent$.pipe(takeWhile(e => !isCloseEvent(e))), server, metadata).subscribe();
+    event$(serverEventSubject.pipe(takeWhile(e => !isCloseEvent(e))), server, metadata).subscribe();
   }
 
   return {

--- a/packages/core/src/server/server.tokens.ts
+++ b/packages/core/src/server/server.tokens.ts
@@ -1,0 +1,5 @@
+import { Observable } from 'rxjs';
+import { AllServerEvents } from './server.event';
+import { createContextToken } from '../context/context.token.factory';
+
+export const serverEvent$ = createContextToken<Observable<AllServerEvents>>();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
A developer has no access to propagated server events inside bound dependency.

## What is the new behavior?
`createServer` context bounds stream of HTTP server events to `serverEvent$` token.

eg. developer can subscribe for `ServerEvent.close` and react accordingly (eg. closing an opened connection).

```typescript
import { serverEvent$ } from '@marblejs/core';

...

ask(serverEvent$)
  .map(event$ => event$.pipe(
    matchEvent(ServerEvent.close),
    take(1),
    mergeMapTo(client.closeConnection())
  ))
  .getOrElse(EMPTY)
  .subscribe();

...
``` 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```