### PR TITLE
refactor(core, websockets, messaging): pass error to stream instead of metadata object

### DIFF
--- a/packages/core/src/+internal/testing/marbles.helper.ts
+++ b/packages/core/src/+internal/testing/marbles.helper.ts
@@ -1,7 +1,10 @@
 import { TestScheduler } from 'rxjs/testing';
 import { EffectMetadata, EffectLike } from '../../effects/effects.interface';
 
-type MarbleFlow = [string, { [marble: string]: any } | undefined];
+type MarbleFlow =
+  | [string, { [marble: string]: any } | undefined]
+  | [string, { [marble: string]: any } | undefined, any]
+  ;
 type MarbleDependencies = { client?: any; meta?: Partial<EffectMetadata> };
 
 export const Marbles = {
@@ -14,15 +17,15 @@ export const Marbles = {
     marbleflow: [MarbleFlow, MarbleFlow],
     dependencies: MarbleDependencies = {},
   ) => {
-    const [initStream, initValues] = marbleflow[0];
-    const [expectedStream, expectedValues] = marbleflow[1];
+    const [initStream, initValues, initError] = marbleflow[0];
+    const [expectedStream, expectedValues, expectedError] = marbleflow[1];
 
     const scheduler = Marbles.createTestScheduler();
-    const stream$ = scheduler.createColdObservable(initStream, initValues);
+    const stream$ = scheduler.createColdObservable(initStream, initValues, initError);
 
     scheduler
       .expectObservable(effect(stream$, dependencies.client, dependencies.meta))
-      .toBe(expectedStream, expectedValues);
+      .toBe(expectedStream, expectedValues, expectedError);
 
     scheduler.flush();
   },

--- a/packages/core/src/effects/effects.interface.ts
+++ b/packages/core/src/effects/effects.interface.ts
@@ -5,14 +5,12 @@ export interface EffectLike {
   (input$: Observable<any>, ...args: any[]): Observable<any>;
 }
 
-export interface Effect<I, O, Client, Err extends Error = Error, Initiator = any> {
-  (input$: Observable<I>, client: Client, meta: EffectMetadata<Err, Initiator>): Observable<O>;
+export interface Effect<I, O, Client> {
+  (input$: Observable<I>, client: Client, meta: EffectMetadata): Observable<O>;
 }
 
-export interface EffectMetadata<Err extends Error = Error, Initiator = any> {
+export interface EffectMetadata {
   ask: ContextProvider;
   scheduler: SchedulerLike;
-  error?: Err;
-  initiator?: Initiator;
   [key: string]: any;
 }

--- a/packages/core/src/effects/effectsMetadata.factory.ts
+++ b/packages/core/src/effects/effectsMetadata.factory.ts
@@ -3,16 +3,12 @@ import { AsyncScheduler } from 'rxjs/internal/scheduler/AsyncScheduler';
 import { SchedulerLike } from 'rxjs';
 import { ContextProvider } from '../context/context.factory';
 
-export const createEffectMetadata = <Scheduler extends SchedulerLike, Err extends Error, Initiator = any>(
+export const createEffectMetadata = <Scheduler extends SchedulerLike>(
   metadata: {
     ask: ContextProvider;
     scheduler?: Scheduler;
-    error?: Err;
-    initiator?: Initiator;
   },
-): EffectMetadata<Err, Initiator> => ({
+): EffectMetadata => ({
   ask: metadata.ask,
   scheduler: metadata.scheduler || AsyncScheduler as any,
-  error: metadata.error,
-  initiator: metadata.initiator,
 });

--- a/packages/core/src/effects/http-effects.interface.ts
+++ b/packages/core/src/effects/http-effects.interface.ts
@@ -16,19 +16,21 @@ export interface HttpMiddlewareEffect<
   O extends HttpRequest = HttpRequest,
 > extends HttpEffect<I, O> {}
 
-export interface HttpErrorEffect<T extends Error = HttpError>
-  extends HttpEffect<HttpRequest, HttpEffectResponse, HttpResponse, T> {}
+export interface HttpErrorEffect<
+  Err extends Error = HttpError,
+> extends HttpEffect<{ req: HttpRequest; error: Err }, HttpEffectResponse, HttpResponse> {}
 
-export interface HttpServerEffect<T extends Event = Event>
-  extends HttpEffect<T, any, http.Server | https.Server> {}
+export interface HttpServerEffect<
+  Ev extends Event = Event
+> extends HttpEffect<Ev, any, http.Server | https.Server> {}
 
-export interface HttpOutputEffect<T extends HttpEffectResponse = HttpEffectResponse>
-  extends HttpEffect<T, HttpEffectResponse> {}
+export interface HttpOutputEffect<
+  Req extends HttpRequest = HttpRequest,
+  Res extends HttpEffectResponse = HttpEffectResponse
+> extends HttpEffect<{ req: Req; res: Res }, HttpEffectResponse> {}
 
 export interface HttpEffect<
   I = HttpRequest,
   O = HttpEffectResponse,
   Client = HttpResponse,
-  Err extends Error = Error,
-  Initiator = HttpRequest,
-> extends Effect<I, O, Client, Err, Initiator> {}
+> extends Effect<I, O, Client> {}

--- a/packages/core/src/error/error.effect.ts
+++ b/packages/core/src/error/error.effect.ts
@@ -1,4 +1,4 @@
-import { map, mapTo } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { HttpErrorEffect } from '../effects/http-effects.interface';
 import { HttpStatus } from '../http.interface';
 import { HttpError, isHttpError } from './error.model';
@@ -18,10 +18,9 @@ const errorFactory = (status: HttpStatus, error: Error) =>
     ? { error: { status, message: error.message, data: error.data, context: error.context } }
     : { error: { status, message: error.message } };
 
-export const defaultError$: HttpErrorEffect<HttpError> = (req$, _, meta) => req$
-  .pipe(
-    mapTo(meta.error || defaultHttpError),
-    map(error => {
+export const defaultError$: HttpErrorEffect<HttpError> = req$ =>
+  req$.pipe(
+    map(({ error = defaultHttpError }) => {
       const status = getStatusCode(error);
       const body = errorFactory(status, error);
       return { status, body };

--- a/packages/core/src/error/specs/error.effect.spec.ts
+++ b/packages/core/src/error/specs/error.effect.spec.ts
@@ -3,11 +3,12 @@ import { defaultError$ } from '../error.effect';
 import { HttpError } from '../error.model';
 
 describe('defaultError$', () => {
-  const incomingRequest = createHttpRequest();
+  const req = createHttpRequest();
   const client = createHttpResponse();
 
   test('maps HttpError', () => {
     const error = new HttpError('test-message', 400);
+    const incomingRequest = { req, error };
     const outgoingResponse = {
       status: 400,
       body: { error: {
@@ -19,11 +20,12 @@ describe('defaultError$', () => {
     Marbles.assertEffect(defaultError$, [
       ['-a-', { a: incomingRequest }],
       ['-a-', { a: outgoingResponse }],
-    ], { client, meta: { error } });
+    ], { client });
   });
 
   test('maps other errors', () => {
     const error = new Error('test-message');
+    const incomingRequest = { req, error };
     const outgoingResponse = {
       status: 500,
       body: { error: {
@@ -39,6 +41,8 @@ describe('defaultError$', () => {
   });
 
   test('maps to "Internal server error" if "error" is not provided', () => {
+    const error = undefined;
+    const incomingRequest = { req, error };
     const outgoingResponse = {
       status: 500,
       body: { error: {

--- a/packages/core/src/listener/http.listener.ts
+++ b/packages/core/src/listener/http.listener.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, OutgoingMessage } from 'http';
 import { pipe } from 'fp-ts/lib/pipeable';
 import * as R from 'fp-ts/lib/Reader';
 import { of, Subject } from 'rxjs';
-import { catchError, defaultIfEmpty, mergeMap, tap, takeWhile } from 'rxjs/operators';
+import { catchError, defaultIfEmpty, mergeMap, tap, takeWhile, map } from 'rxjs/operators';
 import { combineMiddlewares } from '../effects/effects.combiner';
 import {
   HttpEffectResponse,
@@ -35,27 +35,27 @@ export const httpListener = ({
   middlewares = [],
   effects,
   error$ = defaultError$,
-  output$ = out$ => out$,
+  output$ = out$ => out$.pipe(map(o => o.res)),
 }: HttpListenerConfig): R.Reader<Context, HttpListener> => pipe(
   R.ask<Context>(),
   R.map(ctx => {
     const requestSubject$ = new Subject<{ req: HttpRequest; res: HttpResponse }>();
     const combinedMiddlewares = combineMiddlewares(...middlewares);
     const routing = factorizeRouting(effects);
-    const defaultMetadata = createEffectMetadata({ ask: lookup(ctx) });
+    const metadata = createEffectMetadata({ ask: lookup(ctx) });
     const defaultResponse = { status: HttpStatus.NOT_FOUND } as HttpEffectResponse;
 
     requestSubject$.pipe(
       tap(({ req, res }) => res.send = handleResponse(res)(req)),
-      mergeMap(({ req, res }) => combinedMiddlewares(of(req), res, defaultMetadata).pipe(
+      mergeMap(({ req, res }) => combinedMiddlewares(of(req), res, metadata).pipe(
         takeWhile(() => !res.finished),
-        mergeMap(resolveRouting(routing, defaultMetadata)(res)),
+        mergeMap(resolveRouting(routing, metadata)(res)),
         defaultIfEmpty(defaultResponse),
-        mergeMap(out => output$(of(out), res, createEffectMetadata({ ...defaultMetadata, initiator: req }))),
+        mergeMap(out => output$(of({ req, res: out }), res, metadata)),
         tap(res.send),
         catchError(error =>
-          error$(of(req), res, createEffectMetadata({ ...defaultMetadata, error })).pipe(
-            mergeMap(out => output$(of(out), res, createEffectMetadata({ ...defaultMetadata, error }))),
+          error$(of({ req, error }), res, metadata).pipe(
+            mergeMap(out => output$(of({ req, res: out }), res, metadata)),
             tap(res.send),
           ),
         ),

--- a/packages/core/src/operators/matchEvent/matchEvent.operator.spec.ts
+++ b/packages/core/src/operators/matchEvent/matchEvent.operator.spec.ts
@@ -6,7 +6,7 @@ import { Event } from '../../event/event.interface';
 import { ServerEventType, ServerEvent, AllServerEvents, } from '../../server/server.event';
 
 describe('#matchEvent operator', () => {
-  test(`matches incoming string Event`, () => {
+  test(`matches string Event`, () => {
     // given
     const event1: Event = { type: 'TEST_EVENT_1', payload: 1 };
     const event2: Event = { type: 'TEST_EVENT_2', payload: 2 };
@@ -28,7 +28,7 @@ describe('#matchEvent operator', () => {
     ]);
   });
 
-  test(`matches incoming object Event`, () => {
+  test(`matches object Event`, () => {
     // given
     const event1: Event = { type: 'TEST_EVENT_1', payload: 1 };
     const event2: Event = { type: 'TEST_EVENT_2', payload: 2 };
@@ -50,7 +50,7 @@ describe('#matchEvent operator', () => {
     ]);
   });
 
-  test(`matches incoming EventCreator`, () => {
+  test(`matches EventCreator`, () => {
     // given
     const listenEvent: Event = { type: ServerEventType.LISTENING, payload: { port: 80, host: 'localhost' } };
     const closeEvent: Event = { type: ServerEventType.CLOSE, payload: {} };
@@ -67,6 +67,26 @@ describe('#matchEvent operator', () => {
     Marbles.assertEffect(listen$, [
       ['-a-b-c---', { a: closeEvent, b: listenEvent, c: errorEvent }],
       ['---b-----', { b: listenEvent.payload }],
+    ]);
+  });
+
+  test(`matches EventCreator collection`, () => {
+    // given
+    const listenEvent: Event = { type: ServerEventType.LISTENING, payload: { port: 80, host: 'localhost' } };
+    const closeEvent: Event = { type: ServerEventType.CLOSE, payload: {} };
+    const errorEvent: Event = { type: ServerEventType.ERROR, payload: {} };
+
+    // when
+    const listen$ = (event$: Observable<AllServerEvents>) =>
+      event$.pipe(
+        matchEvent(ServerEvent.listening, ServerEvent.error),
+        map(event => event.payload),
+      );
+
+    // then
+    Marbles.assertEffect(listen$, [
+      ['-a-b-c---', { a: closeEvent, b: listenEvent, c: errorEvent }],
+      ['---b-c---', { b: listenEvent.payload, c: errorEvent.payload }],
     ]);
   });
 });

--- a/packages/messaging/src/effects/messaging.effects.interface.ts
+++ b/packages/messaging/src/effects/messaging.effects.interface.ts
@@ -1,5 +1,5 @@
 import { Effect, Event } from '@marblejs/core';
-import { TransportLayerConnection, TransportMessage } from '../transport/transport.interface';
+import { TransportLayerConnection } from '../transport/transport.interface';
 
 type MsgClient = TransportLayerConnection;
 
@@ -9,15 +9,15 @@ export interface MsgMiddlewareEffect<
 > extends MsgEffect<I, O> {}
 
 export interface MsgErrorEffect<
+  I = Event,
   Err extends Error = Error,
-> extends MsgEffect<Event, Event, MsgClient, Err> {}
+> extends MsgEffect<{ event: I; error: Err }, Event, MsgClient> {}
 
 export interface MsgEffect<
   I = Event,
   O = Event,
   Client = MsgClient,
-  Err extends Error = Error,
-> extends Effect<I, O, Client, Err, TransportMessage<any>> {}
+> extends Effect<I, O, Client> {}
 
 export interface MsgOutputEffect<
   I = Event,

--- a/packages/messaging/src/server/messaging.server.spec.ts
+++ b/packages/messaging/src/server/messaging.server.spec.ts
@@ -95,9 +95,10 @@ describe('messagingServer', () => {
           mergeMapTo(throwError(expectedError)),
         );
 
-      const error$: MsgErrorEffect = (event$, _, { error }) =>
+      const error$: MsgErrorEffect = event$ =>
         event$.pipe(
-          tap(e => errorSubject.next([e, error])),
+          tap(({ event, error }) => errorSubject.next([event, error])),
+          map(({ event }) => event),
         );
 
       const server = await runServer(event$, error$);

--- a/packages/websockets/src/effects/ws-effects.interface.ts
+++ b/packages/websockets/src/effects/ws-effects.interface.ts
@@ -11,7 +11,7 @@ export interface WsErrorEffect<
   T extends Error = Error,
   U = Event,
   V = Event
-> extends WsEffect<U, V, MarbleWebSocketClient, T> {}
+> extends WsEffect<{ event: U; error: T }, V, MarbleWebSocketClient> {}
 
 export interface WsConnectionEffect<
   T extends http.IncomingMessage = http.IncomingMessage
@@ -25,5 +25,4 @@ export interface WsEffect<
   T = Event,
   U = Event,
   V = MarbleWebSocketClient,
-  W extends Error = Error,
-> extends Effect<T, U, V, W> {}
+> extends Effect<T, U, V> {}

--- a/packages/websockets/src/error/specs/ws-error.effect.spec.ts
+++ b/packages/websockets/src/error/specs/ws-error.effect.spec.ts
@@ -5,10 +5,11 @@ import { error$ } from '../ws-error.effect';
 describe('error$', () => {
   test('returns stream of error events for defined error object', () => {
     // given
-    const incomingEvent = { type: 'TEST_EVENT' };
-    const error = new EventError(incomingEvent, 'Test error message', { errorData: 'test_error_data' });
+    const event = { type: 'TEST_EVENT' };
+    const error = new EventError(event, 'Test error message', { errorData: 'test_error_data' });
+    const incomingEvent = { event, error };
     const outgoingEvent = {
-      type: incomingEvent.type,
+      type: event.type,
       error: {
         message: error.message,
         data: error.data,
@@ -19,32 +20,34 @@ describe('error$', () => {
     Marbles.assertEffect(error$, [
       ['--a--', { a: incomingEvent }],
       ['--b--', { b: outgoingEvent }],
-    ], { meta: { error } });
+    ]);
   });
 
   test('returns stream of error events for undefined error object', () => {
     // given
-    const incomingEvent = { type: 'TEST_EVENT' };
+    const event = { type: 'TEST_EVENT' };
     const error = undefined;
-    const outgoingEvent = { type: incomingEvent.type, error: {} };
+    const incomingEvent = { event, error };
+    const outgoingEvent = { type: event.type, error: {} };
 
     // then
     Marbles.assertEffect(error$, [
       ['--a--', { a: incomingEvent }],
       ['--b--', { b: outgoingEvent }],
-    ], { meta: { error } });
+    ]);
   });
 
   test('returns stream of error events for undefined event object', () => {
     // given
-    const incomingEvent = undefined;
     const error = undefined;
+    const event = undefined;
+    const incomingEvent = { event, error };
     const outgoingEvent = { type: 'ERROR', error: {} };
 
     // then
     Marbles.assertEffect(error$, [
       ['--a--', { a: incomingEvent }],
       ['--b--', { b: outgoingEvent }],
-    ], { meta: { error } });
+    ]);
   });
 });

--- a/packages/websockets/src/error/ws-error.effect.ts
+++ b/packages/websockets/src/error/ws-error.effect.ts
@@ -8,9 +8,9 @@ const errorFactory = (message: string | undefined, data: any | undefined) => ({
   message, data,
 });
 
-export const error$: WsErrorEffect<EventError> = (event$, _, { error }) =>
+export const error$: WsErrorEffect<EventError> = event$ =>
   event$.pipe(
-    map(event => ({
+    map(({ error, event }) => ({
       type: event ? event.type : DEFAULT_ERROR_CHANNEL,
       error: errorFactory(
         error ? error.message : undefined,

--- a/packages/websockets/src/error/ws-error.handler.ts
+++ b/packages/websockets/src/error/ws-error.handler.ts
@@ -9,6 +9,11 @@ export const handleEffectsError = <IncomingError extends EventError>(
   error$: WsErrorEffect<IncomingError, any, any> | undefined,
 ) => (error: IncomingError) => {
   if (error$) {
-    error$(of(error.event), client, { ...metadata, error }).subscribe(client.sendResponse);
+    const input$ = of({
+      event: error.event,
+      error,
+    });
+
+    error$(input$, client, metadata).subscribe(client.sendResponse);
   }
 };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- When dealing with an error or incoming request in HTTP `output$`, developer had to use the attribute placed in the third effect argument.
`const effect = (req$, client, { initiator, error }) => ...`

Issue Number: N/A


## What is the new behavior?
- In the case of `ErrorEffect` the thrown error is passed to stream directly:

```typescript
const error$: HttpErrorEffect<HttpError> = req$ =>
  req$.pipe(
    map(({ req, error }) => {
      // ...
    }),
  );
```
- In the case of `OutputEffect` the message initiator (eg. initial request) is passed to stream directly:

```typescript
const output$: HttpOutputEffect = out$ =>
  res$.pipe(
    map(({ req, res }) => {
      // ...
    }),
  );
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```