### PR TITLE
feat(core): async dependencies

### DIFF
--- a/packages/@integration/src/http/index.ts
+++ b/packages/@integration/src/http/index.ts
@@ -22,6 +22,10 @@ export const server = createServer({
   ),
 });
 
-if (process.env.NODE_ENV !== 'test') {
-  server();
-}
+export const bootstrap = async () => {
+  const app = await server;
+
+  if (process.env.NODE_ENV !== 'test') app();
+};
+
+bootstrap();

--- a/packages/@integration/src/messaging/client.ts
+++ b/packages/@integration/src/messaging/client.ts
@@ -88,6 +88,10 @@ export const server = createServer({
   ),
 });
 
-if (process.env.NODE_ENV !== 'test') {
-  server();
-}
+export const bootstrap = async () => {
+  const app = await server;
+
+  if (process.env.NODE_ENV !== 'test') app();
+};
+
+bootstrap();

--- a/packages/@integration/src/messaging/server.ts
+++ b/packages/@integration/src/messaging/server.ts
@@ -27,6 +27,10 @@ export const microservice = createMicroservice({
   }),
 });
 
-if (process.env.NODE_ENV !== 'test') {
-  microservice();
-}
+export const bootstrap = async () => {
+  const app = await microservice;
+
+  if (process.env.NODE_ENV !== 'test') app();
+};
+
+bootstrap();

--- a/packages/@integration/src/websockets/http.server.ts
+++ b/packages/@integration/src/websockets/http.server.ts
@@ -13,7 +13,7 @@ import { mapToServer, MarbleWebSocketServer } from '@marblejs/websockets';
 import { logger$ } from '@marblejs/middleware-logger';
 import { merge } from 'rxjs';
 import { tap, map } from 'rxjs/operators';
-import { websocketsServer } from './websockets.server';
+import webSocketListener from './websockets.server';
 
 export const WsServerToken = createContextToken<MarbleWebSocketServer>('MarbleWebSocketServer');
 
@@ -52,7 +52,7 @@ export const server = createServer({
     effects: [root$],
   }),
   dependencies: [
-    bindEagerlyTo(WsServerToken)(websocketsServer),
+    bindEagerlyTo(WsServerToken)(ctx => webSocketListener(ctx)()),
   ],
   event$: (...args) => merge(
     listening$(...args),
@@ -60,6 +60,10 @@ export const server = createServer({
   ),
 });
 
-if (process.env.NODE_ENV !== 'test') {
-  server();
-}
+export const bootstrap = async () => {
+  const app = await server;
+
+  if (process.env.NODE_ENV !== 'test') app();
+};
+
+bootstrap();

--- a/packages/@integration/src/websockets/websockets.server.ts
+++ b/packages/@integration/src/websockets/websockets.server.ts
@@ -38,8 +38,8 @@ const connection$: WsConnectionEffect = req$ =>
     )),
   );
 
-export const websocketsServer = webSocketListener({
+export default webSocketListener({
   middlewares: [logger$],
   effects: [add$],
   connection$,
-})();
+});

--- a/packages/core/src/+internal/testing/http.helper.ts
+++ b/packages/core/src/+internal/testing/http.helper.ts
@@ -67,13 +67,14 @@ export const createMockEffectContext = () => {
   return createEffectContext({ ask: lookup(context), client });
 };
 
-export const createHttpServerTestBed = (server: Server) => {
+export const createHttpServerTestBed = (server: Promise<Server>) => {
   let httpServer: HttpServer;
 
   const getInstance = () => httpServer;
 
   beforeAll(async () => {
-    httpServer = await server();
+    const app = await server;
+    httpServer = await app();
   });
 
   afterAll(done => {
@@ -84,3 +85,5 @@ export const createHttpServerTestBed = (server: Server) => {
     getInstance,
   };
 };
+
+export type HttpServerTestBed = ReturnType<typeof createHttpServerTestBed>;

--- a/packages/core/src/context/context.factory.ts
+++ b/packages/core/src/context/context.factory.ts
@@ -47,18 +47,18 @@ const isLazyDependency = (x: any): x is ContextLazyReader => {
 
 export const createContext = () => M.empty;
 
-export const register = <T>(boundDependency: BoundDependency<T, ContextDependency>) => (context: Context): Context =>
+export const register = <T>(boundDependency: BoundDependency<T, ContextDependency>) => async (context: Context): Promise<Context> =>
   M.insertAt(setoidContextToken)(
     boundDependency.token,
     isEagerDependency(boundDependency.dependency)
-      ? boundDependency.dependency.eval(context)
+      ? await Promise.resolve(boundDependency.dependency.eval(context))
       : boundDependency.dependency,
   )(context);
 
-export const registerAll = (boundDependencies: BoundDependency<any, any>[]) => (context: Context): Context =>
+export const registerAll = (boundDependencies: BoundDependency<any, any>[]) => async (context: Context): Promise<Context> =>
   boundDependencies.reduce(
-    (ctx, dependency) => register(dependency)(ctx),
-    context,
+    async (ctx, dependency) => await register(dependency)(await ctx),
+    Promise.resolve(context),
   );
 
 export const lookup = (context: Context) => <T>(token: ContextToken<T>): O.Option<T> => pipe(

--- a/packages/core/src/context/specs/context.hook.spec.ts
+++ b/packages/core/src/context/specs/context.hook.spec.ts
@@ -7,14 +7,14 @@ describe('#useContext', () => {
     jest.spyOn(console, 'error').mockImplementation();
   });
 
-  test('injects bound dependency', () => {
+  test('injects bound dependency', async () => {
     // given
     const token1 = createContextToken('token_1');
     const token2 = createContextToken('token_2');
     const dependency1 = 'dependency_1';
     const dependency2 = 'dependency_2';
 
-    const context = registerAll([
+    const context = await registerAll([
       bindTo(token1)(() => dependency1),
       bindTo(token2)(() => dependency2),
     ])(createContext());
@@ -30,13 +30,13 @@ describe('#useContext', () => {
     expect(resolvedDependency2).toEqual(dependency2);
   });
 
-  test('throws an error if dependency is not bound', () => {
+  test('throws an error if dependency is not bound', async () => {
     // given
     const token1 = createContextToken('token_1');
     const token2 = createContextToken('token_2');
     const dependency1 = 'dependency_1';
 
-    const context = registerAll([
+    const context = await registerAll([
       bindTo(token1)(() => dependency1),
     ])(createContext());
 

--- a/packages/core/src/context/specs/context.hook.spec.ts
+++ b/packages/core/src/context/specs/context.hook.spec.ts
@@ -7,14 +7,14 @@ describe('#useContext', () => {
     jest.spyOn(console, 'error').mockImplementation();
   });
 
-  test('injects bound dependency', async () => {
+  test('injects bound dependency', () => {
     // given
     const token1 = createContextToken('token_1');
     const token2 = createContextToken('token_2');
     const dependency1 = 'dependency_1';
     const dependency2 = 'dependency_2';
 
-    const context = await registerAll([
+    const context = registerAll([
       bindTo(token1)(() => dependency1),
       bindTo(token2)(() => dependency2),
     ])(createContext());
@@ -30,13 +30,13 @@ describe('#useContext', () => {
     expect(resolvedDependency2).toEqual(dependency2);
   });
 
-  test('throws an error if dependency is not bound', async () => {
+  test('throws an error if dependency is not bound', () => {
     // given
     const token1 = createContextToken('token_1');
     const token2 = createContextToken('token_2');
     const dependency1 = 'dependency_1';
 
-    const context = await registerAll([
+    const context = registerAll([
       bindTo(token1)(() => dependency1),
     ])(createContext());
 

--- a/packages/core/src/http/server/http.server.ts
+++ b/packages/core/src/http/server/http.server.ts
@@ -10,7 +10,7 @@ import { CreateServerConfig, Server } from './http.server.interface';
 
 const DEFAULT_HOSTNAME = '127.0.0.1';
 
-export const createServer = (config: CreateServerConfig): Server => {
+export const createServer = async (config: CreateServerConfig): Promise<Server> => {
   const { httpListener, event$, port, hostname, dependencies = [], options = {} } = config;
 
   const server = options.httpsOptions ? https.createServer(options.httpsOptions) : http.createServer();
@@ -20,7 +20,7 @@ export const createServer = (config: CreateServerConfig): Server => {
   const boundServer = bindTo(ServerClientToken)(() => server);
   const boundServerRequestMetadataStorage = bindTo(ServerRequestMetadataStorageToken)(serverRequestMetadataStorage);
 
-  const context = registerAll([
+  const context = await registerAll([
     boundServer,
     boundServerEvent$,
     ...insertIf(isTestingMetadataOn(), boundServerRequestMetadataStorage),

--- a/packages/core/src/http/server/specs/http.server.listener.spec.ts
+++ b/packages/core/src/http/server/specs/http.server.listener.spec.ts
@@ -11,8 +11,8 @@ describe('Http listener', () => {
   let responseHandler;
   let context: Context;
 
-  beforeAll(async () => {
-    context = await registerAll([
+  beforeAll(() => {
+    context = registerAll([
       bindTo(ServerClientToken)(() => http.createServer()),
     ])(createContext());
   });

--- a/packages/core/src/http/server/specs/http.server.listener.spec.ts
+++ b/packages/core/src/http/server/specs/http.server.listener.spec.ts
@@ -4,15 +4,18 @@ import { mapTo, mergeMap } from 'rxjs/operators';
 import { r } from '../../router/http.router.ixbuilder';
 import { httpListener } from '../http.server.listener';
 import { HttpMiddlewareEffect, HttpEffectResponse } from '../../effects/http.effects.interface';
-import { createContext, registerAll, bindTo } from '../../../context/context.factory';
+import { createContext, registerAll, bindTo, Context } from '../../../context/context.factory';
 import { ServerClientToken } from '../http.server.tokens';
 
 describe('Http listener', () => {
   let responseHandler;
+  let context: Context;
 
-  const context = registerAll([
-    bindTo(ServerClientToken)(() => http.createServer()),
-  ])(createContext());
+  beforeAll(async () => {
+    context = await registerAll([
+      bindTo(ServerClientToken)(() => http.createServer()),
+    ])(createContext());
+  });
 
   beforeEach(() => {
     jest.unmock('../../response/http.responseHandler.ts');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export * from './http/effects/http.effects.interface';
 export * from './http/server/http.server.event';
 export * from './http/server/http.server.interface';
 export * from './http/server/http.server.tokens';
-export * from './http/server/http.server.factory';
+export * from './http/server/http.server';
 export * from './http/server/http.server.listener';
 export * from './http/http.interface';
 

--- a/packages/messaging/src/+internal/testing/messaging.testBed.ts
+++ b/packages/messaging/src/+internal/testing/messaging.testBed.ts
@@ -1,13 +1,14 @@
 import { Microservice } from '../../server/messaging.server.interface';
 import { TransportLayerConnection } from '../../transport/transport.interface';
 
-export const createMicroserviceTestBed = (microservice: Microservice) => {
+export const createMicroserviceTestBed = (microservice: Promise<Microservice>) => {
   let connection: TransportLayerConnection;
 
   const getInstance = () => connection;
 
   beforeAll(async () => {
-    connection = await microservice();
+    const app = await microservice;
+    connection = await app();
   });
 
   afterAll(async () => connection.close());

--- a/packages/messaging/src/server/messaging.server.ts
+++ b/packages/messaging/src/server/messaging.server.ts
@@ -7,7 +7,7 @@ import { CreateMicroserviceConfig, Microservice } from './messaging.server.inter
 import { TransportLayerToken, ServerEventsToken } from './messaging.server.tokens';
 import { AllServerEvents, isCloseEvent, ServerEvent } from './messaging.server.events';
 
-export const createMicroservice = (config: CreateMicroserviceConfig): Microservice => {
+export const createMicroservice = async (config: CreateMicroserviceConfig): Promise<Microservice> => {
   const {
     event$,
     options,
@@ -20,7 +20,7 @@ export const createMicroservice = (config: CreateMicroserviceConfig): Microservi
   const transportLayer = provideTransportLayer(transport, options);
   const boundTransportLayer = bindTo(TransportLayerToken)(() => transportLayer);
   const boundServerEvents = bindTo(ServerEventsToken)(() => serverEventsSubject);
-  const context = registerAll([ boundTransportLayer, boundServerEvents, ...dependencies ])(createContext());
+  const context = await registerAll([ boundTransportLayer, boundServerEvents, ...dependencies ])(createContext());
   const listener = messagingListener(context);
 
   const serverEvent$ = serverEventsSubject.asObservable().pipe(takeWhile(e => !isCloseEvent(e)));

--- a/packages/messaging/src/util/messaging.test.util.ts
+++ b/packages/messaging/src/util/messaging.test.util.ts
@@ -10,7 +10,7 @@ export const runServer = (transport: any, options: any) => (effect$?: MsgEffect,
     options,
     transport,
     messagingListener: messagingListener(effect$ ? { effects: [effect$], output$ } : undefined),
-  })();
+  }).then(app => app());
 
 export const runClient = (transport: Transport, transportOptions: any) =>
   provideTransportLayer(transport, transportOptions).connect({ isConsumer: false });

--- a/packages/middleware-io/test/io-ws.integration.spec.ts
+++ b/packages/middleware-io/test/io-ws.integration.spec.ts
@@ -1,6 +1,6 @@
+import { createContext } from '@marblejs/core';
 import { createWebSocketsTestBed } from '@marblejs/websockets/dist/+internal';
 import { app } from './io-ws.integration';
-import { createContext } from '@marblejs/core';
 
 describe('@marblejs/middleware-io - WebSocket integration', () => {
   const testBed = createWebSocketsTestBed();
@@ -17,7 +17,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
     const context = createContext();
 
     // when
-    app({ server })(context);
+    app(context)({ server });
     targetClient.once('open', () => targetClient.send(event));
 
     // then
@@ -43,7 +43,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
     };
 
     // when
-    app({ server })(context);
+    app(context)({ server });
     targetClient.once('open', () => targetClient.send(event));
 
     // then


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/core** - asynchronous dependency binding

The application start should be delayed until one or more asynchronous tasks are completed. For example, you may not want to start accepting requests until the connection with the database has been established.

The syntax for this is to use async/await with the for reader dependencies. The factory returns a Promise, and the factory function can await asynchronous tasks. Context container (including Marble app factory) will await resolution of the promise before instantiating any reader that depends on (injects) async reader.

**Syntax:**
The async binding is only possible to trigger with eager binding via `bindEagerlyTo` function.
```typescript
bindEagerlyTo(Token)(async () => {

  // some async stuff ...

  return 'some_value';
});

// ...

const foo = useContext(Token)(ask);   // foo === 'some_value'
```

Note that if you will use lazy binding via `bindTo`/`bindLazilyTo` function, you will get:
```typescript
bindTo(Token)(async () => {

  // some async stuff ...

  return 'some_value';
});

// ...

const foo = useContext(Token)(ask);   // foo === Promise<'some_value'>
```

- **@marblejs/core** - Due to the async nature of context resolving, all server-like factory functions will return a Promise.

```typescript
const server = createServer({
  httpListener: httpListener(),
});

const bootstrap = async () => {
  const app = await server;
  app();
};
```

- **@marblejs/core** - eager dependencies can be evaluated regardless of their binding order

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```