### PR TITLE
imp(websockets): use verifyClient for incoming connection verification

### DIFF
--- a/packages/@integration/src/ws.listener.ts
+++ b/packages/@integration/src/ws.listener.ts
@@ -3,12 +3,13 @@ import { iif, throwError, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { add$ } from './effects/calculator.ws-effects';
 import { logger$ } from './middlewares/logger.ws-middleware';
+import { HttpStatus } from '@marblejs/core';
 
 const connection$: WsConnectionEffect = req$ =>
   req$.pipe(
     mergeMap(req => iif(
       () => req.headers.upgrade !== 'websocket',
-      throwError(new WebSocketConnectionError('Unauthorized', 4000)),
+      throwError(new WebSocketConnectionError('Unauthorized', HttpStatus.UNAUTHORIZED)),
       of(req),
     )),
   );

--- a/packages/websockets/src/effects/ws-effects.interface.ts
+++ b/packages/websockets/src/effects/ws-effects.interface.ts
@@ -15,7 +15,7 @@ export interface WsErrorEffect<
 
 export interface WsConnectionEffect<
   T extends http.IncomingMessage = http.IncomingMessage
-> extends WsEffect<T, T, MarbleWebSocketClient> {}
+> extends WsEffect<T, T, undefined> {}
 
 export interface WsOutputEffect<
   T extends Event = Event


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- An incoming connection is validated **after** the initial WebSocket handshake.

## What is the new behavior?
- Incoming WebSocket connection is validated via `verifyClient` hook, just before initial handshake.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```