### PR TITLE
feat(serverless): Support for AWS Lambda

### DIFF
--- a/packages/core/src/server/specs/server.factory.spec.ts
+++ b/packages/core/src/server/specs/server.factory.spec.ts
@@ -53,7 +53,7 @@ describe('#createServer', () => {
       expect(server.listening).toBe(true);
       done();
     });
-  });
+  }, 10000);
 
   test('creates http server and starts listening without specified port and hostname', done => {
     // given

--- a/packages/core/src/server/specs/server.factory.spec.ts
+++ b/packages/core/src/server/specs/server.factory.spec.ts
@@ -48,12 +48,14 @@ describe('#createServer', () => {
       hostname,
       httpListener: app,
     }).run();
-
+    server.on('error', error => {
+      console.error(error);
+    });
     server.on('listening', () => {
       expect(server.listening).toBe(true);
       done();
     });
-  }, 10000);
+  });
 
   test('creates http server and starts listening without specified port and hostname', done => {
     // given

--- a/packages/serverless/README.md
+++ b/packages/serverless/README.md
@@ -1,0 +1,37 @@
+<p align="center">
+  <a href="https://marblejs.com">
+    <img src="https://github.com/marblejs/marble/blob/master/assets/img/logo.png?raw=true" width="200" alt="Marble.js logo"/>
+  </a>
+</p>
+
+# @marblejs/serverless-aws-lambda
+
+AWS Lambda serverless proxy for [Marble.js](https://github.com/marblejs/marble). Based on work of [@mflorence99](https://github.com/mflorence99/aws-serverless-marblejs).
+
+## Installation
+
+```
+$ npm i @marblejs/serverless-aws-lambda
+```
+Requires `@marblejs/core` to be installed.
+
+## Documentation
+
+For the latest updates, documentation, change log, and release information visit [docs.marblejs.com](https://docs.marblejs.com) and follow [@marble_js](https://twitter.com/marble_js) on Twitter.
+
+## Usage
+
+```ts
+import { createLambda, ProxyType } from '@marblejs/severless';
+import httpListener from './httpListener';
+
+export = createLambda({
+  app: httpListener, // Your app goes here
+  type: ProxyType.AWS, // Currently we support only AWS Lambda with API Gateway
+  proxyOptions: { // Optional configuration for specified ProxyType
+    binaryMimeTypes: ['application/octet-stream'], 
+  },
+});
+```
+
+License: MIT

--- a/packages/serverless/README.md
+++ b/packages/serverless/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# @marblejs/serverless-aws-lambda
+# @marblejs/serverless
 
 AWS Lambda serverless proxy for [Marble.js](https://github.com/marblejs/marble). Based on work of [@mflorence99](https://github.com/mflorence99/aws-serverless-marblejs).
 
@@ -26,7 +26,7 @@ import { createLambda, ProxyType } from '@marblejs/severless';
 import httpListener from './httpListener';
 
 export = createLambda({
-  app: httpListener, // Your app goes here
+  httpListener, // Your app goes here
   type: ProxyType.AWS, // Currently we support only AWS Lambda with API Gateway
   proxyOptions: { // Optional configuration for specified ProxyType
     binaryMimeTypes: ['application/octet-stream'], 

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@marblejs/serverless",
+  "version": "2.2.2",
+  "description": "Run Marble.js as a serverless function",
+  "keywords": [
+    "aws",
+    "lambda",
+    "serverless",
+    "marble.js",
+    "amazon",
+    "function"
+  ],
+  "author": "Krzysztof Miemiec <krzysztof.miemiec@gmail.com>",
+  "homepage": "https://github.com/marblejs/marble/tree/master/packages/serverless#readme",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@marblejs/core": "^2.2.2"
+  },
+  "devDependencies": {
+    "@marblejs/core": "^2.2.2",
+    "@types/aws-lambda": "^8.10.26",
+    "@types/node": "^12.0.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/marblejs/marble.git"
+  },
+  "scripts": {
+    "start": "yarn watch",
+    "watch": "tsc -w",
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "test": "jest --config ../../jest.config.js"
+  },
+  "bugs": {
+    "url": "https://github.com/marblejs/marble/issues"
+  }
+}

--- a/packages/serverless/src/+awsLambda/awsLambda.middleware.ts
+++ b/packages/serverless/src/+awsLambda/awsLambda.middleware.ts
@@ -1,11 +1,12 @@
 import { map } from 'rxjs/operators';
 import { HttpMiddlewareEffect } from '@marblejs/core';
 import { getHeaderContent } from '../serverProxy.helpers';
+import { AwsLambdaHeaders } from './awsLambda.types';
 
 export const awsApiGatewayMiddleware$ = (): HttpMiddlewareEffect => (req$) => req$.pipe(
   map(req => {
-    req.apiGatewayEvent = getHeaderContent(req.headers['x-apigateway-event']);
-    req.apiGatewayContext = getHeaderContent(req.headers['x-apigateway-context']);
+    req.apiGatewayEvent = getHeaderContent(req.headers[AwsLambdaHeaders.APIGATEWAY_EVENT]);
+    req.apiGatewayContext = getHeaderContent(req.headers[AwsLambdaHeaders.AWSLAMBDA_CONTEXT]);
     return req;
   }),
 );

--- a/packages/serverless/src/+awsLambda/awsLambda.middleware.ts
+++ b/packages/serverless/src/+awsLambda/awsLambda.middleware.ts
@@ -1,0 +1,11 @@
+import { map } from 'rxjs/operators';
+import { HttpMiddlewareEffect } from '@marblejs/core';
+import { getHeaderContent } from '../serverProxy.helpers';
+
+export const awsApiGatewayMiddleware$ = (): HttpMiddlewareEffect => (req$) => req$.pipe(
+  map(req => {
+    req.apiGatewayEvent = getHeaderContent(req.headers['x-apigateway-event']);
+    req.apiGatewayContext = getHeaderContent(req.headers['x-apigateway-context']);
+    return req;
+  }),
+);

--- a/packages/serverless/src/+awsLambda/awsLambda.types.ts
+++ b/packages/serverless/src/+awsLambda/awsLambda.types.ts
@@ -2,3 +2,7 @@ export interface AwsLambdaProxyOptions {
   binaryMimeTypes: string[];
 }
 
+export enum AwsLambdaHeaders {
+  APIGATEWAY_EVENT = 'x-apigateway-event',
+  AWSLAMBDA_CONTEXT = 'x-awslambda-context',
+}

--- a/packages/serverless/src/+awsLambda/awsLambda.types.ts
+++ b/packages/serverless/src/+awsLambda/awsLambda.types.ts
@@ -1,0 +1,4 @@
+export interface AwsLambdaProxyOptions {
+  binaryMimeTypes: string[];
+}
+

--- a/packages/serverless/src/+awsLambda/awsLambdaHandler.ts
+++ b/packages/serverless/src/+awsLambda/awsLambdaHandler.ts
@@ -1,0 +1,13 @@
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { ServerApp } from '../serverProxy';
+import { AwsLambdaProxy } from './awsLambdaProxy';
+import { AwsLambdaProxyOptions } from './awsLambda.types';
+
+export const createAwsLambdaHandler = (app: ServerApp, options: AwsLambdaProxyOptions) => {
+  const proxy = new AwsLambdaProxy(app, options);
+
+  const handler = (event: APIGatewayProxyEvent, context: Context) =>
+    proxy.handle({ event, context });
+  handler.close = () => proxy.close();
+  return handler;
+};

--- a/packages/serverless/src/+awsLambda/awsLambdaProxy.options.ts
+++ b/packages/serverless/src/+awsLambda/awsLambdaProxy.options.ts
@@ -1,0 +1,11 @@
+export const defaultAwsLambdaProxyOptions = {
+  binaryMimeTypes: [
+    'application/octet-stream',
+    'font/eot',
+    'font/opentype',
+    'font/otf',
+    'image/gif',
+    'image/jpeg',
+    'image/png',
+  ],
+};

--- a/packages/serverless/src/+awsLambda/awsLambdaProxy.ts
+++ b/packages/serverless/src/+awsLambda/awsLambdaProxy.ts
@@ -1,0 +1,63 @@
+import * as url from 'url';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+import { HttpStatus } from '@marblejs/core';
+import { ServerApp, ServerProxy, ServerProxyRequest, ServerProxyResponse } from '../serverProxy';
+import { defaultAwsLambdaProxyOptions } from './awsLambdaProxy.options';
+import { AwsLambdaProxyOptions } from './awsLambda.types';
+
+interface ApiGatewayRequest {
+  event: APIGatewayProxyEvent;
+  context: Context;
+}
+
+export class AwsLambdaProxy extends ServerProxy<ApiGatewayRequest, APIGatewayProxyResult> {
+  options: AwsLambdaProxyOptions;
+
+  constructor(serverApp: ServerApp, options?: Partial<AwsLambdaProxyOptions>) {
+    super(serverApp);
+    this.options = Object.assign({}, defaultAwsLambdaProxyOptions, options);
+  }
+
+  normalizeError(error: Error): Promise<APIGatewayProxyResult> | APIGatewayProxyResult {
+    console.log(error);
+    return { body: error.message, headers: {}, statusCode: HttpStatus.BAD_GATEWAY };
+  }
+
+  normalizeRequest(proxyRequest: ApiGatewayRequest): ServerProxyRequest | Promise<ServerProxyRequest> {
+    const { event, context } = proxyRequest;
+    const { body, headers, ...eventRest } = event;
+    return {
+      path: url.format({ pathname: event.path, query: event.queryStringParameters }),
+      headers: {
+        ...headers,
+        'x-apigateway-event': encodeURIComponent(JSON.stringify(eventRest)),
+        'x-apigateway-context': encodeURIComponent(JSON.stringify(context)),
+      },
+      method: event.httpMethod,
+      body: body ? Buffer.from(body, event.isBase64Encoded ? 'base64' : 'utf8') : undefined,
+    };
+  }
+
+  normalizeResponse(serverProxyResponse: ServerProxyResponse): Promise<APIGatewayProxyResult> | APIGatewayProxyResult {
+    const { headers, body, statusCode } = serverProxyResponse;
+    const { binaryMimeTypes } = this.options;
+
+    if (headers['transfer-encoding'] && headers['transfer-encoding'].includes('chunked')) {
+      delete headers['transfer-encoding'];
+    }
+    if (body && !headers['content-length']) {
+      headers['content-length'] = [String(Buffer.byteLength(body))];
+    }
+
+    const contentType = headers['content-type'] && headers['content-type'][0]
+      ? headers['content-type'][0].split(';')[0]
+      : '';
+    const isBase64Encoded = binaryMimeTypes.includes(contentType);
+    return {
+      body: body.toString(isBase64Encoded ? 'base64' : 'utf8'),
+      statusCode: statusCode || 200,
+      multiValueHeaders: headers,
+      isBase64Encoded,
+    };
+  }
+}

--- a/packages/serverless/src/+awsLambda/index.ts
+++ b/packages/serverless/src/+awsLambda/index.ts
@@ -1,0 +1,13 @@
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { ServerApp } from '../serverProxy';
+import { AwsLambdaProxy } from './awsLambdaProxy';
+import { AwsLambdaProxyOptions } from './awsLambda.types';
+
+export const createAwsLambdaHandler = (app: ServerApp, options: AwsLambdaProxyOptions) => {
+  const proxy = new AwsLambdaProxy(app, options);
+
+  const handler = (event: APIGatewayProxyEvent, context: Context) =>
+    proxy.handle({ event, context });
+  handler.close = () => proxy.close();
+  return handler;
+};

--- a/packages/serverless/src/+awsLambda/index.ts
+++ b/packages/serverless/src/+awsLambda/index.ts
@@ -1,13 +1,3 @@
-import { APIGatewayProxyEvent, Context } from 'aws-lambda';
-import { ServerApp } from '../serverProxy';
-import { AwsLambdaProxy } from './awsLambdaProxy';
-import { AwsLambdaProxyOptions } from './awsLambda.types';
-
-export const createAwsLambdaHandler = (app: ServerApp, options: AwsLambdaProxyOptions) => {
-  const proxy = new AwsLambdaProxy(app, options);
-
-  const handler = (event: APIGatewayProxyEvent, context: Context) =>
-    proxy.handle({ event, context });
-  handler.close = () => proxy.close();
-  return handler;
-};
+export * from './awsLambdaHandler';
+export * from './awsLambda.middleware';
+export * from './awsLambda.types';

--- a/packages/serverless/src/+awsLambda/spec/__snapshots__/awsLambda.spec.ts.snap
+++ b/packages/serverless/src/+awsLambda/spec/__snapshots__/awsLambda.spec.ts.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@marblejs/serverless - AWS Proxy integration POST / returns 200 1`] = `
+Object {
+  "body": "{\\"test\\":\\"value\\"}",
+  "context": Object {
+    "awsRequestId": "c482b12a-38bb-48bf-83a7-d7d8576dd442",
+    "callbackWaitsForEmptyEventLoop": true,
+    "functionName": "sample-lambda-1234567890AB",
+    "functionVersion": "1",
+    "invokedFunctionArn": "arn:aws:lambda:eu-central-1:123456789012:function:sample-lambda-1234567890AB:latest",
+    "logGroupName": "/aws/lambda/sample-lambda-1234567890AB",
+    "logStreamName": "2019/06/01/[latest]d89065cfaf354bd2ba025b5860ecb67e",
+    "memoryLimitInMB": "128",
+  },
+  "event": Object {
+    "httpMethod": "POST",
+    "isBase64Encoded": false,
+    "multiValueHeaders": Object {
+      "Accept": Array [
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      ],
+      "Accept-Encoding": Array [
+        "br, gzip, deflate",
+      ],
+      "Accept-Language": Array [
+        "pl-pl",
+      ],
+      "CloudFront-Forwarded-Proto": Array [
+        "https",
+      ],
+      "CloudFront-Is-Desktop-Viewer": Array [
+        "true",
+      ],
+      "CloudFront-Is-Mobile-Viewer": Array [
+        "false",
+      ],
+      "CloudFront-Is-SmartTV-Viewer": Array [
+        "false",
+      ],
+      "CloudFront-Is-Tablet-Viewer": Array [
+        "false",
+      ],
+      "CloudFront-Viewer-Country": Array [
+        "PL",
+      ],
+      "Content-Type": Array [
+        "text/plain",
+      ],
+      "Host": Array [
+        "1234567890.execute-api.eu-central-1.amazonaws.com",
+      ],
+      "User-Agent": Array [
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15",
+      ],
+      "Via": Array [
+        "2.0 3095e870e1a1a1b03178e40ab1872de5.cloudfront.net (CloudFront)",
+      ],
+      "X-Amz-Cf-Id": Array [
+        "Y25j7-itoeNCvCMwAt5YVWgDduoALWzQ_eL8dYb4-u2M5HC4VTyfeA==",
+      ],
+      "X-Amzn-Trace-Id": Array [
+        "Root=1-5cf2885f-fa32290824a86664bc211d02",
+      ],
+      "X-Forwarded-For": Array [
+        "127.0.0.1, 70.132.34.142",
+      ],
+      "X-Forwarded-Port": Array [
+        "443",
+      ],
+      "X-Forwarded-Proto": Array [
+        "https",
+      ],
+    },
+    "multiValueQueryStringParameters": null,
+    "path": "/",
+    "pathParameters": null,
+    "queryStringParameters": null,
+    "requestContext": Object {
+      "accountId": "534774995974",
+      "apiId": "1234567890",
+      "domainName": "1234567890.execute-api.eu-central-1.amazonaws.com",
+      "domainPrefix": "1234567890",
+      "extendedRequestId": "amo-8HzPliAFgHg=",
+      "httpMethod": "POST",
+      "identity": Object {
+        "accessKey": null,
+        "accountId": null,
+        "caller": null,
+        "cognitoAuthenticationProvider": null,
+        "cognitoAuthenticationType": null,
+        "cognitoIdentityId": null,
+        "cognitoIdentityPoolId": null,
+        "principalOrgId": null,
+        "sourceIp": "127.0.0.1",
+        "user": null,
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15",
+        "userArn": null,
+      },
+      "path": "/Prod/",
+      "protocol": "HTTP/1.1",
+      "requestId": "a17a92fe-8477-11e9-b7d2-51d9bcca17bd",
+      "requestTime": "01/Jun/2019:14:14:55 +0000",
+      "requestTimeEpoch": 1559398495665,
+      "resourceId": "lm3hfkkof6",
+      "resourcePath": "/",
+      "stage": "Prod",
+    },
+    "resource": "/",
+    "stageVariables": null,
+  },
+}
+`;

--- a/packages/serverless/src/+awsLambda/spec/awsLambda.middleware.spec.ts
+++ b/packages/serverless/src/+awsLambda/spec/awsLambda.middleware.spec.ts
@@ -1,16 +1,18 @@
 import { of } from 'rxjs';
 import { awsApiGatewayMiddleware$ } from '../awsLambda.middleware';
-import { HttpRequest } from '@marblejs/core';
+import { AwsLambdaHeaders } from '../awsLambda.types';
+import { createHttpRequest } from '@marblejs/core/dist/+internal/testing/http.helper';
 
 describe('@marblejs/serverless - AWS API Gateway Middleware', () => {
   test('extracts headers from request', async () => {
     const request = await awsApiGatewayMiddleware$()(
-      of({
+      of(createHttpRequest({
+        url: 'ignored',
         headers: {
-          'x-apigateway-context': ['%7B%22context%22%3A0%7D'],
-          'x-apigateway-event': '%7B%22event%22%3A1%7D',
+          [AwsLambdaHeaders.AWSLAMBDA_CONTEXT]: ['%7B%22context%22%3A0%7D'],
+          [AwsLambdaHeaders.APIGATEWAY_EVENT]: '%7B%22event%22%3A1%7D',
         }
-      } as any as HttpRequest),
+      })),
       null as any,
       null as any
     ).toPromise();

--- a/packages/serverless/src/+awsLambda/spec/awsLambda.middleware.spec.ts
+++ b/packages/serverless/src/+awsLambda/spec/awsLambda.middleware.spec.ts
@@ -1,0 +1,20 @@
+import { of } from 'rxjs';
+import { awsApiGatewayMiddleware$ } from '../awsLambda.middleware';
+import { HttpRequest } from '@marblejs/core';
+
+describe('@marblejs/serverless - AWS API Gateway Middleware', () => {
+  test('extracts headers from request', async () => {
+    const request = await awsApiGatewayMiddleware$()(
+      of({
+        headers: {
+          'x-apigateway-context': ['%7B%22context%22%3A0%7D'],
+          'x-apigateway-event': '%7B%22event%22%3A1%7D',
+        }
+      } as any as HttpRequest),
+      null as any,
+      null as any
+    ).toPromise();
+    expect(request.apiGatewayContext).toEqual({ context: 0 });
+    expect(request.apiGatewayEvent).toEqual({ event: 1 });
+  });
+});

--- a/packages/serverless/src/+awsLambda/spec/awsLambda.postContext.mock.json
+++ b/packages/serverless/src/+awsLambda/spec/awsLambda.postContext.mock.json
@@ -1,0 +1,10 @@
+{
+  "callbackWaitsForEmptyEventLoop": true,
+  "functionVersion": "1",
+  "functionName": "sample-lambda-1234567890AB",
+  "memoryLimitInMB": "128",
+  "logGroupName": "/aws/lambda/sample-lambda-1234567890AB",
+  "logStreamName": "2019/06/01/[latest]d89065cfaf354bd2ba025b5860ecb67e",
+  "invokedFunctionArn": "arn:aws:lambda:eu-central-1:123456789012:function:sample-lambda-1234567890AB:latest",
+  "awsRequestId": "c482b12a-38bb-48bf-83a7-d7d8576dd442"
+}

--- a/packages/serverless/src/+awsLambda/spec/awsLambda.postEvent.mock.json
+++ b/packages/serverless/src/+awsLambda/spec/awsLambda.postEvent.mock.json
@@ -1,0 +1,117 @@
+{
+  "resource": "/",
+  "path": "/",
+  "httpMethod": "POST",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Encoding": "br, gzip, deflate",
+    "Accept-Language": "pl-pl",
+    "Content-Type": "text/plain",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "PL",
+    "Host": "1234567890.execute-api.eu-central-1.amazonaws.com",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15",
+    "Via": "2.0 3095e870e1a1a1b03178e40ab1872de5.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "Y25j7-itoeNCvCMwAt5YVWgDduoALWzQ_eL8dYb4-u2M5HC4VTyfeA==",
+    "X-Amzn-Trace-Id": "Root=1-5cf2885f-fa32290824a86664bc211d02",
+    "X-Forwarded-For": "127.0.0.1, 70.132.34.142",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "multiValueHeaders": {
+    "Accept": [
+      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    ],
+    "Accept-Encoding": [
+      "br, gzip, deflate"
+    ],
+    "Accept-Language": [
+      "pl-pl"
+    ],
+    "CloudFront-Forwarded-Proto": [
+      "https"
+    ],
+    "CloudFront-Is-Desktop-Viewer": [
+      "true"
+    ],
+    "CloudFront-Is-Mobile-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-SmartTV-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-Tablet-Viewer": [
+      "false"
+    ],
+    "CloudFront-Viewer-Country": [
+      "PL"
+    ],
+    "Content-Type": [
+      "text/plain"
+    ],
+    "Host": [
+      "1234567890.execute-api.eu-central-1.amazonaws.com"
+    ],
+    "User-Agent": [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15"
+    ],
+    "Via": [
+      "2.0 3095e870e1a1a1b03178e40ab1872de5.cloudfront.net (CloudFront)"
+    ],
+    "X-Amz-Cf-Id": [
+      "Y25j7-itoeNCvCMwAt5YVWgDduoALWzQ_eL8dYb4-u2M5HC4VTyfeA=="
+    ],
+    "X-Amzn-Trace-Id": [
+      "Root=1-5cf2885f-fa32290824a86664bc211d02"
+    ],
+    "X-Forwarded-For": [
+      "127.0.0.1, 70.132.34.142"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ]
+  },
+  "queryStringParameters": null,
+  "multiValueQueryStringParameters": null,
+  "pathParameters": null,
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "lm3hfkkof6",
+    "resourcePath": "/",
+    "httpMethod": "POST",
+    "extendedRequestId": "amo-8HzPliAFgHg=",
+    "requestTime": "01/Jun/2019:14:14:55 +0000",
+    "path": "/Prod/",
+    "accountId": "534774995974",
+    "protocol": "HTTP/1.1",
+    "stage": "Prod",
+    "domainPrefix": "1234567890",
+    "requestTimeEpoch": 1559398495665,
+    "requestId": "a17a92fe-8477-11e9-b7d2-51d9bcca17bd",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "127.0.0.1",
+      "principalOrgId": null,
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 Safari/605.1.15",
+      "user": null
+    },
+    "domainName": "1234567890.execute-api.eu-central-1.amazonaws.com",
+    "apiId": "1234567890"
+  },
+  "body": "{\"test\":\"value\"}",
+  "isBase64Encoded": false
+}

--- a/packages/serverless/src/+awsLambda/spec/awsLambda.setup.ts
+++ b/packages/serverless/src/+awsLambda/spec/awsLambda.setup.ts
@@ -1,14 +1,14 @@
-import { EffectFactory, HttpEffectResponse, httpListener } from '@marblejs/core';
-import { map } from 'rxjs/operators';
+import { HttpEffectResponse, httpListener, r } from '@marblejs/core';
+import { map, mapTo } from 'rxjs/operators';
 import { createLambda, ProxyType } from '../../';
 import { awsApiGatewayMiddleware$ } from '../awsLambda.middleware';
 import { bodyParser$ } from '@marblejs/middleware-body';
 import { Readable } from 'stream';
 
-const effect$ = EffectFactory
-  .matchPath('/')
-  .matchType('POST')
-  .use(req$ => req$.pipe(
+const effect$ = r.pipe(
+  r.matchPath('/'),
+  r.matchType('POST'),
+  r.useEffect(req$ => req$.pipe(
     map((req): HttpEffectResponse => ({
       status: 200,
       body: {
@@ -18,13 +18,14 @@ const effect$ = EffectFactory
         context: req.apiGatewayContext,
       },
     }))
-  ));
+  )),
+);
 
-const chunkedTransferEncodingEffect$ = EffectFactory
-  .matchPath('/chunked-transfer')
-  .matchType('GET')
-  .use(req$ => req$.pipe(
-    map((): HttpEffectResponse => ({
+const chunkedTransferEncodingEffect$ = r.pipe(
+  r.matchPath('/chunked-transfer'),
+  r.matchType('GET'),
+  r.useEffect(req$ => req$.pipe(
+    mapTo(({
       status: 200,
       headers: {
         'transfer-encoding': 'chunked',
@@ -36,7 +37,8 @@ const chunkedTransferEncodingEffect$ = EffectFactory
         }
       }),
     }))
-  ));
+  ))
+);
 
 const app = httpListener({
   middlewares: [

--- a/packages/serverless/src/+awsLambda/spec/awsLambda.setup.ts
+++ b/packages/serverless/src/+awsLambda/spec/awsLambda.setup.ts
@@ -1,0 +1,56 @@
+import { EffectFactory, HttpEffectResponse, httpListener } from '@marblejs/core';
+import { map } from 'rxjs/operators';
+import { createLambda, ProxyType } from '../../';
+import { awsApiGatewayMiddleware$ } from '../awsLambda.middleware';
+import { bodyParser$ } from '@marblejs/middleware-body';
+import { Readable } from 'stream';
+
+const effect$ = EffectFactory
+  .matchPath('/')
+  .matchType('POST')
+  .use(req$ => req$.pipe(
+    map((req): HttpEffectResponse => ({
+      status: 200,
+      body: {
+        path: req.path,
+        body: req.body,
+        event: req.apiGatewayEvent,
+        context: req.apiGatewayContext,
+      },
+    }))
+  ));
+
+const chunkedTransferEncodingEffect$ = EffectFactory
+  .matchPath('/chunked-transfer')
+  .matchType('GET')
+  .use(req$ => req$.pipe(
+    map((): HttpEffectResponse => ({
+      status: 200,
+      headers: {
+        'transfer-encoding': 'chunked',
+      },
+      body: new Readable({
+        read(): void {
+          this.push(JSON.stringify({ key: 'value' }));
+          this.push(null);
+        }
+      }),
+    }))
+  ));
+
+const app = httpListener({
+  middlewares: [
+    bodyParser$(),
+    awsApiGatewayMiddleware$(),
+  ],
+  effects: [
+    effect$,
+    chunkedTransferEncodingEffect$,
+  ],
+});
+
+export const createHandler = () => createLambda({
+  httpListener: app,
+  type: ProxyType.AWS,
+  proxyOptions: {},
+});

--- a/packages/serverless/src/+awsLambda/spec/awsLambda.spec.ts
+++ b/packages/serverless/src/+awsLambda/spec/awsLambda.spec.ts
@@ -1,7 +1,7 @@
-import { createHandler } from './awsLambda.setup';
-import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
-import { createLambda } from '../../handler';
 import { httpListener } from '@marblejs/core';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+import { createHandler } from './awsLambda.setup';
+import { createLambda } from '../../handler';
 
 describe('@marblejs/serverless - AWS Proxy integration', () => {
   let handler;
@@ -43,14 +43,16 @@ describe('@marblejs/serverless - AWS Proxy integration', () => {
       httpMethod: 'GET',
       path: '/chunked-transfer',
     }, {});
+
     expect(response.statusCode).toBe(200);
     expect(response.multiValueHeaders).toBeDefined();
+    // TODO Extract it to a separate method in proxy helpers (is already done in upcoming PR)
     const getHeader = (key: string) =>
       response.multiValueHeaders &&
       response.multiValueHeaders[key] &&
       response.multiValueHeaders[key][0];
     expect(getHeader('content-type')).toBe('application/json');
-    expect(getHeader('content-length')).toBe('15');
+    expect(getHeader('Content-Length')).toBe('15');
     expect(JSON.parse(response.body)).toEqual({ key: 'value' });
   });
 });

--- a/packages/serverless/src/+awsLambda/spec/awsLambda.spec.ts
+++ b/packages/serverless/src/+awsLambda/spec/awsLambda.spec.ts
@@ -1,0 +1,56 @@
+import { createHandler } from './awsLambda.setup';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+import { createLambda } from '../../handler';
+import { httpListener } from '@marblejs/core';
+
+describe('@marblejs/serverless - AWS Proxy integration', () => {
+  let handler;
+  beforeAll(() => {
+    handler = createHandler();
+  });
+
+  afterAll(() => {
+    handler.close();
+  });
+
+  test('POST / returns 200', async () => {
+    const event: APIGatewayProxyEvent = await import('./awsLambda.postEvent.mock.json') as any;
+    const context: Context = await import('./awsLambda.postContext.mock.json') as any;
+    const response: APIGatewayProxyResult = await handler(event, context);
+    expect(JSON.parse(response.body)).toMatchSnapshot();
+    expect(response.statusCode).toBe(200);
+  });
+
+  test('can be called multiple times asynchronously', async () => {
+    const event: APIGatewayProxyEvent = await import('./awsLambda.postEvent.mock.json') as any;
+    const context: Context = await import('./awsLambda.postContext.mock.json') as any;
+    const eventRequest = async () => {
+      const response = await handler(event, context);
+      expect(response.statusCode).toBe(200);
+    };
+    await Promise.all(new Array(10).fill(null).map(eventRequest));
+  });
+
+  test('creates proxy wrapper only for AWS', () => {
+    expect(() => createLambda({
+      type: 'unknown' as any,
+      httpListener: httpListener({ effects: [] }),
+    })).toThrowError('Invalid type specified.');
+  });
+
+  test('removes "transfer-encoding: chunked" header', async () => {
+    const response: APIGatewayProxyResult = await handler({
+      httpMethod: 'GET',
+      path: '/chunked-transfer',
+    }, {});
+    expect(response.statusCode).toBe(200);
+    expect(response.multiValueHeaders).toBeDefined();
+    const getHeader = (key: string) =>
+      response.multiValueHeaders &&
+      response.multiValueHeaders[key] &&
+      response.multiValueHeaders[key][0];
+    expect(getHeader('content-type')).toBe('application/json');
+    expect(getHeader('content-length')).toBe('15');
+    expect(JSON.parse(response.body)).toEqual({ key: 'value' });
+  });
+});

--- a/packages/serverless/src/+awsLambda/spec/awsLambdaProxy.spec.ts
+++ b/packages/serverless/src/+awsLambda/spec/awsLambdaProxy.spec.ts
@@ -1,0 +1,68 @@
+import { AwsLambdaProxy } from '../awsLambdaProxy';
+
+describe('@marblejs/serverless - AWS Proxy', () => {
+  let proxy: AwsLambdaProxy;
+
+  beforeEach(() => {
+    proxy = new AwsLambdaProxy(() => void 0);
+  });
+  afterEach(() => {
+    proxy.close();
+  });
+
+  test('#normalizeError() returns correct lambda response', async () => {
+    const normalizedError = await Promise.resolve(proxy.normalizeError(new Error('Something bad happened.')));
+
+    expect(normalizedError).toEqual({
+      body: 'Something bad happened.',
+      headers: {},
+      statusCode: 502
+    });
+  });
+
+  test('#normalizeRequest() returns server proxy request for minimal request data', async () => {
+    const normalizedRequest = await Promise.resolve(proxy.normalizeRequest({
+      event: {
+        httpMethod: 'GET',
+        path: '/',
+      } as any,
+      context: {} as any,
+    }));
+
+    expect(normalizedRequest).toEqual({
+      method: 'GET',
+      path: '/',
+      body: undefined,
+      headers: {
+        'x-apigateway-context': '%7B%7D',
+        'x-apigateway-event': '%7B%22httpMethod%22%3A%22GET%22%2C%22path%22%3A%22%2F%22%7D',
+      },
+    });
+  });
+
+  test('#normalizeRequest() creates Buffer with base64 encoding', async () => {
+    const normalizedRequest = await Promise.resolve(proxy.normalizeRequest({
+      event: {
+        httpMethod: 'GET',
+        path: '/',
+        body: Buffer.from('test').toString('base64'),
+        isBase64Encoded: true
+      } as any,
+      context: {} as any,
+    }));
+
+    expect(normalizedRequest).toEqual({
+      method: 'GET',
+      path: '/',
+      body: Buffer.from('test'),
+      headers: {
+        'x-apigateway-context': '%7B%7D',
+        'x-apigateway-event': '%7B%22httpMethod%22%3A%22GET%22%2C%22path%22%3A%22%2F%22%2C%22isBase64Encoded%22%3Atrue%7D',
+      },
+    });
+  });
+
+  test('#normalizeResponse() ', async () => {
+
+  });
+});

--- a/packages/serverless/src/handler.ts
+++ b/packages/serverless/src/handler.ts
@@ -1,0 +1,32 @@
+import { AwsLambdaProxyOptions } from './+awsLambda/awsLambda.types';
+import { createContext, httpListener } from '@marblejs/core';
+
+export enum ProxyType {
+  AWS = 'aws',
+}
+
+type ProxyOptions<Type extends ProxyType> =
+  Type extends ProxyType.AWS ? Partial<AwsLambdaProxyOptions> :
+    never;
+
+export interface LambdaOptions<Type extends ProxyType> {
+  httpListener: ReturnType<typeof httpListener>;
+  type: ProxyType;
+  proxyOptions?: ProxyOptions<Type>;
+}
+
+export const createLambda = <Type extends ProxyType>({
+  httpListener,
+  type,
+  proxyOptions
+}: LambdaOptions<Type>) => {
+  const app = httpListener.run(createContext());
+  switch (type) {
+    case ProxyType.AWS:
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { createAwsLambdaHandler } = require('./+awsLambda');
+      return createAwsLambdaHandler(app, proxyOptions);
+    default:
+      throw new Error(`Invalid type specified. Expected: ${Object.values(ProxyType)}`);
+  }
+};

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -1,0 +1,1 @@
+export * from './handler';

--- a/packages/serverless/src/serverProxy.helpers.ts
+++ b/packages/serverless/src/serverProxy.helpers.ts
@@ -1,0 +1,36 @@
+import * as path from 'path';
+
+export const makeSocketPath = () => {
+  const suffix = Math.random().toString(36).substring(2, 15);
+  /* istanbul ignore if */
+  if (/^win/.test(process.platform)) {
+    return path.join('\\\\?\\pipe', process.cwd(), `server-${suffix}`);
+  } else {
+    return `/tmp/server-${suffix}.sock`;
+  }
+};
+
+export const normalizeHeaders = (
+  inputHeaders: Record<string, string | string[] | undefined>,
+): Record<string, string[]> => {
+  const headers = Object.keys(inputHeaders)
+    .reduce((headers, key) => {
+      const header = headers[key] || (headers[key] = []);
+      const value = inputHeaders[key];
+      if (typeof value === 'string') {
+        header.push(value);
+      } else if (Array.isArray(value)) {
+        header.push(...value.filter(v => v !== undefined));
+      }
+      return headers;
+    }, {});
+  for(const key in headers){
+    if(!headers[key].length){
+      delete headers[key];
+    }
+  }
+  return headers;
+};
+
+export const getHeaderContent = (header: undefined | string | string[]) =>
+  header && JSON.parse(decodeURIComponent(typeof header === 'string' ? header : header[0]));

--- a/packages/serverless/src/serverProxy.ts
+++ b/packages/serverless/src/serverProxy.ts
@@ -1,0 +1,119 @@
+import { createServer, IncomingMessage, OutgoingMessage, request, Server } from 'http';
+import { makeSocketPath, normalizeHeaders } from './serverProxy.helpers';
+
+type Resolver<T> = (result: T | Promise<T>) => void;
+
+export type ServerApp = (req: IncomingMessage, res: OutgoingMessage) => void;
+
+export interface ServerProxyRequest {
+  method: string;
+  path: string;
+  host?: string;
+  protocol?: string;
+  headers?: Record<string, string>;
+  body?: Buffer;
+}
+
+export interface ServerProxyResponse {
+  statusCode?: number;
+  statusMessage?: string;
+  body: Buffer;
+  headers: Record<string, string[]>;
+}
+
+export abstract class ServerProxy<ProxyRequest, ProxyResponse> {
+  private readonly server: Server;
+  private listening: boolean = false;
+  private socketPath: string;
+
+  constructor(
+    private app: ServerApp
+  ) {
+    this.socketPath = makeSocketPath();
+    this.server = createServer(this.app);
+    this.server
+      .on('close', () => {
+        this.listening = false;
+        console.log(this.logTag, 'closed');
+      })
+      .on('error', (error: NodeJS.ErrnoException) => {
+        if (error.code === 'EADDRINUSE') {
+          this.socketPath = makeSocketPath();
+          this.server.close(() => this.startServer());
+          return;
+        }
+        console.log(this.logTag, error.toString());
+      })
+      .on('listening', () => {
+        this.listening = true;
+        console.log(this.logTag, 'listening');
+      });
+  }
+
+  close(): void {
+    this.server.close();
+  }
+
+  abstract normalizeRequest(proxyRequest: ProxyRequest): ServerProxyRequest | Promise<ServerProxyRequest>;
+
+  abstract normalizeResponse(serverProxyResponse: ServerProxyResponse): ProxyResponse | Promise<ProxyResponse>;
+
+  abstract normalizeError(error: Error): ProxyResponse | Promise<ProxyResponse>;
+
+  async handle(proxyRequest: ProxyRequest): Promise<ProxyResponse> {
+    const serverProxyRequest = await Promise.resolve(this.normalizeRequest(proxyRequest));
+    return await new Promise<ProxyResponse>((resolve) => {
+      if (this.listening) {
+        this.sendToServer(serverProxyRequest, resolve);
+      } else {
+        this.server.on('listening', () => this.sendToServer(serverProxyRequest, resolve));
+        this.startServer();
+      }
+    });
+  }
+
+  private get logTag(): string {
+    return `ServerProxy ${this.socketPath}`;
+  }
+
+  private sendToServer(serverProxyRequest: ServerProxyRequest, resolve: Resolver<ProxyResponse>) {
+    try {
+      const { headers = {}, body, host, path, method, protocol } = serverProxyRequest;
+      if (body) {
+        headers['Content-Type'] = headers['Content-Type'] || 'text/plain; charset=utf-8';
+      }
+      const req = request({
+        headers,
+        path,
+        method,
+        host,
+        protocol,
+        socketPath: this.socketPath,
+      }, (response: IncomingMessage) => {
+        response.headers = normalizeHeaders(response.headers);
+        const bufferChunks: any[] = [];
+        response
+          .on('data', chunk => bufferChunks.push(chunk))
+          .on('end', () => {
+            let { statusCode, statusMessage, headers } = response;
+
+            resolve(this.normalizeResponse({
+              statusCode,
+              statusMessage,
+              headers: normalizeHeaders(headers),
+              body: Buffer.concat(bufferChunks),
+            }));
+          });
+      }).on('error', error => resolve(this.normalizeError(error)));
+      if (body) {
+        req.write(body);
+      }
+      req.end();
+    } catch (error) {
+      resolve(this.normalizeError(error));
+    }
+  };
+
+  private startServer = () => this.server.listen(this.socketPath);
+
+}

--- a/packages/serverless/src/serverProxy.ts
+++ b/packages/serverless/src/serverProxy.ts
@@ -1,16 +1,17 @@
-import { createServer, IncomingMessage, OutgoingMessage, request, Server } from 'http';
+import { createServer, IncomingMessage, OutgoingHttpHeaders, OutgoingMessage, request, Server } from 'http';
 import { makeSocketPath, normalizeHeaders } from './serverProxy.helpers';
+import { HttpMethod } from '@marblejs/core';
 
 type Resolver<T> = (result: T | Promise<T>) => void;
 
 export type ServerApp = (req: IncomingMessage, res: OutgoingMessage) => void;
 
 export interface ServerProxyRequest {
-  method: string;
+  method: HttpMethod;
   path: string;
   host?: string;
   protocol?: string;
-  headers?: Record<string, string>;
+  headers?: OutgoingHttpHeaders;
   body?: Buffer;
 }
 
@@ -23,7 +24,7 @@ export interface ServerProxyResponse {
 
 export abstract class ServerProxy<ProxyRequest, ProxyResponse> {
   private readonly server: Server;
-  private listening: boolean = false;
+  private listening = false;
   private socketPath: string;
 
   constructor(
@@ -95,7 +96,7 @@ export abstract class ServerProxy<ProxyRequest, ProxyResponse> {
         response
           .on('data', chunk => bufferChunks.push(chunk))
           .on('end', () => {
-            let { statusCode, statusMessage, headers } = response;
+            const { statusCode, statusMessage, headers } = response;
 
             resolve(this.normalizeResponse({
               statusCode,

--- a/packages/serverless/src/spec/serverProxy.helpers.spec.ts
+++ b/packages/serverless/src/spec/serverProxy.helpers.spec.ts
@@ -1,0 +1,19 @@
+import { normalizeHeaders } from '../serverProxy.helpers';
+
+describe('@marblejs/serverless - Server Proxy Helpers', () => {
+  describe('#normalizeHeaders', () => {
+    test('converts headers to Record<string, string[]> format', () => {
+      expect(normalizeHeaders({
+        'Content-Type': 'text/plain',
+        'Host': ['example.com', 'example2.com'],
+        'X-Test': undefined,
+        'X-Test-2': [],
+        'X-Test-3': '',
+      })).toEqual({
+        'Content-Type': ['text/plain'],
+        'Host': ['example.com', 'example2.com'],
+        'X-Test-3': [''],
+      })
+    });
+  });
+});

--- a/packages/serverless/tsconfig.json
+++ b/packages/serverless/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noImplicitReturns": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": false,
+    "resolveJsonModule": true,
     "pretty": true,
     "strict": true,
     "target": "es6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,6 +639,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@types/aws-lambda@^8.10.26":
+  version "8.10.26"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.26.tgz#ebb164a95317b1350c5a57f719e8cb803a76fc97"
+  integrity sha512-RI32vdCHAtKaFpjA9Wp2+VGrE4aagsiHhAEopWCcMDZreZjyC26Wlnwu2CZvqycMjKjZ1tLhpHIJC/VmjJIspQ==
+
 "@types/chalk@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
@@ -684,6 +689,11 @@
 "@types/node@^10.12.15":
   version "10.12.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.15.tgz#20e85651b62fd86656e57c9c9bc771ab1570bc59"
+
+"@types/node@^12.0.4":
+  version "12.0.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.4.tgz#46832183115c904410c275e34cf9403992999c32"
+  integrity sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==
 
 "@types/qs@^6.5.1":
   version "6.5.1"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Marble.js can be used only as a standalone server, which can be run locally or in Docker environment.

## What is the new behavior?
Marble.js app can be proxied with `@marblejs/serverless` like below:

```ts
import { createLambda, ProxyType } from '@marblejs/severless';
import httpListener from './httpListener';

export = createLambda({
  app: httpListener, // Your app goes here
  type: ProxyType.AWS, // Currently we support only AWS Lambda with API Gateway
  proxyOptions: { // Optional configuration for specified ProxyType
    binaryMimeTypes: ['application/octet-stream'], 
  },
});
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information