### PR TITLE
fix(cors): return EMPTY stream if CORS request is handled

### DIFF
--- a/packages/middleware-cors/src/middleware.ts
+++ b/packages/middleware-cors/src/middleware.ts
@@ -1,7 +1,7 @@
 import { isString } from 'util';
-import { tap } from 'rxjs/operators';
+import { of, EMPTY } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
 import { HttpMethod, HttpMiddlewareEffect, HttpStatus } from '@marblejs/core';
-
 import { configurePreflightResponse } from './configurePreflightResponse';
 import { configureResponse } from './configureResponse';
 
@@ -26,17 +26,21 @@ export const cors$ = (options: CORSOptions = {}): HttpMiddlewareEffect => (req$)
   options = { ...DEFAULT_OPTIONS, ...options };
 
   return req$.pipe(
-    tap(req => {
+    mergeMap(req => {
       // skip if not a CORS request
       if (!isString(req.headers.origin)) {
-        return;
+        return of(req);
       }
 
       if (req.method === 'OPTIONS') {
         configurePreflightResponse(req, req.response, options);
         req.response.end();
+
+        return EMPTY;
       } else {
         configureResponse(req, req.response, options);
+
+        return of(req);
       }
     }),
   );

--- a/packages/middleware-cors/src/spec/middleware.spec.ts
+++ b/packages/middleware-cors/src/spec/middleware.spec.ts
@@ -28,10 +28,14 @@ describe('CORS middleware', () => {
 
     const middleware$ = cors$();
 
-    middleware$(request$, ctx).subscribe(() => {
-      expect(request.response.setHeader).toBeCalledWith('Access-Control-Allow-Origin', 'fake-origin');
-      done();
-    });
+    middleware$(request$, ctx).subscribe(
+      () => fail('Should not return any further value.'),
+      undefined,
+      () => {
+        expect(request.response.setHeader).toBeCalledWith('Access-Control-Allow-Origin', 'fake-origin');
+        done();
+      },
+    );
   });
 
   test('handle CORS request', done => {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/middleware-cors** - processes a stream of requests further even if the response is sent 


## What is the new behavior?
- **@marblejs/middleware-cors** - kill stream processing if the response is sent via returning EMPTY stream

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
