### PR TITLE
fix(messaging): don't crash internal messages stream when unhandled error occurs

### DIFF
--- a/packages/@integration/src/messaging/server.ts
+++ b/packages/@integration/src/messaging/server.ts
@@ -91,6 +91,10 @@ export const microservice = createMicroservice({
   ),
 });
 
+const bootstrap = async () => {
+  await microservice();
+};
+
 if (process.env.NODE_ENV !== 'test') {
-  microservice();
+  bootstrap();
 }

--- a/packages/messaging/src/server/messaging.server.listener.ts
+++ b/packages/messaging/src/server/messaging.server.listener.ts
@@ -98,11 +98,16 @@ export const messagingListener = (config: MessagingListenerConfig = {}) => {
       if (effectsSub.closed) { effectsSub = subscribeEffects(message$); }
     }
 
+    const onSubscribeEffectsClose = () => {
+      effectsSub = subscribeEffects(message$);
+    }
+
     const subscribeEffects = (input$: Observable<TransportMessage<any>>) => input$
       .pipe(takeUntil(conn.close$))
       .subscribe(
         onSubscribeEffectsOutput(conn),
         onSubscribeEffectsError(errorSubject),
+        onSubscribeEffectsClose,
       );
 
     conn.close$


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- When an unhandled error is thrown the internally subscribed `messaging.listener` stream is closed. It results in unhandled incoming messages.

## What is the new behavior?
- The internal messaging stream is automatically reconnecting when the stream is unexpectedly closed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
