### PR TITLE
fix(core): matchEvent is not infering `Event.raw` attribute

### DIFF
--- a/packages/core/src/event/event.factory.ts
+++ b/packages/core/src/event/event.factory.ts
@@ -1,69 +1,69 @@
-export type EventCreator<T, Payload> = { type: T } & ((...args: any[]) => { type: T; payload: Payload });
+export type EventCreator<T, Payload> = { type: T; raw?: any } & ((...args: any[]) => { type: T; payload: Payload; raw?: any });
 
 // No args
 export function createEvent<T extends string, Payload>(
   type: T, creator?: () => Payload,
-): { type: T } & (() => { type: T; payload: Payload });
+): { type: T } & (() => { type: T; payload: Payload; raw?: any });
 
 // 1 arg, 1 maybe
 export function createEvent<T extends string, Payload, Arg1>(
   type: T, creator: (arg1?: Arg1) => Payload,
-): { type: T } & ((arg1?: Arg1) => { type: T; payload: Payload });
+): { type: T } & ((arg1?: Arg1) => { type: T; payload: Payload; raw?: any });
 // 1 arg
 export function createEvent<T extends string, Payload, Arg1>(
   type: T, creator: (arg1: Arg1) => Payload,
-): { type: T } & ((arg1: Arg1) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1) => { type: T; payload: Payload; raw?: any });
 
 // 2 args, 2 maybe
 export function createEvent<T extends string, Payload, Arg1, Arg2>(
   type: T, creator: (arg1?: Arg1, arg2?: Arg2) => Payload,
-): { type: T } & ((arg1?: Arg1, arg2?: Arg2) => { type: T; payload: Payload });
+): { type: T } & ((arg1?: Arg1, arg2?: Arg2) => { type: T; payload: Payload; raw?: any });
 // 2 args, 1 maybe
 export function createEvent<T extends string, Payload, Arg1, Arg2>(
   type: T, creator: (arg1: Arg1, arg2?: Arg2) => Payload,
-): { type: T } & ((arg1: Arg1, arg2?: Arg2) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1, arg2?: Arg2) => { type: T; payload: Payload; raw?: any });
 // 2 args
 export function createEvent<T extends string, Payload, Arg1, Arg2>(
   type: T, creator: (arg1: Arg1, arg2: Arg2) => Payload,
-): { type: T } & ((arg1: Arg1, arg2: Arg2) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1, arg2: Arg2) => { type: T; payload: Payload; raw?: any });
 
 // 3 args, 3 maybe
 export function createEvent<T extends string, Payload, Arg1, Arg2, Arg3>(
   type: T, creator: (arg1?: Arg1, arg2?: Arg2, arg3?: Arg3) => Payload,
-): { type: T } & ((arg1?: Arg1, arg2?: Arg2, arg3?: Arg3) => { type: T; payload: Payload });
+): { type: T } & ((arg1?: Arg1, arg2?: Arg2, arg3?: Arg3) => { type: T; payload: Payload; raw?: any });
 // 3 args, 2 maybe
 export function createEvent<T extends string, Payload, Arg1, Arg2, Arg3>(
   type: T, creator: (arg1: Arg1, arg2?: Arg2, arg3?: Arg3) => Payload,
-): { type: T } & ((arg1: Arg1, arg2?: Arg2, arg3?: Arg3) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1, arg2?: Arg2, arg3?: Arg3) => { type: T; payload: Payload; raw?: any });
 // 3 args, 1 maybe
 export function createEvent<T extends string, Payload, Arg1, Arg2, Arg3>(
   type: T, creator: (arg1: Arg1, arg2: Arg2, arg3?: Arg3) => Payload,
-): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3?: Arg3) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3?: Arg3) => { type: T; payload: Payload; raw?: any });
 // 3 args
 export function createEvent<T extends string, Payload, Arg1, Arg2, Arg3>(
   type: T, creator: (arg1: Arg1, arg2: Arg2, arg3: Arg3) => Payload,
-): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3: Arg3) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3: Arg3) => { type: T; payload: Payload; raw?: any });
 
 // 4 args, 4 maybe
 export function createEvent<T extends string, Payload, Arg1, Arg2, Arg3, Arg4>(
   type: T, creator: (arg1?: Arg1, arg2?: Arg2, arg3?: Arg3, arg4?: Arg4) => Payload,
-): { type: T } & ((arg1?: Arg1, arg2?: Arg2, arg3?: Arg3, arg4?: Arg4) => { type: T; payload: Payload });
+): { type: T } & ((arg1?: Arg1, arg2?: Arg2, arg3?: Arg3, arg4?: Arg4) => { type: T; payload: Payload; raw?: any });
 // 4 args, 3 maybe
 export function createEvent<T extends string, Payload, Arg1, Arg2, Arg3, Arg4>(
   type: T, creator: (arg1: Arg1, arg2?: Arg2, arg3?: Arg3, arg4?: Arg4) => Payload,
-): { type: T } & ((arg1: Arg1, arg2?: Arg2, arg3?: Arg3, arg4?: Arg4) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1, arg2?: Arg2, arg3?: Arg3, arg4?: Arg4) => { type: T; payload: Payload; raw?: any });
 // 4 args, 2 maybe
 export function createEvent<T extends string, Payload, Arg1, Arg2, Arg3, Arg4>(
   type: T, creator: (arg1: Arg1, arg2: Arg2, arg3?: Arg3, arg4?: Arg4) => Payload,
-): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3?: Arg3, arg4?: Arg4) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3?: Arg3, arg4?: Arg4) => { type: T; payload: Payload; raw?: any });
 // 4 args, 1 maybe
 export function createEvent<T extends string, Payload, Arg1, Arg2, Arg3, Arg4>(
   type: T, creator: (arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4?: Arg4) => Payload,
-): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4?: Arg4) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4?: Arg4) => { type: T; payload: Payload; raw?: any });
 // 4 args
 export function createEvent<T extends string, Payload, Arg1, Arg2, Arg3, Arg4>(
   type: T, creator: (arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) => Payload,
-): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) => { type: T; payload: Payload });
+): { type: T } & ((arg1: Arg1, arg2: Arg2, arg3: Arg3, arg4: Arg4) => { type: T; payload: Payload; raw?: any });
 
 // Any args & basic definition
 export function createEvent<T extends string, Payload extends {}>(


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
```
  return event$.pipe(
    matchEvent(DocumentEvent.createDocument),
    mergeMap(event => event.raw), // TypeError: Property 'raw' does not exist on type [...]
 );
```

## What is the new behavior?
- `matchEvent` - matched Event type contains `raw` attribute

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
