### PR TITLE
imp(http helper): simplified `createHttpRequest` function and it's usages

### DIFF
--- a/packages/core/src/+internal/testing/http.helper.ts
+++ b/packages/core/src/+internal/testing/http.helper.ts
@@ -10,7 +10,7 @@ import {
 import { EventEmitter } from 'events';
 
 interface HttpRequestMockParams {
-  url: string;
+  url?: string;
   body?: any;
   params?: RouteParameters;
   query?: QueryParameters;
@@ -30,15 +30,17 @@ export interface HttpServerMocks {
   on?: jest.Mock;
 }
 
-export const createHttpRequest = (data: HttpRequestMockParams = { url: '/' }) => ({
-  ...data,
-  url: data.url,
-  body: data.body,
-  params: data.params || {},
-  query: data.query || {},
-  headers: data.headers || {},
-  method: data.method || 'GET',
-}) as HttpRequest;
+export const createHttpRequest = (data?: HttpRequestMockParams) => Object.assign(
+  {},
+  {
+    url: '/',
+    method: 'GET',
+    headers: {},
+    query: {},
+    params: {},
+  },
+  data,
+) as HttpRequest;
 
 export const createHttpResponse = (data: HttpResponseMockParams = {}) =>
   new class extends EventEmitter {

--- a/packages/core/src/effects/specs/effects.combiner.spec.ts
+++ b/packages/core/src/effects/specs/effects.combiner.spec.ts
@@ -9,8 +9,8 @@ describe('#combineMiddlewares', () => {
     const a$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => { req.test = 1; }));
     const b$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
     const c$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
-    const incomingRequest = createHttpRequest({ url: '/' });
-    const outgoingRequest = createHttpRequest({ url: '/', test: 3 });
+    const incomingRequest = createHttpRequest();
+    const outgoingRequest = createHttpRequest({ test: 3 });
 
     // when
     const middlewares$ = combineMiddlewares(a$, b$, c$);
@@ -24,8 +24,8 @@ describe('#combineMiddlewares', () => {
 
   test('returns stream even if middlewares are not provided', () => {
     // given
-    const incomingRequest = createHttpRequest({ url: '/' });
-    const outgoingRequest = createHttpRequest({ url: '/' });
+    const incomingRequest = createHttpRequest();
+    const outgoingRequest = createHttpRequest();
 
     // when
     const middlewares$ = combineMiddlewares();

--- a/packages/core/src/error/specs/error.effect.spec.ts
+++ b/packages/core/src/error/specs/error.effect.spec.ts
@@ -3,7 +3,7 @@ import { defaultError$ } from '../error.effect';
 import { HttpError } from '../error.model';
 
 describe('defaultError$', () => {
-  const incomingRequest = createHttpRequest({ url: '/' });
+  const incomingRequest = createHttpRequest();
   const client = createHttpResponse();
 
   test('maps HttpError', () => {

--- a/packages/core/src/operators/switchToProtocol/switchToProtocol.operator.spec.ts
+++ b/packages/core/src/operators/switchToProtocol/switchToProtocol.operator.spec.ts
@@ -7,7 +7,6 @@ describe('#switchToProtocol operator', () => {
   test(`responds with ${HttpStatus.SWITCHING_PROTOCOLS} status if protocol is supported`, () => {
     // given
     const incomingWebsocketReq = createHttpRequest({
-      url: '/',
       headers: {
         upgrade: 'websocket',
         connection: 'upgrade',
@@ -17,7 +16,6 @@ describe('#switchToProtocol operator', () => {
       status: HttpStatus.SWITCHING_PROTOCOLS,
     };
     const incomingHttpReq = createHttpRequest({
-      url: '/',
       headers: {
         upgrade: 'http2',
         connection: 'upgrade',

--- a/packages/middleware-body/src/specs/body.util.spec.ts
+++ b/packages/middleware-body/src/specs/body.util.spec.ts
@@ -2,9 +2,9 @@ import { createHttpRequest } from '@marblejs/core/dist/+internal/testing/http.he
 import { hasBody } from '../body.util';
 
 test('#hasBody checks if request has body', () => {
-  expect(hasBody(createHttpRequest({ url: '/', body: null }))).toEqual(false);
-  expect(hasBody(createHttpRequest({ url: '/', body: undefined }))).toEqual(false);
-  expect(hasBody(createHttpRequest({ url: '/', body: 'test' }))).toEqual(true);
-  expect(hasBody(createHttpRequest({ url: '/', body: {} }))).toEqual(true);
-  expect(hasBody(createHttpRequest({ url: '/', body: 1 }))).toEqual(true);
+  expect(hasBody(createHttpRequest({ body: null }))).toEqual(false);
+  expect(hasBody(createHttpRequest({ body: undefined }))).toEqual(false);
+  expect(hasBody(createHttpRequest({ body: 'test' }))).toEqual(true);
+  expect(hasBody(createHttpRequest({ body: {} }))).toEqual(true);
+  expect(hasBody(createHttpRequest({ body: 1 }))).toEqual(true);
 });

--- a/packages/serverless/src/+awsLambda/spec/awsLambda.middleware.spec.ts
+++ b/packages/serverless/src/+awsLambda/spec/awsLambda.middleware.spec.ts
@@ -7,7 +7,6 @@ describe('@marblejs/serverless - AWS API Gateway Middleware', () => {
   test('extracts headers from request', async () => {
     const request = await awsApiGatewayMiddleware$()(
       of(createHttpRequest({
-        url: 'ignored',
         headers: {
           [AwsLambdaHeaders.AWSLAMBDA_CONTEXT]: ['%7B%22context%22%3A0%7D'],
           [AwsLambdaHeaders.APIGATEWAY_EVENT]: '%7B%22event%22%3A1%7D',


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
You have to pass `url` whenever you use `createHttpRequest` function. The function is only used for testing purposes.
## What is the new behavior?
Internally in `createHttpRequest` function, the defaults are set in a bit better way. Also, it does accept empty/partial object and still falls back to the right default values.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I also updated usages of the method in all tests.