### PR TITLE
refactor(core, messaging): uniform Listener interface

### DIFF
--- a/packages/core/src/context/context.reader.factory.ts
+++ b/packages/core/src/context/context.reader.factory.ts
@@ -1,0 +1,8 @@
+import { pipe } from 'fp-ts/lib/pipeable';
+import * as R from 'fp-ts/lib/Reader';
+import { ContextProvider, reader } from './context.factory';
+
+export type ReaderHandler<T> = (ask: ContextProvider) => T;
+
+export const createReader = <T>(handler: ReaderHandler<T>) =>
+  pipe(reader, R.map(handler));

--- a/packages/core/src/http/effects/http.effects.interface.ts
+++ b/packages/core/src/http/effects/http.effects.interface.ts
@@ -19,7 +19,7 @@ export interface HttpErrorEffect<
 
 export interface HttpServerEffect<
   Ev extends Event = Event
-> extends HttpEffect<Ev, any, HttpServer> {}
+> extends HttpEffect<Ev, any> {}
 
 export interface HttpOutputEffect<
   Req extends HttpRequest = HttpRequest,
@@ -29,5 +29,4 @@ export interface HttpOutputEffect<
 export interface HttpEffect<
   I = HttpRequest,
   O = HttpEffectResponse,
-  Client = HttpServer,
-> extends Effect<I, O, Client> {}
+> extends Effect<I, O, HttpServer> {}

--- a/packages/core/src/http/server/http.server.listener.ts
+++ b/packages/core/src/http/server/http.server.listener.ts
@@ -29,7 +29,7 @@ export const httpListener = createListener<HttpListenerConfig, HttpListener>(con
     middlewares = [],
     output$,
     error$,
-  } = config;
+  } = config ?? {};
 
   const client = useContext(ServerClientToken)(ask);
   const effectContext = createEffectContext({ ask, client });

--- a/packages/core/src/http/server/http.server.listener.ts
+++ b/packages/core/src/http/server/http.server.listener.ts
@@ -1,62 +1,58 @@
 import { IncomingMessage, OutgoingMessage } from 'http';
-import { pipe } from 'fp-ts/lib/pipeable';
-import * as R from 'fp-ts/lib/Reader';
 import { HttpMiddlewareEffect, HttpErrorEffect, HttpOutputEffect } from '../effects/http.effects.interface';
 import { HttpRequest, HttpResponse } from '../http.interface';
 import { handleResponse } from '../response/http.responseHandler';
-import { RouteEffect, RouteEffectGroup, RoutingItem } from '../router/http.router.interface';
+import { RouteEffect, RouteEffectGroup, Routing } from '../router/http.router.interface';
 import { resolveRouting } from '../router/http.router.resolver.v2';
 import { factorizeRoutingWithDefaults } from '../router/http.router.factory';
 import { ROUTE_NOT_FOUND_ERROR } from '../router/http.router.effects';
-import { Context, lookup } from '../../context/context.factory';
 import { createEffectContext } from '../../effects/effectsContext.factory';
 import { useContext } from '../../context/context.hook';
+import { createListener } from '../../listener/listener.factory';
 import { ServerClientToken } from './http.server.tokens';
 
 export interface HttpListenerConfig {
+  effects?: (RouteEffect | RouteEffectGroup)[];
   middlewares?: HttpMiddlewareEffect[];
-  effects: (RouteEffect | RouteEffectGroup)[];
   error$?: HttpErrorEffect;
   output$?: HttpOutputEffect;
 }
 
 export interface HttpListener {
   (req: IncomingMessage, res: OutgoingMessage): void;
-  config: { routing: RoutingItem[] };
+  config: { routing: Routing };
 };
 
-export const httpListener = ({
-  middlewares = [],
-  effects,
-  output$,
-  error$,
-}: HttpListenerConfig): R.Reader<Context, HttpListener> => pipe(
-  R.ask<Context>(),
-  R.map(ctx => {
-    const ask = lookup(ctx);
-    const client = useContext(ServerClientToken)(ask);
-    const effectContext = createEffectContext({ ask, client });
-    const routing = factorizeRoutingWithDefaults(effects, middlewares);
-    const { resolve, errorSubject } = resolveRouting(routing, effectContext)(output$, error$);
+export const httpListener = createListener<HttpListenerConfig, HttpListener>(config => ask => {
+  const {
+    effects = [],
+    middlewares = [],
+    output$,
+    error$,
+  } = config;
 
-    const httpServer = (req: IncomingMessage, res: OutgoingMessage) => {
-      const marbleReq = req as HttpRequest;
-      const marbleRes = res as HttpResponse;
+  const client = useContext(ServerClientToken)(ask);
+  const effectContext = createEffectContext({ ask, client });
+  const routing = factorizeRoutingWithDefaults(effects, middlewares ?? []);
+  const { resolve, errorSubject } = resolveRouting(routing, effectContext)(output$, error$);
 
-      marbleRes.send = handleResponse(ask)(marbleRes)(marbleReq);
-      marbleReq.response = marbleRes;
+  const httpServer = (req: IncomingMessage, res: OutgoingMessage) => {
+    const marbleReq = req as HttpRequest;
+    const marbleRes = res as HttpResponse;
 
-      const routeSubject = resolve(marbleReq);
+    marbleRes.send = handleResponse(ask)(marbleRes)(marbleReq);
+    marbleReq.response = marbleRes;
 
-      if (routeSubject) {
-        routeSubject.next(marbleReq);
-      } else {
-        errorSubject.next({ req: marbleReq, error: ROUTE_NOT_FOUND_ERROR });
-      }
-    };
+    const routeSubject = resolve(marbleReq);
 
-    httpServer.config = { routing };
+    if (routeSubject) {
+      routeSubject.next(marbleReq);
+    } else {
+      errorSubject.next({ req: marbleReq, error: ROUTE_NOT_FOUND_ERROR });
+    }
+  };
 
-    return httpServer;
-  }),
-);
+  httpServer.config = { routing };
+
+  return httpServer;
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,7 +29,12 @@ export * from './operators';
 export * from './event/event.factory';
 export * from './event/event.interface';
 
+// core - listener
+export * from './listener/listener.factory';
+export * from './listener/listener.interface';
+
 // core - context
 export * from './context/context.factory';
 export * from './context/context.hook';
+export * from './context/context.reader.factory';
 export * from './context/context.token.factory';

--- a/packages/core/src/listener/listener.factory.ts
+++ b/packages/core/src/listener/listener.factory.ts
@@ -3,7 +3,7 @@ import { createReader, ReaderHandler } from '../context/context.reader.factory';
 import { ListenerConfig, Listener } from './listener.interface';
 
 export type ListenerHandler<T extends ListenerConfig, U> =
-  (config: T) => ReaderHandler<U>;
+  (config?: T) => ReaderHandler<U>;
 
 export const createListener = <T extends ListenerConfig, U>(
   handler: ListenerHandler<T, U>

--- a/packages/core/src/listener/listener.factory.ts
+++ b/packages/core/src/listener/listener.factory.ts
@@ -1,0 +1,10 @@
+import { flow } from 'fp-ts/lib/function';
+import { createReader, ReaderHandler } from '../context/context.reader.factory';
+import { ListenerConfig, Listener } from './listener.interface';
+
+export type ListenerHandler<T extends ListenerConfig, U> =
+  (config: T) => ReaderHandler<U>;
+
+export const createListener = <T extends ListenerConfig, U>(
+  handler: ListenerHandler<T, U>
+): Listener<T, U> => flow(handler, createReader);

--- a/packages/core/src/listener/listener.interface.ts
+++ b/packages/core/src/listener/listener.interface.ts
@@ -10,5 +10,5 @@ export interface ListenerConfig<T = any> {
 }
 
 export interface Listener<T extends ListenerConfig, U> {
-  (config: T): Reader<Context, U>;
+  (config?: T): Reader<Context, U>;
 }

--- a/packages/core/src/listener/listener.interface.ts
+++ b/packages/core/src/listener/listener.interface.ts
@@ -1,0 +1,14 @@
+import { Reader } from 'fp-ts/lib/Reader';
+import { Effect } from '../effects/effects.interface';
+import { Context } from '../context/context.factory';
+
+export interface ListenerConfig<T = any> {
+  effects?: any[];
+  middlewares?: any[];
+  error$?: Effect<any, any, T>;
+  output$?: Effect<any, any, T>;
+}
+
+export interface Listener<T extends ListenerConfig, U> {
+  (config: T): Reader<Context, U>;
+}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/core**, **@marblejs/messaging** - Introducing uniform way for creating `Listener` functions 
- **@marblejs/core** - `HttpListenerConfig` - `effects` is not required anymore (it is defaulted to empty array inside)
- **@marblejs/core** - exposed `createReader` function in public API. From now you don't have to write the whole *fp-ts* boilerplate in order to define context reader function

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
