### PR TITLE
fix(core): request url parse error

### DIFF
--- a/packages/@integration/test/integration.spec.ts
+++ b/packages/@integration/test/integration.spec.ts
@@ -71,6 +71,15 @@ describe('API integration', () => {
         expect(body).toHaveLength(3);
       }));
 
+  test(`GET returns 200 with Content-Type=application/json: /api/v1/user?email=test%40test.com`, async () =>
+    request(server)
+      .get('/api/v1/user?email=test%40test.com')
+      .set('Authorization', 'Bearer FAKE')
+      .expect(200)
+      .then(({ header }) => {
+        expect(header['content-type']).toBe(ContentType.APPLICATION_JSON);
+      }));
+
   test('GET returns single object: /api/v1/user/10', async () =>
     request(server)
       .get('/api/v1/user/10')

--- a/packages/core/src/response/response.handler.ts
+++ b/packages/core/src/response/response.handler.ts
@@ -1,3 +1,4 @@
+import * as url from 'url';
 import { EMPTY } from 'rxjs';
 import { HttpEffectResponse } from '../effects/http-effects.interface';
 import { HttpRequest, HttpResponse, HttpStatus } from '../http.interface';
@@ -10,8 +11,9 @@ export const handleResponse = (res: HttpResponse) => (req: HttpRequest) => (effe
   if (res.finished) { return EMPTY; }
 
   const status = effect.status || HttpStatus.OK;
+  const path = url.parse(req.url).pathname || '';
 
-  const headersFactoryWithData = headersFactory({ body: effect.body, path: req.url, status });
+  const headersFactoryWithData = headersFactory({ body: effect.body, path, status });
   const headers = headersFactoryWithData(effect.headers);
 
   const bodyFactoryWithHeaders = bodyFactory(headers);

--- a/packages/core/src/router/specs/router.query.factory.spec.ts
+++ b/packages/core/src/router/specs/router.query.factory.spec.ts
@@ -61,4 +61,16 @@ describe('#queryParamsFactory', () => {
     // then
     expect(params).toEqual(expectedParamsObj);
   });
+
+  test('parses URL like parameter', () => {
+    // given
+    const exampleURL = 'user=test%40test.com';
+    const expectedParamsObj = { user: 'test@test.com' };
+
+    // when
+    const params = queryParamsFactory(exampleURL);
+
+    // then
+    expect(params).toEqual(expectedParamsObj);
+  })
 });


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Server returns `500` status code when query parameters contains URL-like value

Issue Number: #145 

## What is the new behavior?
Server reacts correctly when an URL ends with `.whatever` (eg. user@email.com)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
