### PR TITLE
fix(stream-responses): Stream response is stringified if Content-Type is application/json

### DIFF
--- a/packages/core/src/response/responseBody.factory.ts
+++ b/packages/core/src/response/responseBody.factory.ts
@@ -2,9 +2,10 @@ import { HttpHeaders } from '../http.interface';
 import { ContentType, isStream } from '../+internal';
 
 export const bodyFactory = (headers: HttpHeaders) => (body: any) => {
-  if(isStream(body)){
+  if (isStream(body)) {
     return body;
   }
+  
   switch (headers['Content-Type']) {
     case ContentType.APPLICATION_JSON:
       return JSON.stringify(body);

--- a/packages/core/src/response/responseBody.factory.ts
+++ b/packages/core/src/response/responseBody.factory.ts
@@ -1,7 +1,10 @@
 import { HttpHeaders } from '../http.interface';
-import { ContentType } from '../+internal';
+import { ContentType, isStream } from '../+internal';
 
 export const bodyFactory = (headers: HttpHeaders) => (body: any) => {
+  if(isStream(body)){
+    return body;
+  }
   switch (headers['Content-Type']) {
     case ContentType.APPLICATION_JSON:
       return JSON.stringify(body);


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A stream body is being stringified when:
* `Content-Type` header is set explicitly to `application/json`
* `Content-Type` header is not specified (it defaults to case above)
It also causes a header conflict when `Transfer-Encoding` header is explicitly set to `chunked`, because body is not a stream which causes `Content-Length` header to be set.

## What is the new behavior?
Body is not stringified when it's a stream, regardless of `Content-Type` header.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

It fixes issue with https://github.com/marblejs/marble/pull/136 testing, where I try to send JSON as streamed body.