### PR TITLE
fix(testing/doc-gen): Removed const in favor of enum

### DIFF
--- a/packages/middleware-io/src/io.json-schema.ts
+++ b/packages/middleware-io/src/io.json-schema.ts
@@ -56,7 +56,7 @@ const IoTypes: Record<IoTag, IoConverter> = {
 
   [IoTag.NULL]: () => ({ type: 'null' }),
 
-  [IoTag.LITERAL]: (type: t.LiteralType<any>) => ({ const: type.value }),
+  [IoTag.LITERAL]: (type: t.LiteralType<any>) => ({ enum: [type.value] }),
 
   [IoTag.UNION]: (type: t.UnionType<t.Any[]>) =>
     type.types.every(element => getTag(element) === IoTag.LITERAL)

--- a/packages/middleware-io/src/specs/io.json-schema.spec.ts
+++ b/packages/middleware-io/src/specs/io.json-schema.spec.ts
@@ -118,9 +118,9 @@ describe('#ioTypeToJsonSchema', () => {
   });
 
   test('supports t.literal conversion', () => {
-    expect(ioTypeToJsonSchema(t.literal(30))).toEqual({ const: 30 });
-    expect(ioTypeToJsonSchema(t.literal(true))).toEqual({ const: true });
-    expect(ioTypeToJsonSchema(t.literal('test'))).toEqual({ const: 'test' });
+    expect(ioTypeToJsonSchema(t.literal(30))).toEqual({ enum: [30] });
+    expect(ioTypeToJsonSchema(t.literal(true))).toEqual({ enum: [true] });
+    expect(ioTypeToJsonSchema(t.literal('test'))).toEqual({ enum: ['test'] });
   });
 
   test('supports t.null conversion', () => {

--- a/packages/middleware-io/src/specs/io.request.middleware.spec.ts
+++ b/packages/middleware-io/src/specs/io.request.middleware.spec.ts
@@ -73,7 +73,7 @@ describe('#requestValidator$', () => {
               additionalProperties: true,
             },
             headers: {
-              properties: { 'content-type': { const: 'application/json' } },
+              properties: { 'content-type': { enum: ['application/json'] } },
               required: ['content-type'],
               type: 'object',
               additionalProperties: true


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`@marblejs/middleware-io` generates JSON Schema 7, which is not fully supported by OpenAPI Specification 3. OAS/Swagger does not support `const`.

## What is the new behavior?
We use `enum` instead of `const`, which simply works. 😄 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
