### PR TITLE
fix(core): RouteEffect middlewares

### DIFF
--- a/packages/core/src/router/router.factory.ts
+++ b/packages/core/src/router/router.factory.ts
@@ -9,6 +9,7 @@ import {
   RouteEffectGroup,
 } from './router.interface';
 import { factorizeRegExpWithParams } from './router.params.factory';
+import { isNonNullable } from '../+internal/utils';
 
 export const factorizeRouting = (
   routes: (RouteEffect | RouteEffectGroup)[],
@@ -33,7 +34,7 @@ export const factorizeRouting = (
     const method: RoutingMethod = {
       effect: route.effect,
       middleware: middlewares.length
-        ? combineMiddlewares(...middlewares)
+        ? combineMiddlewares(...[...middlewares, route.middleware].filter(isNonNullable))
         : route.middleware,
       parameters,
     };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When the middleware is composed through `r.use` pipe function it is not properly reflected inside the built routing table, which results in the wrong middleware application.

```typescript
const effect$ = r.pipe(
  r.matchPath('/test'),
  r.matchType('GET'),
  r.use(someMiddleware$),
  r.useEffect(req$ => req$.pipe(
    // ...
  )),
);
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
