### PR TITLE
refactor(core): pass `HttpResponse` to `req` object and `HttpServer` instance to `context.client`

### DIFF
--- a/packages/@integration/package.json
+++ b/packages/@integration/package.json
@@ -4,9 +4,9 @@
   "description": "Marble.js integration tests",
   "main": "src/index.ts",
   "scripts": {
-    "start:http": "ts-node --project tsconfig.json src/http/index.ts",
+    "start:http": "PORT=1337 ts-node --project tsconfig.json src/http/index.ts",
     "start:websockets": "ts-node --project tsconfig.json src/websockets/http.server.ts",
-    "start:messaging:server": "ts-node --project tsconfig.json src/messaging/server.ts",
+    "start:messaging:server": "PORT=1337 ts-node --project tsconfig.json src/messaging/server.ts",
     "start:messaging:client": "ts-node --project tsconfig.json src/messaging/client.ts",
     "watch:dev": "nodemon --watch src --ext ts --ignore '*.spec.ts' --exec yarn start",
     "test": "jest --config ../../jest.config.js",

--- a/packages/@integration/src/http/index.ts
+++ b/packages/@integration/src/http/index.ts
@@ -3,6 +3,10 @@ import { merge } from 'rxjs';
 import { tap, map } from 'rxjs/operators';
 import httpListener from './http.listener';
 
+const port = process.env.PORT
+  ? Number(process.env.PORT)
+  : undefined;
+
 const listening$: HttpServerEffect = event$ =>
   event$.pipe(
     matchEvent(ServerEvent.listening),
@@ -11,7 +15,7 @@ const listening$: HttpServerEffect = event$ =>
   );
 
 export const server = createServer({
-  port: 1337,
+  port,
   httpListener,
   event$: (...args) => merge(
     listening$(...args),

--- a/packages/@integration/src/messaging/client.ts
+++ b/packages/@integration/src/messaging/client.ts
@@ -16,6 +16,10 @@ import { merge, forkJoin } from 'rxjs';
 import { tap, map, mergeMap, mapTo } from 'rxjs/operators';
 import { requestValidator$, t } from '@marblejs/middleware-io';
 
+const port = process.env.PORT
+  ? Number(process.env.PORT)
+  : undefined;
+
 const ClientToken = createContextToken<MessagingClient>('MessagingClient');
 
 const client = messagingClient({
@@ -71,7 +75,7 @@ const listening$: HttpServerEffect = event$ =>
   );
 
 export const server = createServer({
-  port: Number(process.env.PORT) || 1337,
+  port,
   httpListener: httpListener({
     middlewares: [logger$()],
     effects: [test$, fib$],

--- a/packages/@integration/test/http.integration.spec.ts
+++ b/packages/@integration/test/http.integration.spec.ts
@@ -1,36 +1,28 @@
 import * as request from 'supertest';
-import { HttpStatus, HttpServer } from '@marblejs/core';
-import { ContentType } from '@marblejs/core/dist/+internal';
+import { HttpStatus } from '@marblejs/core';
+import { ContentType, createHttpServerTestBed } from '@marblejs/core/dist/+internal';
 import { server } from '../src/http';
 
 describe('API integration', () => {
-  let httpServer: HttpServer;
-
-  beforeAll(async () => {
-    httpServer = await server();
-  });
-
-  afterAll(done => {
-    httpServer.close(done);
-  });
+  const httpTestBed = createHttpServerTestBed(server);
 
   test('POST returns 404 when route not found: /', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .post('/')
       .expect(404));
 
   test('GET returns status 200: /api/v1', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1')
       .expect(200, '"API version: v1"'));
 
   test('GET returns status 200: /api/v2', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v2')
       .expect(200, '"API version: v2"'));
 
   test('GET returns status 400: /api/v3 if provided version is not supported', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v3')
       .expect(400, {
         error: {
@@ -50,7 +42,7 @@ describe('API integration', () => {
       }));
 
   test('GET: /api/v1/foo triggers 404 effect', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1/foo')
       .expect(404, {
         error: {
@@ -60,7 +52,7 @@ describe('API integration', () => {
       }));
 
   test('GET returns error response: /api/v1/error', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1/error')
       .expect(HttpStatus.NOT_IMPLEMENTED, {
         error: {
@@ -71,7 +63,7 @@ describe('API integration', () => {
       }));
 
   test('GET returns collection: /api/v1/user', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1/user')
       .set('Authorization', 'Bearer FAKE')
       .expect(200)
@@ -80,7 +72,7 @@ describe('API integration', () => {
       }));
 
   test(`GET returns 200 with Content-Type=application/json: /api/v1/user?email=test%40test.com`, async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1/user?email=test%40test.com')
       .set('Authorization', 'Bearer FAKE')
       .expect(200)
@@ -89,7 +81,7 @@ describe('API integration', () => {
       }));
 
   test('GET returns single object: /api/v1/user/10', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1/user/10')
       .set('Authorization', 'Bearer FAKE')
       .expect(200)
@@ -98,25 +90,25 @@ describe('API integration', () => {
       }));
 
   test('GET returns 404 not found: /api/v1/user/0', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1/user/0')
       .set('Authorization', 'Bearer FAKE')
       .expect(404, { error: { status: 404, message: 'User does not exist' } }));
 
   test('GET returns 401 if not authorized: /api/v1/user/10', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1/user/10')
       .expect(401, { error: { status: 401, message: 'Unauthorized' } }));
 
   test('parses POST body and returns echo for secured route: /api/v1/user', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .post('/api/v1/user')
       .set('Authorization', 'Bearer FAKE')
       .send({ user: { id: 'test_id' } })
       .expect(200, { data: { user: { id: 'test_id' } } }));
 
   test(`parses POST ${ContentType.APPLICATION_X_WWW_FORM_URLENCODED} body and echoes back for secured route: /api/v1/user`, async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .post('/api/v1/user')
       .set('Authorization', 'Bearer FAKE')
       .set('Content-Type', ContentType.APPLICATION_X_WWW_FORM_URLENCODED)
@@ -124,18 +116,18 @@ describe('API integration', () => {
       .expect(200, { data: { user: { id: 'test_id' } } }));
 
   test(`returns static file as ${ContentType.TEXT_HTML}: /api/v1/static/index.html`, async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1/static/index.html')
       .expect('Content-Type', ContentType.TEXT_HTML)
       .then(res => expect(res.text).toContain('<h1>Test</h1>')));
 
   test(`returns static file as ${ContentType.IMAGE_PNG}: /api/v1/static/img/flow.png`, async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v1/static/img/flow.png')
       .expect('Content-Type', ContentType.IMAGE_PNG));
 
   test(`OPTIONS returns 204`, async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .options('/api/v2')
       .set('origin', 'fake-origin')
       .expect('Access-Control-Allow-Methods', 'HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS')
@@ -146,7 +138,7 @@ describe('API integration', () => {
       .expect(204));
 
   test(`GET returns 200`, async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .get('/api/v2')
       .set('origin', 'fake-origin')
       .expect('Access-Control-Allow-Origin', 'fake-origin')

--- a/packages/@integration/test/http.integration.spec.ts
+++ b/packages/@integration/test/http.integration.spec.ts
@@ -1,28 +1,36 @@
 import * as request from 'supertest';
-import { HttpStatus } from '@marblejs/core';
+import { HttpStatus, HttpServer } from '@marblejs/core';
 import { ContentType } from '@marblejs/core/dist/+internal';
-import { server as marbleServer } from '../src/http';
-
-const { server } = marbleServer.config;
+import { server } from '../src/http';
 
 describe('API integration', () => {
+  let httpServer: HttpServer;
+
+  beforeAll(async () => {
+    httpServer = await server();
+  });
+
+  afterAll(done => {
+    httpServer.close(done);
+  });
+
   test('POST returns 404 when route not found: /', async () =>
-    request(server)
+    request(httpServer)
       .post('/')
       .expect(404));
 
   test('GET returns status 200: /api/v1', async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1')
       .expect(200, '"API version: v1"'));
 
   test('GET returns status 200: /api/v2', async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v2')
       .expect(200, '"API version: v2"'));
 
   test('GET returns status 400: /api/v3 if provided version is not supported', async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v3')
       .expect(400, {
         error: {
@@ -42,7 +50,7 @@ describe('API integration', () => {
       }));
 
   test('GET: /api/v1/foo triggers 404 effect', async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1/foo')
       .expect(404, {
         error: {
@@ -52,7 +60,7 @@ describe('API integration', () => {
       }));
 
   test('GET returns error response: /api/v1/error', async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1/error')
       .expect(HttpStatus.NOT_IMPLEMENTED, {
         error: {
@@ -63,7 +71,7 @@ describe('API integration', () => {
       }));
 
   test('GET returns collection: /api/v1/user', async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1/user')
       .set('Authorization', 'Bearer FAKE')
       .expect(200)
@@ -72,7 +80,7 @@ describe('API integration', () => {
       }));
 
   test(`GET returns 200 with Content-Type=application/json: /api/v1/user?email=test%40test.com`, async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1/user?email=test%40test.com')
       .set('Authorization', 'Bearer FAKE')
       .expect(200)
@@ -81,7 +89,7 @@ describe('API integration', () => {
       }));
 
   test('GET returns single object: /api/v1/user/10', async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1/user/10')
       .set('Authorization', 'Bearer FAKE')
       .expect(200)
@@ -90,25 +98,25 @@ describe('API integration', () => {
       }));
 
   test('GET returns 404 not found: /api/v1/user/0', async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1/user/0')
       .set('Authorization', 'Bearer FAKE')
       .expect(404, { error: { status: 404, message: 'User does not exist' } }));
 
   test('GET returns 401 if not authorized: /api/v1/user/10', async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1/user/10')
       .expect(401, { error: { status: 401, message: 'Unauthorized' } }));
 
   test('parses POST body and returns echo for secured route: /api/v1/user', async () =>
-    request(server)
+    request(httpServer)
       .post('/api/v1/user')
       .set('Authorization', 'Bearer FAKE')
       .send({ user: { id: 'test_id' } })
       .expect(200, { data: { user: { id: 'test_id' } } }));
 
   test(`parses POST ${ContentType.APPLICATION_X_WWW_FORM_URLENCODED} body and echoes back for secured route: /api/v1/user`, async () =>
-    request(server)
+    request(httpServer)
       .post('/api/v1/user')
       .set('Authorization', 'Bearer FAKE')
       .set('Content-Type', ContentType.APPLICATION_X_WWW_FORM_URLENCODED)
@@ -116,18 +124,18 @@ describe('API integration', () => {
       .expect(200, { data: { user: { id: 'test_id' } } }));
 
   test(`returns static file as ${ContentType.TEXT_HTML}: /api/v1/static/index.html`, async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1/static/index.html')
       .expect('Content-Type', ContentType.TEXT_HTML)
       .then(res => expect(res.text).toContain('<h1>Test</h1>')));
 
   test(`returns static file as ${ContentType.IMAGE_PNG}: /api/v1/static/img/flow.png`, async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v1/static/img/flow.png')
       .expect('Content-Type', ContentType.IMAGE_PNG));
 
   test(`OPTIONS returns 204`, async () =>
-    request(server)
+    request(httpServer)
       .options('/api/v2')
       .set('origin', 'fake-origin')
       .expect('Access-Control-Allow-Methods', 'HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS')
@@ -138,7 +146,7 @@ describe('API integration', () => {
       .expect(204));
 
   test(`GET returns 200`, async () =>
-    request(server)
+    request(httpServer)
       .get('/api/v2')
       .set('origin', 'fake-origin')
       .expect('Access-Control-Allow-Origin', 'fake-origin')

--- a/packages/@integration/test/messaging.integration.spec.ts
+++ b/packages/@integration/test/messaging.integration.spec.ts
@@ -1,16 +1,18 @@
 import * as request from 'supertest';
-import { server as httpServer } from '../src/messaging/client';
+import { server } from '../src/messaging/client';
 import { microservice as messagingServer } from '../src/messaging/server';
 
-const microservice = messagingServer();
-
-beforeAll(() => microservice);
-beforeAll(() => jest.spyOn(console, 'log').mockImplementation());
-beforeAll(() => jest.spyOn(console, 'info').mockImplementation());
-
 describe('messaging integration', () => {
-  test('GET /fib returns 10, 11, 12, 13, 14 th fibonacci number', async () =>
-    request(httpServer.config.server)
+  const microservice = messagingServer();
+
+  beforeAll(() => microservice);
+  beforeAll(() => jest.spyOn(console, 'log').mockImplementation());
+  beforeAll(() => jest.spyOn(console, 'info').mockImplementation());
+  afterAll(() => microservice.then(con => con.close()));
+
+  test('GET /fib returns 10, 11, 12, 13, 14 th fibonacci number', async () => {
+    const httpServer = await server();
+    return request(httpServer)
       .get('/fib/10')
       .expect(200, [
         { type: 'FIB_RESULT', payload: 55 },
@@ -18,7 +20,7 @@ describe('messaging integration', () => {
         { type: 'FIB_RESULT', payload: 144 },
         { type: 'FIB_RESULT', payload: 233 },
         { type: 'FIB_RESULT', payload: 377 },
-      ]));
+      ]);
+  });
 });
 
-afterAll(() => microservice.then(con => con.close()));

--- a/packages/@integration/test/messaging.integration.spec.ts
+++ b/packages/@integration/test/messaging.integration.spec.ts
@@ -1,18 +1,22 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import * as request from 'supertest';
+import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
+import { createMicroserviceTestBed } from '@marblejs/messaging/dist/+internal/testing';
 import { server } from '../src/messaging/client';
-import { microservice as messagingServer } from '../src/messaging/server';
+import { microservice } from '../src/messaging/server';
 
 describe('messaging integration', () => {
-  const microservice = messagingServer();
+  const httpTestBed = createHttpServerTestBed(server);
+  const microserviceTestBed = createMicroserviceTestBed(microservice);
 
-  beforeAll(() => microservice);
-  beforeAll(() => jest.spyOn(console, 'log').mockImplementation());
-  beforeAll(() => jest.spyOn(console, 'info').mockImplementation());
-  afterAll(() => microservice.then(con => con.close()));
+  beforeAll(async () => {
+    jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'info').mockImplementation();
+  });
 
-  test('GET /fib returns 10, 11, 12, 13, 14 th fibonacci number', async () => {
-    const httpServer = await server();
-    return request(httpServer)
+  test('GET /fib returns 10, 11, 12, 13, 14 th fibonacci number', async () =>
+    request(httpTestBed.getInstance())
       .get('/fib/10')
       .expect(200, [
         { type: 'FIB_RESULT', payload: 55 },
@@ -20,7 +24,7 @@ describe('messaging integration', () => {
         { type: 'FIB_RESULT', payload: 144 },
         { type: 'FIB_RESULT', payload: 233 },
         { type: 'FIB_RESULT', payload: 377 },
-      ]);
-  });
+      ])
+  );
 });
 

--- a/packages/core/src/+internal/testing/http.helper.ts
+++ b/packages/core/src/+internal/testing/http.helper.ts
@@ -40,6 +40,7 @@ export const createHttpRequest = (data?: HttpRequestMockParams) => Object.assign
     query: {},
     params: {},
     meta: {},
+    response: createHttpResponse() as HttpResponse,
   },
   data,
 ) as HttpRequest;
@@ -47,4 +48,8 @@ export const createHttpRequest = (data?: HttpRequestMockParams) => Object.assign
 export const createHttpResponse = (data: HttpResponseMockParams = {}) =>
   new class extends EventEmitter {
     statusCode = data.statusCode;
+    writeHead = jest.fn();
+    setHeader = jest.fn();
+    getHeader = jest.fn();
+    end = jest.fn();
   } as any as HttpResponse;

--- a/packages/core/src/+internal/testing/http.helper.ts
+++ b/packages/core/src/+internal/testing/http.helper.ts
@@ -5,11 +5,13 @@ import {
   HttpMethod,
   RouteParameters,
   QueryParameters,
+  HttpServer,
 } from '../../http.interface';
 import * as http from 'http';
 import { EventEmitter } from 'events';
 import { createContext, lookup } from '../../context/context.factory';
 import { createEffectContext } from '../../effects/effectsContext.factory';
+import { Server } from '../../server/server.interface';
 
 interface HttpRequestMockParams {
   url?: string;
@@ -62,4 +64,22 @@ export const createMockEffectContext = () => {
   const context = createContext();
   const client = http.createServer();
   return createEffectContext({ ask: lookup(context), client });
+};
+
+export const createHttpServerTestBed = (server: Server) => {
+  let httpServer: HttpServer;
+
+  const getInstance = () => httpServer;
+
+  beforeAll(async () => {
+    httpServer = await server();
+  });
+
+  afterAll(done => {
+    httpServer.close(done);
+  });
+
+  return {
+    getInstance,
+  };
 };

--- a/packages/core/src/+internal/testing/http.helper.ts
+++ b/packages/core/src/+internal/testing/http.helper.ts
@@ -6,7 +6,10 @@ import {
   RouteParameters,
   QueryParameters,
 } from '../../http.interface';
+import * as http from 'http';
 import { EventEmitter } from 'events';
+import { createContext, lookup } from '../../context/context.factory';
+import { createEffectContext } from '../../effects/effectsContext.factory';
 
 interface HttpRequestMockParams {
   url?: string;
@@ -16,6 +19,7 @@ interface HttpRequestMockParams {
   headers?: HttpHeaders;
   method?: HttpMethod;
   meta?: Record<string, any>;
+  response?: HttpResponse;
   [key: string]: any;
 }
 
@@ -53,3 +57,9 @@ export const createHttpResponse = (data: HttpResponseMockParams = {}) =>
     getHeader = jest.fn();
     end = jest.fn();
   } as any as HttpResponse;
+
+export const createMockEffectContext = () => {
+  const context = createContext();
+  const client = http.createServer();
+  return createEffectContext({ ask: lookup(context), client });
+};

--- a/packages/core/src/+internal/testing/marbles.helper.ts
+++ b/packages/core/src/+internal/testing/marbles.helper.ts
@@ -20,6 +20,14 @@ export const Marbles = {
     const [initStream, initValues, initError] = marbleflow[0];
     const [expectedStream, expectedValues, expectedError] = marbleflow[1];
 
+    if (initValues) {
+      Object.values(initValues).map(req => req.response = undefined);
+    }
+
+    if (expectedValues) {
+      Object.values(expectedValues).map(req => req.response = undefined);
+    }
+
     const scheduler = Marbles.createTestScheduler();
     const stream$ = scheduler.createColdObservable(initStream, initValues, initError);
 

--- a/packages/core/src/+internal/testing/marbles.helper.ts
+++ b/packages/core/src/+internal/testing/marbles.helper.ts
@@ -20,14 +20,6 @@ export const Marbles = {
     const [initStream, initValues, initError] = marbleflow[0];
     const [expectedStream, expectedValues, expectedError] = marbleflow[1];
 
-    if (initValues) {
-      Object.values(initValues).map(req => req.response = undefined);
-    }
-
-    if (expectedValues) {
-      Object.values(expectedValues).map(req => req.response = undefined);
-    }
-
     const scheduler = Marbles.createTestScheduler();
     const stream$ = scheduler.createColdObservable(initStream, initValues, initError);
 

--- a/packages/core/src/effects/http-effects.interface.ts
+++ b/packages/core/src/effects/http-effects.interface.ts
@@ -1,6 +1,4 @@
-import * as http from 'http';
-import * as https from 'https';
-import { HttpRequest, HttpResponse, HttpStatus, HttpHeaders } from '../http.interface';
+import { HttpRequest, HttpStatus, HttpHeaders, HttpServer } from '../http.interface';
 import { HttpError } from '../error/error.model';
 import { Event } from '../event/event.interface';
 import { Effect } from './effects.interface';
@@ -18,11 +16,11 @@ export interface HttpMiddlewareEffect<
 
 export interface HttpErrorEffect<
   Err extends Error = HttpError,
-> extends HttpEffect<{ req: HttpRequest; error: Err }, HttpEffectResponse, HttpResponse> {}
+> extends HttpEffect<{ req: HttpRequest; error: Err }, HttpEffectResponse> {}
 
 export interface HttpServerEffect<
   Ev extends Event = Event
-> extends HttpEffect<Ev, any, http.Server | https.Server> {}
+> extends HttpEffect<Ev, any, HttpServer> {}
 
 export interface HttpOutputEffect<
   Req extends HttpRequest = HttpRequest,
@@ -32,5 +30,5 @@ export interface HttpOutputEffect<
 export interface HttpEffect<
   I = HttpRequest,
   O = HttpEffectResponse,
-  Client = HttpResponse,
+  Client = HttpServer,
 > extends Effect<I, O, Client> {}

--- a/packages/core/src/effects/specs/effects.combiner.spec.ts
+++ b/packages/core/src/effects/specs/effects.combiner.spec.ts
@@ -1,40 +1,39 @@
+import { of } from 'rxjs';
 import { tap, mapTo, filter } from 'rxjs/operators';
 import { HttpMiddlewareEffect, HttpEffect } from '../http-effects.interface';
 import { combineMiddlewares, combineEffects } from '../effects.combiner';
-import { Marbles, createHttpRequest } from '../../+internal';
+import { Marbles, createHttpRequest, createMockEffectContext } from '../../+internal';
 
 describe('#combineMiddlewares', () => {
-  test('combines middlewares into one stream', () => {
+  test('combines middlewares into one stream', async () => {
     // given
     const a$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => { req.test = 1; }));
     const b$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
     const c$: HttpMiddlewareEffect = req$ => req$.pipe(tap(req => { req.test = req.test + 1; }));
+    const ctx = createMockEffectContext();
     const incomingRequest = createHttpRequest();
-    const outgoingRequest = createHttpRequest({ test: 3 });
+    const outgoingRequest = createHttpRequest({ test: 3, response: incomingRequest.response });
 
     // when
     const middlewares$ = combineMiddlewares(a$, b$, c$);
+    const response = await middlewares$(of(incomingRequest), ctx).toPromise();
 
     // then
-    Marbles.assertEffect(middlewares$, [
-      ['(a|)', { a: incomingRequest }],
-      ['(a|)', { a: outgoingRequest }],
-    ]);
+    expect(response).toEqual(outgoingRequest);
   });
 
-  test('returns stream even if middlewares are not provided', () => {
+  test('returns stream even if middlewares are not provided', async () => {
     // given
+    const ctx = createMockEffectContext();
     const incomingRequest = createHttpRequest();
-    const outgoingRequest = createHttpRequest();
+    const outgoingRequest = createHttpRequest({ response: incomingRequest.response });
 
     // when
     const middlewares$ = combineMiddlewares();
 
     // then
-    Marbles.assertEffect(middlewares$, [
-      ['(a|)', { a: incomingRequest }],
-      ['(a|)', { a: outgoingRequest }],
-    ]);
+    const response = await middlewares$(of(incomingRequest), ctx).toPromise();
+    expect(response).toEqual(outgoingRequest);
   });
 });
 

--- a/packages/core/src/http.interface.ts
+++ b/packages/core/src/http.interface.ts
@@ -1,4 +1,5 @@
 import * as http from 'http';
+import * as https from 'https';
 import { Observable } from 'rxjs';
 import { HttpEffectResponse } from './effects/http-effects.interface';
 
@@ -13,6 +14,7 @@ export interface HttpRequest<
   params: TParams;
   query: TQuery;
   meta?: Record<string, any>;
+  response: HttpResponse;
   [key: string]: any;
 }
 
@@ -42,6 +44,8 @@ export enum HttpMethodType {
   TRACE,
   '*',
 }
+
+export type HttpServer = https.Server | http.Server;
 
 export type HttpMethod = keyof typeof HttpMethodType;
 

--- a/packages/core/src/listener/http.listener.spec.ts
+++ b/packages/core/src/listener/http.listener.spec.ts
@@ -4,13 +4,18 @@ import { mapTo, switchMap } from 'rxjs/operators';
 import { httpListener } from './http.listener';
 import { EffectFactory } from '../effects/effects.factory';
 import { HttpMiddlewareEffect } from '../effects/http-effects.interface';
-import { createContext } from '../context/context.factory';
+import { createContext, registerAll, bindTo } from '../context/context.factory';
+import { ServerClientToken } from '../server/server.tokens';
 
 describe('Http listener', () => {
   let effectsCombiner;
   let responseHandler;
   let routerFactory;
   let routerResolver;
+
+  const context = registerAll([
+    bindTo(ServerClientToken)(jest.fn),
+  ])(createContext());
 
   const effect$ = EffectFactory
     .matchPath('/')
@@ -36,7 +41,6 @@ describe('Http listener', () => {
     // given
     const req = {} as IncomingMessage;
     const res = {} as OutgoingMessage;
-    const context = createContext();
 
     // when
     effectsCombiner.combineMiddlewares = jest.fn(() => () => of(req));
@@ -62,7 +66,6 @@ describe('Http listener', () => {
   test('#httpListener allows empty middlewares', () => {
     // given
     const req = {} as IncomingMessage;
-    const context = createContext();
 
     // when
     effectsCombiner.combineMiddlewares = jest.fn(() => () => of(req));
@@ -81,7 +84,6 @@ describe('Http listener', () => {
     const error = new Error('test');
     const req = {} as IncomingMessage;
     const res = {} as OutgoingMessage;
-    const context = createContext();
     const error$ = jest.fn(() => of({ body: 'error' }));
 
     // when

--- a/packages/core/src/router/router.resolver.ts
+++ b/packages/core/src/router/router.resolver.ts
@@ -1,6 +1,6 @@
 import { EMPTY, Observable, of } from 'rxjs';
 import { mergeMap, takeWhile } from 'rxjs/operators';
-import { HttpMethod, HttpRequest, HttpResponse } from '../http.interface';
+import { HttpMethod, HttpRequest, HttpServer } from '../http.interface';
 import { EffectContext } from '../effects/effects.interface';
 import { HttpEffectResponse } from '../effects/http-effects.interface';
 import { RouteMatched, Routing, RoutingItem } from './router.interface';
@@ -38,8 +38,8 @@ export const findRoute = (
 };
 
 export const resolveRouting =
-  (routing: Routing, effectContext: EffectContext<HttpResponse>) => (req: HttpRequest): Observable<HttpEffectResponse> => {
-    if (effectContext.client.finished) { return EMPTY; }
+  (routing: Routing, effectContext: EffectContext<HttpServer>) => (req: HttpRequest): Observable<HttpEffectResponse> => {
+    if (req.response.finished) { return EMPTY; }
     req.meta = {};
 
     const [urlPath, urlQuery] = req.url.split('?');
@@ -55,7 +55,7 @@ export const resolveRouting =
 
     return middleware
       ? middleware(of(req), effectContext).pipe(
-          takeWhile(() => !effectContext.client.finished),
+          takeWhile(() => !req.response.finished),
           mergeMap(req => routeMatched.effect(of(req), effectContext))
         )
       : routeMatched.effect(of(req), effectContext);

--- a/packages/core/src/router/specs/router.factory.spec.ts
+++ b/packages/core/src/router/specs/router.factory.spec.ts
@@ -8,7 +8,7 @@ import { createHttpRequest } from '../../+internal';
 import { HttpEffect, HttpMiddlewareEffect } from '../../effects/http-effects.interface';
 import { createEffectContext } from '../../effects/effectsContext.factory';
 import { EffectContext } from '../../effects/effects.interface';
-import { HttpResponse } from '../../http.interface';
+import { HttpServer } from '../../http.interface';
 
 describe('#factorizeRouting', () => {
   test('factorizes routing with nested groups', () => {
@@ -83,7 +83,7 @@ describe('#factorizeRouting', () => {
     // given
     const spy = jest.fn();
     const req$ = of(createHttpRequest());
-    const ctx = createEffectContext({} as EffectContext<HttpResponse>);
+    const ctx = createEffectContext({} as EffectContext<HttpServer>);
     const m$: HttpMiddlewareEffect = req$ => req$.pipe(tap(spy));
     const e$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
 

--- a/packages/core/src/router/specs/router.factory.spec.ts
+++ b/packages/core/src/router/specs/router.factory.spec.ts
@@ -4,11 +4,8 @@ import { of } from 'rxjs';
 import { mapTo, tap } from 'rxjs/operators';
 import { RouteEffect, RouteEffectGroup, Routing } from '../router.interface';
 import { factorizeRouting } from '../router.factory';
-import { createHttpRequest } from '../../+internal';
+import { createHttpRequest, createMockEffectContext } from '../../+internal';
 import { HttpEffect, HttpMiddlewareEffect } from '../../effects/http-effects.interface';
-import { createEffectContext } from '../../effects/effectsContext.factory';
-import { EffectContext } from '../../effects/effects.interface';
-import { HttpServer } from '../../http.interface';
 
 describe('#factorizeRouting', () => {
   test('factorizes routing with nested groups', () => {
@@ -82,8 +79,8 @@ describe('#factorizeRouting', () => {
   test('composes routed middlewares', async () => {
     // given
     const spy = jest.fn();
-    const req$ = of(createHttpRequest());
-    const ctx = createEffectContext({} as EffectContext<HttpServer>);
+    const req = createHttpRequest();
+    const ctx = createMockEffectContext();
     const m$: HttpMiddlewareEffect = req$ => req$.pipe(tap(spy));
     const e$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
 
@@ -109,7 +106,7 @@ describe('#factorizeRouting', () => {
     // when
     const factorizedRouting = factorizeRouting(routing);
     const middleware$ = factorizedRouting[0].methods.GET!.middleware!;
-    await middleware$(req$, ctx).toPromise();
+    await middleware$(of(req), ctx).toPromise();
 
     // then
     expect(spy).toHaveBeenCalledTimes(4);

--- a/packages/core/src/router/specs/router.resolver.spec.ts
+++ b/packages/core/src/router/specs/router.resolver.spec.ts
@@ -1,14 +1,10 @@
-import * as http from 'http';
 import { mapTo, tap, map } from 'rxjs/operators';
 import { HttpEffect, HttpMiddlewareEffect } from '../../effects/http-effects.interface';
 import { EffectContext } from '../../effects/effects.interface';
 import { findRoute, resolveRouting } from '../router.resolver';
 import { HttpMethod, HttpServer } from '../../http.interface';
 import { RouteMatched, Routing } from '../router.interface';
-import { createContext } from '../../context/context.factory';
-import { createEffectContext } from '../../effects/effectsContext.factory';
-import { lookup } from '../../context/context.factory';
-import { createHttpRequest } from '../../+internal';
+import { createHttpRequest, createMockEffectContext } from '../../+internal';
 
 describe('#findRoute', () => {
   test('finds route inside collection', () => {
@@ -106,18 +102,14 @@ describe('#findRoute', () => {
 describe('#resolveRouting', () => {
   let router;
   let queryFactory;
-  let effectContext: EffectContext<HttpServer>;
-  const context = createContext();
+  let ctx: EffectContext<HttpServer>;
 
   beforeEach(() => {
     jest.unmock('../router.resolver.ts');
     jest.unmock('../router.query.factory');
     router = require('../router.resolver.ts');
     queryFactory = require('../router.query.factory');
-    effectContext = createEffectContext({
-      ask: lookup(context),
-      client: http.createServer(),
-    });
+    ctx = createMockEffectContext();
   });
 
   test('resolves found effect', done => {
@@ -129,7 +121,7 @@ describe('#resolveRouting', () => {
     // when
     router.findRoute = jest.fn(() => expectedMachingResult);
     queryFactory.queryParamsFactory = jest.fn(() => ({}));
-    const resolvedRoute = resolveRouting([], effectContext)(req);
+    const resolvedRoute = resolveRouting([], ctx)(req);
 
     // then
     resolvedRoute.subscribe(effect => {
@@ -146,7 +138,7 @@ describe('#resolveRouting', () => {
 
     // when
     router.findRoute = jest.fn(() => undefined);
-    const resolvedRoute = resolveRouting([], effectContext)(req);
+    const resolvedRoute = resolveRouting([], ctx)(req);
 
     // then
     resolvedRoute.subscribe(
@@ -171,7 +163,7 @@ describe('#resolveRouting', () => {
     req.response.finished = true;
 
     // when
-    const resolvedRoute = resolveRouting([], effectContext)(req);
+    const resolvedRoute = resolveRouting([], ctx)(req);
 
     // then
     resolvedRoute.subscribe(
@@ -201,7 +193,7 @@ describe('#resolveRouting', () => {
     // when
     router.findRoute = jest.fn(() => expectedMachingResult);
     queryFactory.queryParamsFactory = jest.fn(() => ({}));
-    const resolvedRoute = resolveRouting([], effectContext)(req);
+    const resolvedRoute = resolveRouting([], ctx)(req);
 
     // then
     resolvedRoute.subscribe(effect => {

--- a/packages/core/src/server/server.event.subscriber.ts
+++ b/packages/core/src/server/server.event.subscriber.ts
@@ -1,58 +1,56 @@
 import * as http from 'http';
-import * as https from 'https';
 import * as net from 'net';
-import { Subject, Observable } from 'rxjs';
 import { ServerEventType, ServerEvent, AllServerEvents, isCloseEvent } from './server.event';
 import { AddressInfo } from 'net';
+import { Subject, Observable } from 'rxjs';
 import { takeWhile } from 'rxjs/operators';
+import { HttpServer } from '../http.interface';
 
-export const subscribeServerEvents =
-  (hostname: string) =>
-  (httpServer: http.Server | https.Server): Observable<AllServerEvents> => {
-    const event$ = new Subject<AllServerEvents>();
+export const subscribeServerEvents = (hostname: string) => (httpServer: HttpServer): Observable<AllServerEvents> => {
+  const event$ = new Subject<AllServerEvents>();
 
-    httpServer.on(ServerEventType.CONNECT, (req: http.IncomingMessage, socket: net.Socket, head: Buffer) =>
-      event$.next(ServerEvent.connect(req, socket, head)),
-    );
+  httpServer.on(ServerEventType.CONNECT, (req: http.IncomingMessage, socket: net.Socket, head: Buffer) =>
+    event$.next(ServerEvent.connect(req, socket, head)),
+  );
 
-    httpServer.on(ServerEventType.CONNECTION, (socket: net.Socket) =>
-      event$.next(ServerEvent.connection(socket)),
-    );
+  httpServer.on(ServerEventType.CONNECTION, (socket: net.Socket) =>
+    event$.next(ServerEvent.connection(socket)),
+  );
 
-    httpServer.on(ServerEventType.CLIENT_ERROR, (error: Error, socket: net.Socket) =>
-      event$.next(ServerEvent.clientError(error, socket)),
-    );
+  httpServer.on(ServerEventType.CLIENT_ERROR, (error: Error, socket: net.Socket) =>
+    event$.next(ServerEvent.clientError(error, socket)),
+  );
 
-    httpServer.on(ServerEventType.CLOSE, () =>
-      event$.next(ServerEvent.close()),
-    );
+  httpServer.on(ServerEventType.CLOSE, () =>
+    event$.next(ServerEvent.close()),
+  );
 
-    httpServer.on(ServerEventType.CHECK_CONTINUE, (req: http.IncomingMessage, res: http.ServerResponse) =>
-      event$.next(ServerEvent.checkContinue(req, res)),
-    );
+  httpServer.on(ServerEventType.CHECK_CONTINUE, (req: http.IncomingMessage, res: http.ServerResponse) =>
+    event$.next(ServerEvent.checkContinue(req, res)),
+  );
 
-    httpServer.on(ServerEventType.CHECK_EXPECTATION, (req: http.IncomingMessage, res: http.ServerResponse) =>
-      event$.next(ServerEvent.checkExpectation(req, res)),
-    );
+  httpServer.on(ServerEventType.CHECK_EXPECTATION, (req: http.IncomingMessage, res: http.ServerResponse) =>
+    event$.next(ServerEvent.checkExpectation(req, res)),
+  );
 
-    httpServer.on(ServerEventType.ERROR, (error: Error) =>
-      event$.next(ServerEvent.error(error)),
-    );
+  httpServer.on(ServerEventType.ERROR, (error: Error) =>
+    event$.next(ServerEvent.error(error)),
+  );
 
-    httpServer.on(ServerEventType.REQUEST, (req: http.IncomingMessage, res: http.ServerResponse) =>
-      event$.next(ServerEvent.request(req, res)),
-    );
+  httpServer.on(ServerEventType.REQUEST, (req: http.IncomingMessage, res: http.ServerResponse) =>
+    event$.next(ServerEvent.request(req, res)),
+  );
 
-    httpServer.on(ServerEventType.UPGRADE, (req: http.IncomingMessage, socket: net.Socket, head: Buffer) =>
-      event$.next(ServerEvent.upgrade(req, socket, head)),
-    );
+  httpServer.on(ServerEventType.UPGRADE, (req: http.IncomingMessage, socket: net.Socket, head: Buffer) =>
+    event$.next(ServerEvent.upgrade(req, socket, head)),
+  );
 
-    httpServer.on(ServerEventType.LISTENING, () => {
-      const serverAddressInfo = httpServer.address() as AddressInfo;
-      event$.next(ServerEvent.listening(serverAddressInfo.port, hostname));
-    });
+  httpServer.on(ServerEventType.LISTENING, () => {
+    const serverAddressInfo = httpServer.address() as AddressInfo;
+    event$.next(ServerEvent.listening(serverAddressInfo.port, hostname));
+  });
 
-    return event$
-      .asObservable()
-      .pipe(takeWhile(e => !isCloseEvent(e)));
-  };
+  return event$
+    .asObservable()
+    .pipe(takeWhile(e => !isCloseEvent(e)));
+};

--- a/packages/core/src/server/server.factory.ts
+++ b/packages/core/src/server/server.factory.ts
@@ -1,44 +1,46 @@
 import * as http from 'http';
 import * as https from 'https';
-import { Subject } from 'rxjs';
-import { takeWhile } from 'rxjs/operators';
-import { isCloseEvent, AllServerEvents } from './server.event';
 import { subscribeServerEvents } from './server.event.subscriber';
 import { createContext, lookup, registerAll, bindTo } from '../context/context.factory';
 import { createEffectContext } from '../effects/effectsContext.factory';
 import { CreateServerConfig, Server } from './server.interface';
-import { serverEvent$ } from './server.tokens';
+import {ServerClientToken, ServerEventStreamToken } from './server.tokens';
 
 const DEFAULT_HOSTNAME = '127.0.0.1';
 
 export const createServer = (config: CreateServerConfig): Server => {
   const { httpListener, event$, port, hostname, dependencies = [], options = {} } = config;
-  const serverEventSubject = new Subject<AllServerEvents>();
-  const boundServerEvent$ = bindTo(serverEvent$)(() => serverEventSubject.asObservable());
-  const context = registerAll([ boundServerEvent$, ...dependencies ])(createContext());
 
-  const httpListenerWithContext = httpListener(context);
-  const server = options.httpsOptions
-    ? https.createServer(options.httpsOptions, httpListenerWithContext)
-    : http.createServer(httpListenerWithContext);
+  const server = options.httpsOptions ? https.createServer(options.httpsOptions) : http.createServer();
+  const serverEvent$ = subscribeServerEvents(hostname || DEFAULT_HOSTNAME)(server);
 
-  subscribeServerEvents(hostname || DEFAULT_HOSTNAME)(serverEventSubject)(server);
+  const boundServerEvent$ = bindTo(ServerEventStreamToken)(() => serverEvent$);
+  const boundServer = bindTo(ServerClientToken)(() => server);
+
+  const context = registerAll([
+    boundServer,
+    boundServerEvent$,
+    ...dependencies,
+  ])(createContext());
 
   if (event$) {
     const ctx = createEffectContext({ ask: lookup(context), client: server });
-    event$(serverEventSubject.pipe(takeWhile(e => !isCloseEvent(e))), ctx).subscribe();
+    event$(serverEvent$, ctx).subscribe();
   }
 
   const listen = () => new Promise<https.Server | http.Server>((resolve, reject) => {
     const runningServer = server.listen(port, hostname);
+    const httpListenerWithContext = httpListener(context);
+
+    // @TODO: bind Routing
+
     runningServer.once('listening', () => resolve(runningServer));
     runningServer.once('error', error => reject(error));
+    runningServer.once('close', runningServer.removeAllListeners);
+    runningServer.on('request', httpListenerWithContext);
   });
 
-  listen.config = {
-    ...httpListenerWithContext.config,
-    server,
-  };
+  listen.context = context;
 
   return listen;
 };

--- a/packages/core/src/server/server.factory.ts
+++ b/packages/core/src/server/server.factory.ts
@@ -4,7 +4,7 @@ import { subscribeServerEvents } from './server.event.subscriber';
 import { createContext, lookup, registerAll, bindTo } from '../context/context.factory';
 import { createEffectContext } from '../effects/effectsContext.factory';
 import { CreateServerConfig, Server } from './server.interface';
-import {ServerClientToken, ServerEventStreamToken } from './server.tokens';
+import { ServerClientToken, ServerEventStreamToken } from './server.tokens';
 
 const DEFAULT_HOSTNAME = '127.0.0.1';
 

--- a/packages/core/src/server/server.interface.ts
+++ b/packages/core/src/server/server.interface.ts
@@ -3,8 +3,6 @@ import * as https from 'https';
 import { httpListener } from '../listener/http.listener';
 import { HttpServerEffect } from '../effects/http-effects.interface';
 import { BoundDependency, Context } from '../context/context.factory';
-import { RoutingItem } from '../router/router.interface';
-import { HttpServer } from '../http.interface';
 
 export interface CreateServerConfig {
   port?: number;
@@ -22,9 +20,4 @@ export interface Server {
 
 export interface ServerOptions {
   httpsOptions?: https.ServerOptions;
-}
-
-export interface ServerConfig {
-  server: HttpServer;
-  routing: RoutingItem[];
 }

--- a/packages/core/src/server/server.interface.ts
+++ b/packages/core/src/server/server.interface.ts
@@ -2,8 +2,9 @@ import * as http from 'http';
 import * as https from 'https';
 import { httpListener } from '../listener/http.listener';
 import { HttpServerEffect } from '../effects/http-effects.interface';
-import { BoundDependency } from '../context/context.factory';
+import { BoundDependency, Context } from '../context/context.factory';
 import { RoutingItem } from '../router/router.interface';
+import { HttpServer } from '../http.interface';
 
 export interface CreateServerConfig {
   port?: number;
@@ -16,7 +17,7 @@ export interface CreateServerConfig {
 
 export interface Server {
   (): Promise<https.Server | http.Server>;
-  config: ServerConfig;
+  context: Context;
 }
 
 export interface ServerOptions {
@@ -24,6 +25,6 @@ export interface ServerOptions {
 }
 
 export interface ServerConfig {
-  server: https.Server | http.Server;
+  server: HttpServer;
   routing: RoutingItem[];
 }

--- a/packages/core/src/server/server.tokens.ts
+++ b/packages/core/src/server/server.tokens.ts
@@ -1,5 +1,9 @@
 import { Observable } from 'rxjs';
 import { AllServerEvents } from './server.event';
 import { createContextToken } from '../context/context.token.factory';
+import { HttpServer } from '../http.interface';
+import { Routing } from '../router/router.helpers';
 
-export const serverEvent$ = createContextToken<Observable<AllServerEvents>>();
+export const ServerEventStreamToken = createContextToken<Observable<AllServerEvents>>('ServerEventStreamToken');
+export const ServerClientToken = createContextToken<HttpServer>('ServerClientToken');
+export const ServerRoutingToken = createContextToken<Routing>('ServerRoutingToken');

--- a/packages/core/src/server/specs/server.factory.spec.ts
+++ b/packages/core/src/server/specs/server.factory.spec.ts
@@ -98,7 +98,7 @@ describe('#createServer', () => {
     expect(boundServer).toBeDefined();
   });
 
-  test.only(`emits server events`, async done => {
+  test(`emits server events`, async done => {
     // given
     const app = httpListener({ effects: [] });
 

--- a/packages/messaging/src/+internal/testing/index.ts
+++ b/packages/messaging/src/+internal/testing/index.ts
@@ -1,0 +1,1 @@
+export * from './messaging.testBed';

--- a/packages/messaging/src/+internal/testing/messaging.testBed.ts
+++ b/packages/messaging/src/+internal/testing/messaging.testBed.ts
@@ -1,0 +1,18 @@
+import { Microservice } from '../../server/messaging.server.interface';
+import { TransportLayerConnection } from '../../transport/transport.interface';
+
+export const createMicroserviceTestBed = (microservice: Microservice) => {
+  let connection: TransportLayerConnection;
+
+  const getInstance = () => connection;
+
+  beforeAll(async () => {
+    connection = await microservice();
+  });
+
+  afterAll(async () => connection.close());
+
+  return {
+    getInstance,
+  };
+};

--- a/packages/messaging/src/client/messaging.client.ts
+++ b/packages/messaging/src/client/messaging.client.ts
@@ -1,7 +1,7 @@
 import * as O from 'fp-ts/lib/Option';
 import * as R from 'fp-ts/lib/Reader';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { reader, serverEvent$, matchEvent, ServerEvent, AllServerEvents } from '@marblejs/core';
+import { reader, ServerEventStreamToken,  matchEvent, ServerEvent, AllServerEvents } from '@marblejs/core';
 import { from, Observable, EMPTY } from 'rxjs';
 import { mergeMap, take, map, mapTo, mergeMapTo } from 'rxjs/operators';
 import { TransportMessage, TransportLayerConnection } from '../transport/transport.interface';
@@ -56,7 +56,7 @@ export const messagingClient = (config: MessagingClientConfig) => {
     const connection = transportLayer.connect({ isConsumer: false });
 
     pipe(
-      ask(serverEvent$),
+      ask(ServerEventStreamToken),
       O.map(teardownOnClose$(connection)),
       O.getOrElse(() => EMPTY as Observable<any>),
     ).subscribe();

--- a/packages/messaging/src/server/messaging.server.interface.ts
+++ b/packages/messaging/src/server/messaging.server.interface.ts
@@ -1,7 +1,7 @@
 import { BoundDependency } from '@marblejs/core';
 import { messagingListener } from './messaging.server.listener';
 import { MsgServerEffect } from '../effects/messaging.effects.interface';
-import { TransportStrategy } from '../transport/transport.interface';
+import { TransportStrategy, TransportLayerConnection } from '../transport/transport.interface';
 
 type ConfigurationBase =  {
   messagingListener: ReturnType<typeof messagingListener>;
@@ -13,3 +13,7 @@ export type CreateMicroserviceConfig =
   & TransportStrategy
   & ConfigurationBase
   ;
+
+export interface Microservice {
+  (): Promise<TransportLayerConnection>;
+}

--- a/packages/messaging/src/server/messaging.server.ts
+++ b/packages/messaging/src/server/messaging.server.ts
@@ -1,13 +1,13 @@
 import { createContext, registerAll, bindTo, createEffectContext, lookup, combineEffects } from '@marblejs/core';
 import { Subject } from 'rxjs';
 import { takeWhile } from 'rxjs/operators';
-import { CreateMicroserviceConfig } from './messaging.server.interface';
+import { CreateMicroserviceConfig, Microservice } from './messaging.server.interface';
 import { provideTransportLayer } from '../transport/transport.provider';
 import { TransportLayerToken, ServerEventsToken } from './messaging.server.tokens';
 import { AllServerEvents, isCloseEvent } from './messaging.server.events';
 import { statusLogger$ } from '../middlewares/messaging.statusLogger.middleware';
 
-export const createMicroservice = (config: CreateMicroserviceConfig) => {
+export const createMicroservice = (config: CreateMicroserviceConfig): Microservice => {
   const {
     event$,
     options,

--- a/packages/middleware-body/src/specs/body.middleware.spec.ts
+++ b/packages/middleware-body/src/specs/body.middleware.spec.ts
@@ -1,12 +1,13 @@
-import { HttpRequest, createContext, createEffectContext, lookup } from '@marblejs/core';
-import { Marbles, ContentType, createHttpResponse } from '@marblejs/core/dist/+internal';
+import * as http from 'http';
 import * as qs from 'qs';
-import { of } from 'rxjs';
-import { bodyParser$ } from '../body.middleware';
 import * as MockReq from 'mock-req';
+import { of } from 'rxjs';
+import { HttpRequest, createContext, createEffectContext, lookup } from '@marblejs/core';
+import { Marbles, ContentType } from '@marblejs/core/dist/+internal';
+import { bodyParser$ } from '../body.middleware';
 
 describe('bodyParser$ middleware', () => {
-  const client = createHttpResponse();
+  const client = http.createServer();
   const context = createContext();
   const ctx = createEffectContext({ ask: lookup(context), client });
 

--- a/packages/middleware-body/src/specs/body.middleware.spec.ts
+++ b/packages/middleware-body/src/specs/body.middleware.spec.ts
@@ -1,15 +1,13 @@
-import * as http from 'http';
 import * as qs from 'qs';
 import * as MockReq from 'mock-req';
 import { of } from 'rxjs';
-import { HttpRequest, createContext, createEffectContext, lookup } from '@marblejs/core';
+import { HttpRequest } from '@marblejs/core';
+import { createMockEffectContext } from '@marblejs/core/dist/+internal/testing';
 import { Marbles, ContentType } from '@marblejs/core/dist/+internal';
 import { bodyParser$ } from '../body.middleware';
 
 describe('bodyParser$ middleware', () => {
-  const client = http.createServer();
-  const context = createContext();
-  const ctx = createEffectContext({ ask: lookup(context), client });
+  const ctx = createMockEffectContext();
 
   beforeEach(() => {
     spyOn(console, 'log').and.stub();
@@ -157,7 +155,6 @@ describe('bodyParser$ middleware', () => {
     http$.subscribe(
       () => {
         fail('Exceptions should be thrown');
-        done();
       },
       error => {
         expect(error.message).toBe('Request body parse error');
@@ -181,7 +178,6 @@ describe('bodyParser$ middleware', () => {
     http$.subscribe(
       () => {
         fail('Exceptions should be thrown');
-        done();
       },
       error => {
         expect(error).toBeDefined();

--- a/packages/middleware-body/test/bodyParser.integration.spec.ts
+++ b/packages/middleware-body/test/bodyParser.integration.spec.ts
@@ -1,10 +1,14 @@
 import { ContentType } from '@marblejs/core/dist/+internal/http';
+import { createServer, HttpServer } from '@marblejs/core';
 import * as request from 'supertest';
 import { app } from './bodyParser.integration';
-import { createContext } from '@marblejs/core';
 
 describe('@marblejs/middleware-body - integration', () => {
-  const httpServer = app(createContext());
+  let httpServer: HttpServer;
+
+  beforeEach(async () => {
+    httpServer = await createServer({ httpListener: app })();
+  });
 
   describe('POST /default-parser', () => {
     test(`parses ${ContentType.APPLICATION_JSON} content-type`, async () =>
@@ -33,7 +37,7 @@ describe('@marblejs/middleware-body - integration', () => {
         .post('/multiple-parsers')
         .set({ 'Content-Type': ContentType.APPLICATION_JSON })
         .send(body)
-        .expect(200, body)
+        .expect(200, body),
     );
 
     test(`parses custom "test/json" content-type`, async () =>

--- a/packages/middleware-body/test/bodyParser.integration.spec.ts
+++ b/packages/middleware-body/test/bodyParser.integration.spec.ts
@@ -1,18 +1,16 @@
 import { ContentType } from '@marblejs/core/dist/+internal/http';
-import { createServer, HttpServer } from '@marblejs/core';
+import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
+import { createServer } from '@marblejs/core';
 import * as request from 'supertest';
 import { app } from './bodyParser.integration';
 
 describe('@marblejs/middleware-body - integration', () => {
-  let httpServer: HttpServer;
-
-  beforeEach(async () => {
-    httpServer = await createServer({ httpListener: app })();
-  });
+  const server = createServer({ httpListener: app });
+  const httpTestBed = createHttpServerTestBed(server);
 
   describe('POST /default-parser', () => {
     test(`parses ${ContentType.APPLICATION_JSON} content-type`, async () =>
-      request(httpServer)
+      request(httpTestBed.getInstance())
         .post('/default-parser')
         .set({ 'Content-Type': ContentType.APPLICATION_JSON })
         .send({ id: 'id', name: 'name', age: 100 })
@@ -20,7 +18,7 @@ describe('@marblejs/middleware-body - integration', () => {
     );
 
     test(`parses ${ContentType.APPLICATION_X_WWW_FORM_URLENCODED} content-type`, async () =>
-      request(httpServer)
+      request(httpTestBed.getInstance())
         .post('/default-parser')
         .set({ 'Content-Type': ContentType.APPLICATION_X_WWW_FORM_URLENCODED })
         .send({ id: 'id', name: 'name', age: 100 })
@@ -33,7 +31,7 @@ describe('@marblejs/middleware-body - integration', () => {
     const text = 'test message';
 
     test(`parses ${ContentType.APPLICATION_JSON} content-type`, async () =>
-      request(httpServer)
+      request(httpTestBed.getInstance())
         .post('/multiple-parsers')
         .set({ 'Content-Type': ContentType.APPLICATION_JSON })
         .send(body)
@@ -41,7 +39,7 @@ describe('@marblejs/middleware-body - integration', () => {
     );
 
     test(`parses custom "test/json" content-type`, async () =>
-      request(httpServer)
+      request(httpTestBed.getInstance())
         .post('/multiple-parsers')
         .set({ 'Content-Type': 'test/json' })
         .send(body)
@@ -49,7 +47,7 @@ describe('@marblejs/middleware-body - integration', () => {
     );
 
     test(`parses ${ContentType.APPLICATION_VND_API_JSON} content-type`, async () =>
-      request(httpServer)
+      request(httpTestBed.getInstance())
         .post('/multiple-parsers')
         .set({ 'Content-Type': ContentType.APPLICATION_VND_API_JSON })
         .send(body)
@@ -57,7 +55,7 @@ describe('@marblejs/middleware-body - integration', () => {
     );
 
     test(`parses ${ContentType.TEXT_PLAIN} content-type`, async () =>
-      request(httpServer)
+      request(httpTestBed.getInstance())
         .post('/multiple-parsers')
         .set({ 'Content-Type': ContentType.TEXT_PLAIN })
         .send(text)
@@ -65,7 +63,7 @@ describe('@marblejs/middleware-body - integration', () => {
     );
 
     test(`parses ${ContentType.APPLICATION_OCTET_STREAM} content-type`, async () =>
-      request(httpServer)
+      request(httpTestBed.getInstance())
         .post('/multiple-parsers')
         .set({ 'Content-Type': ContentType.APPLICATION_OCTET_STREAM })
         .send(text)

--- a/packages/middleware-cors/src/middleware.ts
+++ b/packages/middleware-cors/src/middleware.ts
@@ -22,7 +22,7 @@ const DEFAULT_OPTIONS: CORSOptions = {
   optionsSuccessStatus: HttpStatus.NO_CONTENT,
 };
 
-export const cors$ = (options: CORSOptions = {}): HttpMiddlewareEffect => (req$, ctx) => {
+export const cors$ = (options: CORSOptions = {}): HttpMiddlewareEffect => (req$) => {
   options = { ...DEFAULT_OPTIONS, ...options };
 
   return req$.pipe(
@@ -33,10 +33,10 @@ export const cors$ = (options: CORSOptions = {}): HttpMiddlewareEffect => (req$,
       }
 
       if (req.method === 'OPTIONS') {
-        configurePreflightResponse(req, ctx.client, options);
-        ctx.client.end();
+        configurePreflightResponse(req, req.response, options);
+        req.response.end();
       } else {
-        configureResponse(req, ctx.client, options);
+        configureResponse(req, req.response, options);
       }
     }),
   );

--- a/packages/middleware-cors/src/spec/applyHeaders.spec.ts
+++ b/packages/middleware-cors/src/spec/applyHeaders.spec.ts
@@ -1,5 +1,5 @@
+import { createHttpResponse } from '@marblejs/core/dist/+internal/testing';
 import { AccessControlHeader, applyHeaders, ConfiguredHeader } from '../applyHeaders';
-import { createMockResponse } from '../util';
 
 describe('applyHeaders', () => {
   test('should handle many methods correctly', done => {
@@ -7,7 +7,7 @@ describe('applyHeaders', () => {
       { key: AccessControlHeader.Origin, value: '*' },
       { key: AccessControlHeader.Methods, value: 'POST' },
     ];
-    const res = createMockResponse();
+    const res = createHttpResponse();
 
     applyHeaders(configured, res);
 

--- a/packages/middleware-cors/src/spec/configurePreflightResponse.spec.ts
+++ b/packages/middleware-cors/src/spec/configurePreflightResponse.spec.ts
@@ -1,12 +1,13 @@
+import { createHttpResponse } from '@marblejs/core/dist/+internal/testing';
 import { configurePreflightResponse } from '../configurePreflightResponse';
 import { CORSOptions } from '../middleware';
-import { createMockRequest, createMockResponse } from '../util';
+import { createMockRequest } from '../util';
 
 describe('configurePreflightResponse', () => {
   test('should configure headers correctly', done => {
     const origin = 'fake-origin';
     const req = createMockRequest('OPTIONS', { origin });
-    const res = createMockResponse();
+    const res = createHttpResponse();
     const options: CORSOptions = {
       origin: '*',
       methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
@@ -39,7 +40,7 @@ describe('configurePreflightResponse', () => {
   test('should configure headers correctly', done => {
     const origin = 'fake-origin';
     const req = createMockRequest('OPTIONS', { origin });
-    const res = createMockResponse();
+    const res = createHttpResponse();
     const options: CORSOptions = {
       origin: '*',
       withCredentials: false,
@@ -70,7 +71,7 @@ describe('configurePreflightResponse', () => {
   test('should disallow preflight request', done => {
     const origin = 'fake-origin';
     const req = createMockRequest('OPTIONS', { origin });
-    const res = createMockResponse();
+    const res = createHttpResponse();
     const options: CORSOptions = {
       origin: 'another-origin',
       methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
@@ -99,7 +100,7 @@ describe('configurePreflightResponse', () => {
       origin,
       'access-control-request-method': 'GET',
     });
-    const res = createMockResponse();
+    const res = createHttpResponse();
     const options: CORSOptions = {
       origin: 'fake-origin',
       methods: ['OPTIONS'],

--- a/packages/middleware-cors/src/spec/configureResponse.spec.ts
+++ b/packages/middleware-cors/src/spec/configureResponse.spec.ts
@@ -1,14 +1,13 @@
+import { createHttpResponse } from '@marblejs/core/dist/+internal/testing';
 import { configureResponse } from '../configureResponse';
 import { CORSOptions } from '../middleware';
-import { createMockRequest, createMockResponse } from '../util';
-
-
+import { createMockRequest } from '../util';
 
 describe('configureResponse', () => {
   test('should configure response correctly', done => {
     const origin = 'fake-origin';
     const req = createMockRequest('GET', { origin });
-    const res = createMockResponse();
+    const res = createHttpResponse();
     const options: CORSOptions = {
       origin: 'fake-origin',
       methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
@@ -40,7 +39,7 @@ describe('configureResponse', () => {
   test('should configure response correctly', done => {
     const origin = 'fake-origin';
     const req = createMockRequest('GET', { origin });
-    const res = createMockResponse();
+    const res = createHttpResponse();
     const options: CORSOptions = {
       origin: 'fake-origin',
       methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],

--- a/packages/middleware-cors/src/spec/middleware.spec.ts
+++ b/packages/middleware-cors/src/spec/middleware.spec.ts
@@ -29,7 +29,7 @@ describe('CORS middleware', () => {
     const middleware$ = cors$();
 
     middleware$(request$, ctx).subscribe(() => {
-      expect(ctx.client.setHeader).toBeCalledWith('Access-Control-Allow-Origin', 'fake-origin');
+      expect(request.response.setHeader).toBeCalledWith('Access-Control-Allow-Origin', 'fake-origin');
       done();
     });
   });
@@ -53,9 +53,9 @@ describe('CORS middleware', () => {
     const middleware$ = cors$(options);
 
     middleware$(request$, ctx).subscribe(() => {
-      expect(ctx.client.setHeader).toBeCalledWith('Access-Control-Allow-Origin', 'fake-origin');
-      expect(ctx.client.setHeader).toBeCalledWith('Access-Control-Allow-Credentials', 'true');
-      expect(ctx.client.setHeader).toBeCalledWith('Access-Control-Expose-Headers', 'X-Header, X-Custom-Header');
+      expect(request.response.setHeader).toBeCalledWith('Access-Control-Allow-Origin', 'fake-origin');
+      expect(request.response.setHeader).toBeCalledWith('Access-Control-Allow-Credentials', 'true');
+      expect(request.response.setHeader).toBeCalledWith('Access-Control-Expose-Headers', 'X-Header, X-Custom-Header');
       done();
     });
   });

--- a/packages/middleware-cors/src/util.ts
+++ b/packages/middleware-cors/src/util.ts
@@ -1,4 +1,6 @@
-import { HttpResponse, HttpMethod, HttpRequest, createEffectContext, createContext, lookup } from '@marblejs/core';
+import * as http from 'http';
+import { HttpMethod, createEffectContext, createContext, lookup } from '@marblejs/core';
+import { createHttpRequest } from '@marblejs/core/dist/+internal';
 
 export const capitalize = (str: string): string =>
   str
@@ -9,24 +11,13 @@ export const capitalize = (str: string): string =>
 export const isString = (str: any): boolean =>
   typeof str === 'string' || str instanceof String;
 
-
-export const createMockResponse = () => (({
-  writeHead: jest.fn(),
-  setHeader: jest.fn(),
-  getHeader: jest.fn(),
-  end: jest.fn(),
-} as unknown) as HttpResponse);
-
 export const createMockRequest = (
   method: HttpMethod = 'GET',
   headers: any = { origin: 'fake-origin' },
-) => (({
-  method,
-  headers: { ...headers },
-} as unknown) as HttpRequest);
+) => createHttpRequest({ method, headers });
 
 export const createMockEffectContext = () => {
   const context = createContext();
-  const client = createMockResponse();
+  const client = http.createServer();
   return createEffectContext({ ask: lookup(context), client });
 };

--- a/packages/middleware-io/test/io-http.integration.spec.ts
+++ b/packages/middleware-io/test/io-http.integration.spec.ts
@@ -1,17 +1,15 @@
 import * as request from 'supertest';
-import { createServer, HttpServer } from '@marblejs/core';
+import { createServer } from '@marblejs/core';
+import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
 import { app } from './io-http.integration';
 
 describe('@marblejs/middleware-io - HTTP integration', () => {
-  let server: HttpServer;
-
-  beforeEach(async () => {
-    server = await createServer({ httpListener: app })();
-  });
+  const server = createServer({ httpListener: app });
+  const httpTestBed = createHttpServerTestBed(server);
 
   test('POST / returns 200 with user object', async () => {
     const user = { id: 'id', name: 'name', age: 100 };
-    return request(server)
+    return request(httpTestBed.getInstance())
       .post('/')
       .send({ user })
       .expect(200, user);
@@ -19,7 +17,7 @@ describe('@marblejs/middleware-io - HTTP integration', () => {
 
   test('POST / returns 400 with validation error object', async () => {
     const user = { id: 'id', name: 'name', age: '100' };
-    return request(server)
+    return request(httpTestBed.getInstance())
       .post('/')
       .send({ user })
       .expect(400)

--- a/packages/middleware-io/test/io-http.integration.spec.ts
+++ b/packages/middleware-io/test/io-http.integration.spec.ts
@@ -1,21 +1,25 @@
 import * as request from 'supertest';
-import { createContext } from '@marblejs/core';
+import { createServer, HttpServer } from '@marblejs/core';
 import { app } from './io-http.integration';
 
 describe('@marblejs/middleware-io - HTTP integration', () => {
+  let server: HttpServer;
+
+  beforeEach(async () => {
+    server = await createServer({ httpListener: app })();
+  });
+
   test('POST / returns 200 with user object', async () => {
-    const httpServer = app(createContext());
     const user = { id: 'id', name: 'name', age: 100 };
-    return request(httpServer)
+    return request(server)
       .post('/')
       .send({ user })
       .expect(200, user);
   });
 
   test('POST / returns 400 with validation error object', async () => {
-    const httpServer = app(createContext());
     const user = { id: 'id', name: 'name', age: '100' };
-    return request(httpServer)
+    return request(server)
       .post('/')
       .send({ user })
       .expect(400)

--- a/packages/middleware-joi/test/helpers/api.spec-util.ts
+++ b/packages/middleware-joi/test/helpers/api.spec-util.ts
@@ -65,5 +65,7 @@ const middlewares = [
     { stripUnknown: true }
   )
 ];
+
 const effects = [api$];
-export const server = () => httpListener({ middlewares, effects });
+
+export const app = httpListener({ middlewares, effects });

--- a/packages/middleware-joi/test/integration/integration.spec.ts
+++ b/packages/middleware-joi/test/integration/integration.spec.ts
@@ -1,21 +1,18 @@
 import * as request from 'supertest';
-import { HttpServer, createServer } from '@marblejs/core';
+import { createServer } from '@marblejs/core';
+import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
 import { app } from '../helpers/api.spec-util';
 
 describe('Joi middleware - Integration', () => {
   const token = '181782881DB38D84';
-
-  let httpServer: HttpServer;
-
-  beforeEach(async () => {
-    httpServer = await createServer({ httpListener: app })();
-  });
+  const server = createServer({ httpListener: app });
+  const httpTestBed = createHttpServerTestBed(server);
 
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(jest.fn);
   });
 
-  it('should fail without a token', async () => {
+  test('should fail without a token', async () => {
     const expected = {
       error: {
         status: 400,
@@ -23,19 +20,19 @@ describe('Joi middleware - Integration', () => {
       }
     };
 
-    return request(httpServer)
+    return request(httpTestBed.getInstance())
       .get('/api/user/1')
       .then(res => expect(res.body).toEqual(expected));
   });
 
-  it('should send a get request with parameters', async () => {
-    return request(httpServer)
+  test('should send a get request with parameters', async () => {
+    return request(httpTestBed.getInstance())
       .get('/api/user/1')
       .set('token', token)
       .expect(200, { id: 1 });
   });
 
-  it('should send a get request with an invalid param', async () => {
+  test('should send a get request with an invalid param', async () => {
     const expected = {
       error: {
         status: 400,
@@ -43,30 +40,30 @@ describe('Joi middleware - Integration', () => {
       }
     };
 
-    return request(httpServer)
+    return request(httpTestBed.getInstance())
       .get('/api/user/11')
       .set('token', token)
       .then(res => expect(res.body).toEqual(expected));
   });
 
-  it('should send a get request with query', async () => {
-    return request(httpServer)
+  test('should send a get request with query', async () => {
+    return request(httpTestBed.getInstance())
       .get('/api/post?page=2')
       .set('token', token)
       .expect(200, { page: 2 });
   });
 
-  it('should send a post request with body', async () => {
-    return request(httpServer)
+  test('should send a post request with body', async () => {
+    return request(httpTestBed.getInstance())
       .post('/api/user')
       .set('token', token)
       .send({ name: 'lucio' })
       .expect(200, { name: 'lucio', passport: 'marble.js' });
   });
 
-  it('should send a post request with query and body', async () => {
+  test('should send a post request with query and body', async () => {
     const time = Date.now();
-    return request(httpServer)
+    return request(httpTestBed.getInstance())
       .post(`/api/post?timestamp=${time}`)
       .set('token', token)
       .send({ title: 'Middleware Joi' })

--- a/packages/middleware-joi/test/integration/integration.spec.ts
+++ b/packages/middleware-joi/test/integration/integration.spec.ts
@@ -1,10 +1,15 @@
 import * as request from 'supertest';
-import { createContext } from '@marblejs/core';
-import { server } from '../helpers/api.spec-util';
+import { HttpServer, createServer } from '@marblejs/core';
+import { app } from '../helpers/api.spec-util';
 
 describe('Joi middleware - Integration', () => {
-  const app = server()(createContext());
   const token = '181782881DB38D84';
+
+  let httpServer: HttpServer;
+
+  beforeEach(async () => {
+    httpServer = await createServer({ httpListener: app })();
+  });
 
   beforeEach(() => {
     jest.spyOn(console, 'warn').mockImplementation(jest.fn);
@@ -18,13 +23,13 @@ describe('Joi middleware - Integration', () => {
       }
     };
 
-    return request(app)
+    return request(httpServer)
       .get('/api/user/1')
       .then(res => expect(res.body).toEqual(expected));
   });
 
   it('should send a get request with parameters', async () => {
-    return request(app)
+    return request(httpServer)
       .get('/api/user/1')
       .set('token', token)
       .expect(200, { id: 1 });
@@ -38,21 +43,21 @@ describe('Joi middleware - Integration', () => {
       }
     };
 
-    return request(app)
+    return request(httpServer)
       .get('/api/user/11')
       .set('token', token)
       .then(res => expect(res.body).toEqual(expected));
   });
 
   it('should send a get request with query', async () => {
-    return request(app)
+    return request(httpServer)
       .get('/api/post?page=2')
       .set('token', token)
       .expect(200, { page: 2 });
   });
 
   it('should send a post request with body', async () => {
-    return request(app)
+    return request(httpServer)
       .post('/api/user')
       .set('token', token)
       .send({ name: 'lucio' })
@@ -61,7 +66,7 @@ describe('Joi middleware - Integration', () => {
 
   it('should send a post request with query and body', async () => {
     const time = Date.now();
-    return request(app)
+    return request(httpServer)
       .post(`/api/post?timestamp=${time}`)
       .set('token', token)
       .send({ title: 'Middleware Joi' })

--- a/packages/middleware-joi/test/unit/body.spec.ts
+++ b/packages/middleware-joi/test/unit/body.spec.ts
@@ -1,5 +1,5 @@
+import * as http from 'http';
 import { HttpRequest, createContext, createEffectContext, lookup } from '@marblejs/core';
-import { createHttpResponse } from '@marblejs/core/dist/+internal/testing';
 import { bodyParser$ } from '@marblejs/middleware-body';
 import { of } from 'rxjs';
 import { validator$, Joi } from '../../src';
@@ -9,7 +9,7 @@ const MockReq = require('mock-req');
 
 describe('Joi middleware - Body', () => {
   const context = createContext();
-  const client = createHttpResponse();
+  const client = http.createServer();
   const ctx = createEffectContext({ ask: lookup(context), client });
 
   it(`throws an error if doesn't pass a required field`, done => {

--- a/packages/middleware-joi/test/unit/body.spec.ts
+++ b/packages/middleware-joi/test/unit/body.spec.ts
@@ -1,6 +1,6 @@
-import * as http from 'http';
-import { HttpRequest, createContext, createEffectContext, lookup } from '@marblejs/core';
+import { HttpRequest } from '@marblejs/core';
 import { bodyParser$ } from '@marblejs/middleware-body';
+import { createMockEffectContext } from '@marblejs/core/dist/+internal';
 import { of } from 'rxjs';
 import { validator$, Joi } from '../../src';
 
@@ -8,9 +8,7 @@ import { validator$, Joi } from '../../src';
 const MockReq = require('mock-req');
 
 describe('Joi middleware - Body', () => {
-  const context = createContext();
-  const client = http.createServer();
-  const ctx = createEffectContext({ ask: lookup(context), client });
+  const ctx = createMockEffectContext();
 
   it(`throws an error if doesn't pass a required field`, done => {
     expect.assertions(2);

--- a/packages/middleware-jwt/src/spec/jwt.middleware.spec.ts
+++ b/packages/middleware-jwt/src/spec/jwt.middleware.spec.ts
@@ -1,3 +1,4 @@
+import * as http from 'http';
 import {
   HttpRequest,
   HttpError,
@@ -6,7 +7,6 @@ import {
   createEffectContext,
   lookup,
 } from '@marblejs/core';
-import { createHttpResponse } from '@marblejs/core/dist/+internal/testing/http.helper';
 import { authorize$ } from '@marblejs/middleware-jwt/src/jwt.middleware';
 import { of, throwError, iif } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
@@ -23,7 +23,8 @@ const verifyPayload$ = (payload: { id: string }) =>
 describe('JWT middleware', () => {
   let utilModule;
   let factoryModule;
-  const client = createHttpResponse();
+
+  const client = http.createServer();
   const context = createContext();
   const ctx = createEffectContext({ ask: lookup(context), client });
 
@@ -63,7 +64,6 @@ describe('JWT middleware', () => {
       },
       () => {
         fail(`Stream shouldn\'t throw an error`);
-        done();
       }
     );
   });
@@ -116,7 +116,6 @@ describe('JWT middleware', () => {
     middleware$.subscribe(
       () => {
         fail(`Stream should throw an error`);
-        done();
       },
       err => {
         expect(err).toEqual(expectedError);

--- a/packages/middleware-jwt/src/spec/jwt.middleware.spec.ts
+++ b/packages/middleware-jwt/src/spec/jwt.middleware.spec.ts
@@ -1,12 +1,5 @@
-import * as http from 'http';
-import {
-  HttpRequest,
-  HttpError,
-  HttpStatus,
-  createContext,
-  createEffectContext,
-  lookup,
-} from '@marblejs/core';
+import { HttpRequest, HttpError, HttpStatus } from '@marblejs/core';
+import { createMockEffectContext } from '@marblejs/core/dist/+internal';
 import { authorize$ } from '@marblejs/middleware-jwt/src/jwt.middleware';
 import { of, throwError, iif } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
@@ -24,9 +17,7 @@ describe('JWT middleware', () => {
   let utilModule;
   let factoryModule;
 
-  const client = http.createServer();
-  const context = createContext();
-  const ctx = createEffectContext({ ask: lookup(context), client });
+  const ctx = createMockEffectContext();
 
   beforeEach(() => {
     jest.unmock('../jwt.util.ts');

--- a/packages/middleware-jwt/test/jwt.integration.spec.ts
+++ b/packages/middleware-jwt/test/jwt.integration.spec.ts
@@ -1,19 +1,17 @@
 import * as request from 'supertest';
 import { verifyToken } from '../src';
 import { app, SECRET_KEY } from './jwt.integration';
-import { HttpServer, createServer } from '@marblejs/core';
+import { createServer } from '@marblejs/core';
+import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
 
 const LOGIN_CREDENTIALS = { email: 'admin@admin.com', password: 'admin' };
 
 describe('@marblejs/middleware-jwt - HTTP integration', () => {
-  let httpServer: HttpServer;
-
-  beforeEach(async () => {
-    httpServer = await createServer({ httpListener: app })();
-  });
+  const server = createServer({ httpListener: app });
+  const httpTestBed = createHttpServerTestBed(server);
 
   test('POST /api/login returns token and verifies its correctness', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .post('/api/login')
       .send(LOGIN_CREDENTIALS)
       .expect(200)
@@ -28,13 +26,13 @@ describe('@marblejs/middleware-jwt - HTTP integration', () => {
       }));
 
     test('GET /api/secured authorizes request and checks the `req.user` object', async () => {
-      const token = await request(httpServer)
+      const token = await request(httpTestBed.getInstance())
         .post('/api/login')
         .send(LOGIN_CREDENTIALS)
         .expect(200)
         .then(req => req.body.token as string);
 
-      return request(httpServer)
+      return request(httpTestBed.getInstance())
         .get('/api/secured')
         .set('Authorization', `Bearer ${token}`)
         .expect(200)
@@ -47,20 +45,20 @@ describe('@marblejs/middleware-jwt - HTTP integration', () => {
     });
 
     test('GET /api/secured return 401 if payload doesn\'t pass verification', async () => {
-      const token = await request(httpServer)
+      const token = await request(httpTestBed.getInstance())
         .post('/api/login')
         .send({ ...LOGIN_CREDENTIALS, email: 'doesnt_exists@admin.com' })
         .expect(200)
         .then(req => req.body.token as string);
 
-      return request(httpServer)
+      return request(httpTestBed.getInstance())
         .get('/api/secured')
         .set('Authorization', `Bearer ${token}`)
         .expect(401, { error: { status: 401, message: 'Unauthorized' } });
     });
 
     test('GET /api/secured returns 401 if token is wrong', async () =>
-      request(httpServer)
+      request(httpTestBed.getInstance())
         .get('/api/secured')
         .set('Authorization', `Bearer WRONG_TOKEN`)
         .expect(401, { error: { status: 401, message: 'Unauthorized' } }));

--- a/packages/middleware-jwt/test/jwt.integration.spec.ts
+++ b/packages/middleware-jwt/test/jwt.integration.spec.ts
@@ -1,12 +1,16 @@
 import * as request from 'supertest';
 import { verifyToken } from '../src';
 import { app, SECRET_KEY } from './jwt.integration';
-import { createContext } from '@marblejs/core';
+import { HttpServer, createServer } from '@marblejs/core';
 
 const LOGIN_CREDENTIALS = { email: 'admin@admin.com', password: 'admin' };
 
 describe('@marblejs/middleware-jwt - HTTP integration', () => {
-  const httpServer = app(createContext());
+  let httpServer: HttpServer;
+
+  beforeEach(async () => {
+    httpServer = await createServer({ httpListener: app })();
+  });
 
   test('POST /api/login returns token and verifies its correctness', async () =>
     request(httpServer)

--- a/packages/middleware-logger/src/logger.handler.ts
+++ b/packages/middleware-logger/src/logger.handler.ts
@@ -1,20 +1,20 @@
-import { HttpRequest, HttpResponse } from '@marblejs/core';
+import { HttpRequest } from '@marblejs/core';
 import { fromEvent, Timestamp } from 'rxjs';
 import { take, filter, mapTo, map } from 'rxjs/operators';
 import { factorizeLog } from './logger.factory';
 import { LoggerOptions } from './logger.model';
 import { writeToStream, isNotSilent, filterResponse } from './logger.util';
 
-export const loggerHandler = (res: HttpResponse, opts: LoggerOptions) => (stamp: Timestamp<HttpRequest>) =>
-  fromEvent(res, 'finish')
+export const loggerHandler = (opts: LoggerOptions) => (stamp: Timestamp<HttpRequest>) =>
+  fromEvent(stamp.value.response, 'finish')
     .pipe(
       take(1),
       mapTo(stamp.value),
-      map(req => ({ req, res })),
+      map(req => ({ req, res: req.response })),
       filter(isNotSilent(opts)),
       filter(filterResponse(opts)),
     )
-    .subscribe(() => {
+    .subscribe(({ res }) => {
       const { info } = console;
       const log = factorizeLog(res, stamp);
       const streamLog = log({ colorize: false, timestamp: true });

--- a/packages/middleware-logger/src/logger.middleware.ts
+++ b/packages/middleware-logger/src/logger.middleware.ts
@@ -3,10 +3,10 @@ import { timestamp, tap, map } from 'rxjs/operators';
 import { LoggerOptions } from './logger.model';
 import { loggerHandler } from './logger.handler';
 
-export const logger$ = (opts: LoggerOptions = {}): HttpMiddlewareEffect => (req$, ctx) =>
+export const logger$ = (opts: LoggerOptions = {}): HttpMiddlewareEffect => req$ =>
   req$.pipe(
     timestamp(),
-    tap(loggerHandler(ctx.client, opts)),
+    tap(loggerHandler(opts)),
     map(({ value: req }) => req),
   );
 

--- a/packages/middleware-logger/src/logger.util.ts
+++ b/packages/middleware-logger/src/logger.util.ts
@@ -10,7 +10,7 @@ export const isNotSilent = (opts: LoggerOptions) => (_: LoggerCtx) =>
 
 export const filterResponse = (opts: LoggerOptions) => (ctx: LoggerCtx) => pipe(
   O.fromNullable(opts.filter),
-  O.map(filter => filter(ctx.res, ctx.req)),
+  O.map(filter => filter(ctx.res, ctx.req)), // @TODO: use only HttpRequest
   O.getOrElse(() => true),
 );
 

--- a/packages/middleware-logger/src/spec/logger.handler.spec.ts
+++ b/packages/middleware-logger/src/spec/logger.handler.spec.ts
@@ -1,11 +1,9 @@
 import { Timestamp } from 'rxjs';
-import { EventEmitter } from 'events';
 import { WriteStream } from 'fs';
-import { HttpResponse, HttpRequest } from '@marblejs/core';
+import { HttpRequest } from '@marblejs/core';
 import { loggerHandler } from '../logger.handler';
 import { LoggerOptions } from '../logger.model';
-
-class HttpResponseMock extends EventEmitter {}
+import { createHttpRequest } from '@marblejs/core/dist/+internal';
 
 describe('#loggerHandler', () => {
   let loggerUtil;
@@ -25,17 +23,17 @@ describe('#loggerHandler', () => {
 
   test('writes log to provided stream', () => {
     // given
-    const res = new HttpResponseMock() as HttpResponse;
+    const req = createHttpRequest();
     const stream = {} as WriteStream;
     const opts = { silent: false, stream } as LoggerOptions;
-    const stamp = {} as Timestamp<HttpRequest>;
+    const stamp = { value: req, timestamp: 0 } as Timestamp<HttpRequest>;
     const expectedLog = 'test_log';
 
     // when
     loggerUtil.writeToStream = jest.fn();
     loggerFactory.factorizeLog = jest.fn(() => () => expectedLog);
-    loggerHandler(res, opts)(stamp);
-    res.emit('finish');
+    loggerHandler(opts)(stamp);
+    req.response.emit('finish');
 
     // then
     expect(loggerUtil.writeToStream).toHaveBeenCalledWith(stream, expectedLog);
@@ -43,17 +41,17 @@ describe('#loggerHandler', () => {
 
   test('writes log to console.info', () => {
     // given
-    const res = new HttpResponseMock() as HttpResponse;
+    const req = createHttpRequest();
     const opts = { silent: false };
-    const stamp = {} as Timestamp<HttpRequest>;
+    const stamp = { value: req, timestamp: 0 } as Timestamp<HttpRequest>;
     const expectedLog = 'test_log';
 
     // when
     jest.spyOn(console, 'info').mockImplementation(jest.fn());
     loggerUtil.writeToStream = jest.fn();
     loggerFactory.factorizeLog = jest.fn(() => () => expectedLog);
-    loggerHandler(res, opts)(stamp);
-    res.emit('finish');
+    loggerHandler(opts)(stamp);
+    req.response.emit('finish');
 
     // then
     expect(console.info).toHaveBeenCalledWith(expectedLog);

--- a/packages/middleware-logger/src/spec/logger.middleware.spec.ts
+++ b/packages/middleware-logger/src/spec/logger.middleware.spec.ts
@@ -1,14 +1,6 @@
-import * as http from 'http';
 import { of } from 'rxjs';
-import { createHttpRequest } from '@marblejs/core/dist/+internal';
+import { createHttpRequest, createMockEffectContext } from '@marblejs/core/dist/+internal';
 import { logger$, loggerWithOpts$ } from '../logger.middleware';
-import { createEffectContext, createContext, lookup } from '@marblejs/core';
-
-const createMockEffectContext = () => {
-  const context = createContext();
-  const client = http.createServer();
-  return createEffectContext({ ask: lookup(context), client });
-};
 
 beforeEach(() => {
   spyOn(console, 'log').and.stub();

--- a/packages/middleware-logger/src/spec/logger.middleware.spec.ts
+++ b/packages/middleware-logger/src/spec/logger.middleware.spec.ts
@@ -1,10 +1,11 @@
-import { Marbles, createHttpRequest, createHttpResponse } from '@marblejs/core/dist/+internal';
+import * as http from 'http';
+import { Marbles, createHttpRequest } from '@marblejs/core/dist/+internal';
 import { logger$, loggerWithOpts$ } from '../logger.middleware';
 import { createEffectContext, createContext, lookup } from '@marblejs/core';
 
 const createMockEffectContext = () => {
   const context = createContext();
-  const client = createHttpResponse();
+  const client = http.createServer();
   return createEffectContext({ ask: lookup(context), client });
 };
 
@@ -20,14 +21,14 @@ describe('logger$', () => {
     const ctx = createMockEffectContext();
     const request = createHttpRequest({ url: '/', method: 'GET' });
 
-    ctx.client.statusCode = 200;
+    request.response.statusCode = 200;
 
     Marbles.assertEffect(logger$(), [
       ['-a-', { a: request }],
       ['-a-', { a: request }],
     ], { ctx });
 
-    ctx.client.emit('finish');
+    request.response.emit('finish');
     expect(console.info).toHaveBeenCalled();
   });
 
@@ -35,14 +36,14 @@ describe('logger$', () => {
     const ctx = createMockEffectContext();
     const request = createHttpRequest({ url: '/test', method: 'POST' });
 
-    ctx.client.statusCode = 403;
+    request.response.statusCode = 403;
 
     Marbles.assertEffect(logger$(), [
       ['-a-', { a: request }],
       ['-a-', { a: request }],
     ], { ctx });
 
-    ctx.client.emit('finish');
+    request.response.emit('finish');
     expect(console.info).toHaveBeenCalled();
   });
 
@@ -54,7 +55,7 @@ describe('loggerWithOpts$', () => {
     const ctx = createMockEffectContext();
     const request = createHttpRequest({ url: '/', method: 'GET' });
 
-    ctx.client.statusCode = 200;
+    request.response.statusCode = 200;
 
     spyOn(console, 'info').and.stub();
 
@@ -63,7 +64,7 @@ describe('loggerWithOpts$', () => {
       ['-a-', { a: request }],
     ], { ctx });
 
-    ctx.client.emit('finish');
+    request.response.emit('finish');
     expect(console.info).toHaveBeenCalled();
   });
 

--- a/packages/middleware-multipart/src/specs/multipart.middleware.spec.ts
+++ b/packages/middleware-multipart/src/specs/multipart.middleware.spec.ts
@@ -1,8 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import * as rimraf from 'rimraf';
 import * as request from 'supertest';
 import { map } from 'rxjs/operators';
-import { r, use, httpListener, HttpServer, createServer } from '@marblejs/core';
+import { r, use, httpListener, createServer } from '@marblejs/core';
+import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
 import { multipart$ } from '../multipart.middleware';
 import { streamFileTo } from '../multipart.util';
 
@@ -47,25 +49,23 @@ const filesystemMultipart$ = r.pipe(
     }}))
   )));
 
-const app = httpListener({
-  effects: [memoryMultipart$, memoryWithOptionsMultipart$, filesystemMultipart$],
+const server = createServer({
+  httpListener: httpListener({
+    effects: [memoryMultipart$, memoryWithOptionsMultipart$, filesystemMultipart$],
+  }),
 });
 
 describe('multipart$', () => {
-  let httpServer: HttpServer;
-
-  beforeEach(async () => {
-    httpServer = await createServer({ httpListener: app })();
-  });
+  const httpTestBed = createHttpServerTestBed(server);
 
   afterEach(() => {
-    if (fs.existsSync(TMP_PATH)) { fs.rmdirSync(TMP_PATH); }
+    if (fs.existsSync(TMP_PATH)) { rimraf.sync(TMP_PATH); }
   });
 
   test('parses multipart/form-data request with additional fields and stores it in-memory', async () => {
     const data = Buffer.from('test_buffer_1');
 
-    return request(httpServer)
+    return request(httpTestBed.getInstance())
       .post('/memory')
       .field('field_1', 'test_1')
       .field('field_2', 'test_2')
@@ -92,7 +92,7 @@ describe('multipart$', () => {
     const savedFilePath = path.resolve(TMP_PATH, 'data_field');
     const file = fs.readFileSync(uploadFilePath);
 
-    return request(httpServer)
+    return request(httpTestBed.getInstance())
       .post('/filesystem')
       .field('field_1', 'test_1')
       .field('field_2', 'test_2')
@@ -118,7 +118,7 @@ describe('multipart$', () => {
   });
 
   test('throws an error if incoming request is not multipart/form-data', async () =>
-    request(httpServer)
+    request(httpTestBed.getInstance())
       .post('/memory')
       .send({ test: 'test' })
       .expect(412)
@@ -134,7 +134,7 @@ describe('multipart$', () => {
     const data1 = Buffer.from('test_buffer_1');
     const data2 = Buffer.from('test_buffer_2');
 
-    return request(httpServer)
+    return request(httpTestBed.getInstance())
       .post('/memory-with-options')
       .attach('data_field_1', data1)
       .attach('data_field_2', data2)
@@ -148,7 +148,7 @@ describe('multipart$', () => {
   });
 
   test('throws an error if max fields count limit is reached', async () => {
-    return request(httpServer)
+    return request(httpTestBed.getInstance())
       .post('/memory-with-options')
       .field('field_1', 'test_1')
       .field('field_2', 'test_2')
@@ -165,7 +165,7 @@ describe('multipart$', () => {
   test('throws an error if max file size limit is reached', async () => {
     const data = Buffer.from(Array(100).fill(0));
 
-    return request(httpServer)
+    return request(httpTestBed.getInstance())
       .post('/memory-with-options')
       .attach('data_field', data)
       .expect(412)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When talking about HTTP server request handling we have to typically deal with two objects:
1. **HttpRequest** - `http.IncomingMessage`
2. **HttpResponse** - `http.ServerResponse`

They nature expects that they need to be carried together, eg. as a tuple. The current Marble.js HttpEffect API defines that the **HttpResponse** object is carried inside `ctx` object (via second argument) and makes the API blocked for future improvements and optimization (effects can't be eagerly instantiated).

```typescript
const effect$ = r.pipe(
  r.matchPath('/'),
  r.matchType('GET'),
  r.useEffect((req$, ctx) => req$.pipe(
    map(req => ...),
    // ctx.client -- HttpResponse object instance
  )));
```

## What is the new behavior?
1. The aim of this breaking change is to enable further optimizations (#181) and process server requests (messages) as it should be made since the beginning.

```typescript
export interface HttpRequest extends http.IncomingMessage {
  url: string;
  method: HttpMethod;
  body: Body;
  params: Params;
  query: Query;
  meta?: Record<string, any>;
  response: HttpResponse;           // 👈 
}
```

```typescript
const effect$ = r.pipe(
  r.matchPath('/'),
  r.matchType('GET'),
  r.useEffect((req$, ctx) => req$.pipe(
    map(req => ...),
    // req.response -- HttpResponse object
    // ctx.client -- running HTTP/HTTPS server instance
  )));
```

**Why the interface is not like this**: `{ req: HttpRequest, res: HttpResponse }`?
Response object is barely used (only in specialized middlewares) thus mapping it each time to `req` object is extra lame...

2. Routing is no longer provided via return value of `creteServer` method. You will be able to grab it using `context` which is returned together with already running server. 

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```