### PR TITLE
imp(core): ask context for lazy reader dependency and bootstrap it only once

### DIFF
--- a/packages/core/src/context/context.factory.ts
+++ b/packages/core/src/context/context.factory.ts
@@ -43,11 +43,15 @@ export const registerAll = (boundDependencies: BoundDependency<any, any>[]) => (
   );
 
 export const lookup = (context: Context) => <T>(token: ContextToken<T>): Option<T> =>
-  M.lookup(ordContextToken)(token, context).map(dependency =>
-    isReader(dependency)
-      ? dependency.run(context)
-      : dependency
-  );
+  M.lookup(ordContextToken)(token, context).map(dependency => {
+    if (!isReader(dependency)) {
+      return dependency;
+    }
+
+    const boostrapedDependency = dependency.run(context);
+    context.set(token, boostrapedDependency);
+    return boostrapedDependency;
+  });
 
 export const bindTo =
   <T>(token: ContextToken<T>) =>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- context asked for lazy reader dependency returns a new instance every time

## What is the new behavior?
- context asked for lazy reader dependency returns a new instance only once, next time it will return previously bootstrapped instance

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```