### PR TITLE
feat(core): continuous HTTP stream

### DIFF
--- a/packages/@integration/src/http/effects/static.effects.ts
+++ b/packages/@integration/src/http/effects/static.effects.ts
@@ -17,39 +17,50 @@ const getFileValidator$ = requestValidator$({
 const postFile$ = r.pipe(
   r.matchPath('/upload'),
   r.matchType('POST'),
-  r.useEffect(req$ => req$.pipe(
-    use(multipart$({
-      files: ['image_1'],
-      stream: streamFileTo(TMP_PATH),
-    })),
-    map(req => ({
-      body: {
-        file: req.files,
-        body: req.body,
-      },
-    }))
-  )));
+  r.useEffect(req$ => {
+    console.log('Effect bootstrapped: "postFile$"');
+
+    return req$.pipe(
+      use(multipart$({
+        files: ['image_1'],
+        stream: streamFileTo(TMP_PATH),
+      })),
+      map(req => ({
+        body: {
+          file: req.files,
+          body: req.body,
+        },
+      }))
+    );
+  }));
 
 const getFileStream$ = r.pipe(
   r.matchPath('/stream/:dir*'),
   r.matchType('GET'),
-  r.useEffect(req$ => req$.pipe(
-    use(getFileValidator$),
-    map(req => req.params.dir),
-    map(dir => fs.createReadStream(path.resolve(STATIC_PATH, dir))),
-    map(body => ({ body })),
-  )),
-);
+  r.useEffect(req$ => {
+    console.log('Effect bootstrapped: "getFileStream$"');
+
+    return req$.pipe(
+      use(getFileValidator$),
+      map(req => req.params.dir),
+      map(dir => fs.createReadStream(path.resolve(STATIC_PATH, dir))),
+      map(body => ({ body })),
+    );
+  }));
 
 const getFile$ = r.pipe(
   r.matchPath('/:dir*'),
   r.matchType('GET'),
-  r.useEffect(req$ => req$.pipe(
-    use(getFileValidator$),
-    map(req => req.params.dir),
-    mergeMap(readFile(STATIC_PATH)),
-    map(body => ({ body }))
-  )));
+  r.useEffect(req$ => {
+    console.log('Effect bootstrapped: "getFile$"');
+
+    return req$.pipe(
+      use(getFileValidator$),
+      map(req => req.params.dir),
+      mergeMap(readFile(STATIC_PATH)),
+      map(body => ({ body }))
+    );
+  }));
 
 export const static$ = combineRoutes(
   '/static',

--- a/packages/core/src/+internal/utils/array.util.ts
+++ b/packages/core/src/+internal/utils/array.util.ts
@@ -16,4 +16,4 @@ export const mapArray = <T, R>(f: (v: T) => R) => (array: T[]) =>
   array.map(f);
 
 export const insertIf = <T>(condition: boolean, ...elements: T[]) =>
-  condition ? elements : [];
+  condition ? elements as NonNullable<T>[] : [];

--- a/packages/core/src/error/error.factory.ts
+++ b/packages/core/src/error/error.factory.ts
@@ -2,9 +2,10 @@ import chalk from 'chalk';
 import { CoreError } from './error.model';
 
 export type CoreErrorOptions = {
-  contextMethod: string;
+  contextMethod?: string;
   contextPackage?: string;
   offset?: number;
+  printStacktrace?: boolean;
 };
 
 export const stringifyStackTrace = (stackTrace: NodeJS.CallSite[]) =>
@@ -13,28 +14,30 @@ export const stringifyStackTrace = (stackTrace: NodeJS.CallSite[]) =>
     .join('\n  ');
 
 export const coreErrorStackTraceFactory = (opts: CoreErrorOptions) => (message: string, stack: NodeJS.CallSite[]) => {
-  const methodPointer = opts.offset || 0;
+  const methodPointer = opts.offset ?? 0;
+  const printStacktrace = opts.printStacktrace ?? true;
   const method = stack[methodPointer];
 
   const filePointer = methodPointer + 1;
   const file   = stack[filePointer];
 
   const restStack = stack.slice(filePointer, stack.length);
-  const [line, col] = [file.getLineNumber() || 0, file.getColumnNumber() || 0];
-  const packageName = opts.contextPackage || '@marblejs/core';
-  const methodName = opts.contextMethod + ' : ' + (method.getMethodName() || '-');
-  const fileName = file.getFileName() || '';
+  const [line, col] = [file.getLineNumber() ?? 0, file.getColumnNumber() ?? 0];
+  const packageName = opts.contextPackage ?? '@marblejs/core';
+  const methodName = opts.contextMethod + ' : ' + (method.getMethodName() ?? '-');
+  const fileName = file.getFileName() ?? '';
 
   return `
   ${chalk.red(`${packageName} error:`)}
 
   🚨  ${message}
-
+  ${printStacktrace ? `
   👉  ${chalk.yellow.bold(methodName)}
-    @ file: ${chalk.underline(fileName)}
-    @ line: [${line.toString()}:${col.toString()}]
+  @ file: ${chalk.underline(fileName)}
+  @ line: [${line.toString()}:${col.toString()}]
 
-  ${stringifyStackTrace(restStack)}\n`;
+  ${stringifyStackTrace(restStack)}\n` : ''}
+  `;
 };
 
 export const coreErrorFactory = (message: string, opts: CoreErrorOptions) =>

--- a/packages/core/src/http/effects/http.effects.interface.ts
+++ b/packages/core/src/http/effects/http.effects.interface.ts
@@ -3,6 +3,7 @@ import { Event } from '../../event/event.interface';
 import { Effect } from '../../effects/effects.interface';
 
 export interface HttpEffectResponse<T = any> {
+  request: HttpRequest;
   status?: HttpStatus;
   headers?: HttpHeaders;
   body?: T;

--- a/packages/core/src/http/effects/http.effects.interface.ts
+++ b/packages/core/src/http/effects/http.effects.interface.ts
@@ -3,7 +3,7 @@ import { Event } from '../../event/event.interface';
 import { Effect } from '../../effects/effects.interface';
 
 export interface HttpEffectResponse<T = any> {
-  request: HttpRequest;
+  request?: HttpRequest;
   status?: HttpStatus;
   headers?: HttpHeaders;
   body?: T;

--- a/packages/core/src/http/error/http.error.model.ts
+++ b/packages/core/src/http/error/http.error.model.ts
@@ -1,9 +1,11 @@
+import chalk from 'chalk';
 import { HttpStatus, HttpRequest } from '../http.interface';
 import { ExtendableError } from '../../+internal/utils';
+import { HttpEffectResponse } from '../effects/http.effects.interface';
+import { coreErrorFactory } from '../../error/error.factory';
 
 export enum HttpErrorType {
   HTTP_ERROR = 'HttpError',
-  HTTP_EFFECT_ERROR = 'HttpEffectError',
 }
 
 export class HttpError extends ExtendableError {
@@ -11,20 +13,32 @@ export class HttpError extends ExtendableError {
     public readonly message: string,
     public readonly status: HttpStatus,
     public readonly data?: object,
+    public readonly request?: HttpRequest,
     public readonly context?: string,
   ) {
     super(HttpErrorType.HTTP_ERROR, message);
   }
 }
 
-export class HttpEffectError extends ExtendableError {
-  constructor(
-    public readonly error: Error,
-    public readonly request: HttpRequest,
-  ) {
-    super(HttpErrorType.HTTP_EFFECT_ERROR, 'An error occured in HttpEffect');
-  }
-}
-
 export const isHttpError = (error: Error): error is HttpError =>
   error.name === HttpErrorType.HTTP_ERROR;
+
+export const unexpectedErrorWhileSendingErrorFactory = (error: Error) => {
+  const message = `An unexpected error ${chalk.red(`"${error.message}"`)} occured while sending an error response. Please check your error effect.`;
+  return coreErrorFactory(message, { printStacktrace: false });
+}
+
+export const unexpectedErrorWhileSendingOutputFactory = (error: Error) => {
+  const message = `An unexpected error ${chalk.red(`"${error.message}"`)} occured while sending a response. Please check your output effect.`;
+  return coreErrorFactory(message, { printStacktrace: false });
+}
+
+export const responseNotBoundToRequestErrorFactory = (response: HttpEffectResponse) => {
+  const message = `An effect returned a response: "${chalk.yellow(JSON.stringify(response))}" without bound request`;
+  return coreErrorFactory(message, { printStacktrace: false });
+}
+
+export const errorNotBoundToRequestErrorFactory = (error: Error) => {
+  const message = `An effect or middleware thrown an error ${chalk.red(`"${error.message}"`)} without bound request.`;
+  return coreErrorFactory(message, { printStacktrace: false });
+}

--- a/packages/core/src/http/error/http.error.model.ts
+++ b/packages/core/src/http/error/http.error.model.ts
@@ -1,8 +1,9 @@
-import { HttpStatus } from '../http.interface';
+import { HttpStatus, HttpRequest } from '../http.interface';
 import { ExtendableError } from '../../+internal/utils';
 
 export enum HttpErrorType {
   HTTP_ERROR = 'HttpError',
+  HTTP_EFFECT_ERROR = 'HttpEffectError',
 }
 
 export class HttpError extends ExtendableError {
@@ -13,6 +14,15 @@ export class HttpError extends ExtendableError {
     public readonly context?: string,
   ) {
     super(HttpErrorType.HTTP_ERROR, message);
+  }
+}
+
+export class HttpEffectError extends ExtendableError {
+  constructor(
+    public readonly error: Error,
+    public readonly request: HttpRequest,
+  ) {
+    super(HttpErrorType.HTTP_EFFECT_ERROR, 'An error occured in HttpEffect');
   }
 }
 

--- a/packages/core/src/http/router/http.router.combiner.ts
+++ b/packages/core/src/http/router/http.router.combiner.ts
@@ -1,5 +1,6 @@
+import { HttpMiddlewareEffect } from '../effects/http.effects.interface';
 import { RouteCombinerConfig, RouteEffectGroup, RouteEffect } from './http.router.interface';
-import { isRouteCombinerConfig } from './http.router.helpers';
+import { isRouteCombinerConfig, decorateMiddleware } from './http.router.helpers';
 
 export function combineRoutes(path: string, config: RouteCombinerConfig): RouteEffectGroup;
 export function combineRoutes(path: string, effects: (RouteEffect | RouteEffectGroup)[]): RouteEffectGroup;
@@ -17,3 +18,10 @@ export function combineRoutes(
       : [],
   };
 }
+
+export const combineRouteMiddlewares =
+  (decorate: boolean) => (...middlewares: HttpMiddlewareEffect[]): HttpMiddlewareEffect => (input$, ctx) =>
+    middlewares.reduce(
+      (i$, middleware) => middleware(decorate ? decorateMiddleware(i$) : i$, ctx),
+      decorate ? decorateMiddleware(input$) : input$,
+    );

--- a/packages/core/src/http/router/http.router.factory.ts
+++ b/packages/core/src/http/router/http.router.factory.ts
@@ -1,5 +1,4 @@
 import { HttpMiddlewareEffect } from '../effects/http.effects.interface';
-import { combineMiddlewares } from '../../effects/effects.combiner';
 import { isRouteEffectGroup } from './http.router.helpers';
 import {
   Routing,
@@ -37,9 +36,10 @@ export const factorizeRouting = (
     const method: RoutingMethod = {
       parameters,
       effect: route.effect,
-      middleware: middlewares.length
-        ? combineMiddlewares(...middlewares, route.middleware)
-        : route.middleware,
+      meta: route.meta,
+      middlewares: middlewares.length
+        ? route.middleware ? [...middlewares, route.middleware] : middlewares
+        : route.middleware ? [route.middleware] : [],
     };
 
     if (foundRoute) {

--- a/packages/core/src/http/router/http.router.factory.ts
+++ b/packages/core/src/http/router/http.router.factory.ts
@@ -1,3 +1,4 @@
+import { insertIf } from '../../+internal';
 import { HttpMiddlewareEffect } from '../effects/http.effects.interface';
 import { isRouteEffectGroup } from './http.router.helpers';
 import {
@@ -37,9 +38,10 @@ export const factorizeRouting = (
       parameters,
       effect: route.effect,
       meta: route.meta,
-      middlewares: middlewares.length
-        ? route.middleware ? [...middlewares, route.middleware] : middlewares
-        : route.middleware ? [route.middleware] : [],
+      middlewares: [
+        ...middlewares,
+        ...insertIf(!!route.middleware, route.middleware),
+      ],
     };
 
     if (foundRoute) {

--- a/packages/core/src/http/router/http.router.helpers.ts
+++ b/packages/core/src/http/router/http.router.helpers.ts
@@ -1,10 +1,49 @@
-import { RouteCombinerConfig, RouteEffectGroup, Routing } from './http.router.interface';
+import { Observable, pipe, throwError, of } from 'rxjs';
+import { pipeFromArray } from 'rxjs/internal/util/pipe';
+import { mergeMap, catchError, map } from 'rxjs/operators';
+import { HttpRequest, HttpStatus } from '../http.interface';
+import { HttpEffectResponse } from '../effects/http.effects.interface';
+import { isHttpError, HttpError } from '../error/http.error.model';
+import { RouteCombinerConfig, RouteEffectGroup } from './http.router.interface';
 
-export { Routing };
-
-export const isRouteEffectGroup = (item): item is RouteEffectGroup =>
+export const isRouteEffectGroup = (item: any): item is RouteEffectGroup =>
   Array.isArray(item.effects) &&
   Array.isArray(item.middlewares);
 
-export const isRouteCombinerConfig = (item): item is RouteCombinerConfig =>
+export const isRouteCombinerConfig = (item: any): item is RouteCombinerConfig =>
   Array.isArray(item.effects);
+
+export const decorateEffect = (stream: Observable<HttpRequest>) => {
+  stream.pipe = (...operations: any[]): Observable<any> => {
+    return pipe(
+      mergeMap((request: HttpRequest) => pipeFromArray([
+        ...operations,
+        map((res: HttpEffectResponse) => ({ ...res, request })),
+        catchError((error: Error) =>
+          isHttpError(error)
+            ? throwError(new HttpError(error.message, error.status, error.data, request, error.context))
+            : throwError(new HttpError(error.message, HttpStatus.INTERNAL_SERVER_ERROR, undefined, request))
+        ),
+      ])(of(request)) as Observable<HttpEffectResponse>),
+    )(stream);
+  };
+
+  return stream;
+};
+
+export const decorateMiddleware = (stream: Observable<HttpRequest>) => {
+  stream.pipe = (...operations: any[]): Observable<any> => {
+    return pipe(
+      mergeMap((request: HttpRequest) => pipeFromArray([
+        ...operations,
+        catchError((error: Error) =>
+          isHttpError(error)
+            ? throwError(new HttpError(error.message, error.status, error.data, request, error.context))
+            : throwError(new HttpError(error.message, HttpStatus.INTERNAL_SERVER_ERROR, undefined, request))
+        ),
+      ])(of(request)) as Observable<HttpRequest>),
+    )(stream);
+  };
+
+  return stream;
+};

--- a/packages/core/src/http/router/http.router.interface.ts
+++ b/packages/core/src/http/router/http.router.interface.ts
@@ -1,9 +1,11 @@
-import { Observable } from 'rxjs';
+import { Subject } from 'rxjs';
 import { HttpMethod, HttpRequest } from '../http.interface';
 import { HttpEffect, HttpMiddlewareEffect, HttpEffectResponse } from '../effects/http.effects.interface';
 
 // Route
 export interface RouteMeta extends Record<string, any> {
+  name?: string;
+  continuous?: boolean;
   overridable?: boolean;
 }
 
@@ -36,8 +38,9 @@ export interface ParametricRegExp {
 
 export interface RoutingMethod {
   parameters?: string[];
-  middleware?: HttpMiddlewareEffect | undefined;
+  middlewares: HttpMiddlewareEffect[];
   effect: HttpEffect;
+  meta?: RouteMeta;
 }
 
 export interface RoutingItem {
@@ -50,7 +53,7 @@ export type Routing = RoutingItem[];
 
 export interface BootstrappedRoutingItem extends Omit<RoutingItem, 'methods'> {
   methods: Partial<Record<HttpMethod, {
-    process: (req$: Observable<HttpRequest>) => Observable<HttpEffectResponse>;
+    subject: Subject<HttpRequest>;
     parameters?: string[];
   }>>;
 }
@@ -58,7 +61,7 @@ export interface BootstrappedRoutingItem extends Omit<RoutingItem, 'methods'> {
 export type BootstrappedRouting = BootstrappedRoutingItem[];
 
 export interface RouteMatched {
-  process: (req$: Observable<HttpRequest>) => Observable<HttpEffectResponse>;
+  subject: Subject<HttpRequest>;
   params: Record<string, string>;
   path: string;
 }

--- a/packages/core/src/http/router/http.router.ixbuilder.ts
+++ b/packages/core/src/http/router/http.router.ixbuilder.ts
@@ -1,11 +1,7 @@
-import { Observable, OperatorFunction, throwError, of } from 'rxjs';
-import { mergeMap, map, catchError } from 'rxjs/operators';
-import { pipeFromArray } from 'rxjs/internal/util/pipe';
 import { combineMiddlewares } from '../../effects/effects.combiner';
 import { IxBuilder, ichainCurry } from '../../+internal/fp/IxBuilder';
-import { HttpMiddlewareEffect, HttpEffect, HttpEffectResponse } from '../effects/http.effects.interface';
-import { HttpMethod, HttpRequest } from '../http.interface';
-import { HttpEffectError } from '../error/http.error.model';
+import { HttpMiddlewareEffect, HttpEffect } from '../effects/http.effects.interface';
+import { HttpMethod } from '../http.interface';
 import { RouteEffect, RouteMeta } from './http.router.interface';
 
 type Ready = 'Ready';
@@ -130,83 +126,4 @@ function pipe(
   )(route).run();
 }
 
-type EffectFn = (input$: Observable<HttpRequest>) => Observable<HttpEffectResponse>;
-
-export function handle(): EffectFn;
-export function handle<A>(
-  op1: OperatorFunction<HttpRequest, A>,
-): EffectFn;
-export function handle<A, B>(
-  op1: OperatorFunction<HttpRequest, A>,
-  op2: OperatorFunction<A, B>,
-): EffectFn;
-export function handle<A, B, C>(
-  op1: OperatorFunction<HttpRequest, A>,
-  op2: OperatorFunction<A, B>,
-  op3: OperatorFunction<B, C>,
-): EffectFn;
-export function handle<A, B, C, D>(
-  op1: OperatorFunction<HttpRequest, A>,
-  op2: OperatorFunction<A, B>,
-  op3: OperatorFunction<B, C>,
-  op4: OperatorFunction<C, D>,
-): EffectFn;
-export function handle<A, B, C, D, E>(
-  op1: OperatorFunction<HttpRequest, A>,
-  op2: OperatorFunction<A, B>,
-  op3: OperatorFunction<B, C>,
-  op4: OperatorFunction<C, D>,
-  op5: OperatorFunction<D, E>,
-): EffectFn;
-export function handle<A, B, C, D, E, F>(
-  op1: OperatorFunction<HttpRequest, A>,
-  op2: OperatorFunction<A, B>,
-  op3: OperatorFunction<B, C>,
-  op4: OperatorFunction<C, D>,
-  op5: OperatorFunction<D, E>,
-  op6: OperatorFunction<E, F>,
-): EffectFn;
-export function handle<A, B, C, D, E, F, G>(
-  op1: OperatorFunction<HttpRequest, A>,
-  op2: OperatorFunction<A, B>,
-  op3: OperatorFunction<B, C>,
-  op4: OperatorFunction<C, D>,
-  op5: OperatorFunction<D, E>,
-  op6: OperatorFunction<E, F>,
-  op7: OperatorFunction<F, G>,
-): EffectFn;
-export function handle<A, B, C, D, E, F, G, H>(
-  op1: OperatorFunction<HttpRequest, A>,
-  op2: OperatorFunction<A, B>,
-  op3: OperatorFunction<B, C>,
-  op4: OperatorFunction<C, D>,
-  op5: OperatorFunction<D, E>,
-  op6: OperatorFunction<E, F>,
-  op7: OperatorFunction<F, G>,
-  op8: OperatorFunction<G, H>,
-): EffectFn;
-export function handle<A, B, C, D, E, F, G, H, I>(
-  op1: OperatorFunction<HttpRequest, A>,
-  op2: OperatorFunction<A, B>,
-  op3: OperatorFunction<B, C>,
-  op4: OperatorFunction<C, D>,
-  op5: OperatorFunction<D, E>,
-  op6: OperatorFunction<E, F>,
-  op7: OperatorFunction<F, G>,
-  op8: OperatorFunction<G, H>,
-  op9: OperatorFunction<H, I>,
-  ...operations: OperatorFunction<any, any>[]
-): EffectFn;
-
-export function handle(...operators: OperatorFunction<any, any>[]): EffectFn {
-  return input$ =>
-    input$.pipe(
-      mergeMap(request => pipeFromArray([
-        ...operators,
-        map(res => ({ ...res, request })),
-        catchError(error => throwError(new HttpEffectError(error, request))),
-      ])(of(request)) as Observable<HttpEffectResponse>),
-    );
-}
-
-export const r = { matchPath, matchType, use, useEffect, applyMeta, pipe, handle };
+export const r = { matchPath, matchType, use, useEffect, applyMeta, pipe };

--- a/packages/core/src/http/router/http.router.ixbuilder.ts
+++ b/packages/core/src/http/router/http.router.ixbuilder.ts
@@ -1,7 +1,11 @@
+import { Observable, OperatorFunction, throwError, of } from 'rxjs';
+import { mergeMap, map, catchError } from 'rxjs/operators';
+import { pipeFromArray } from 'rxjs/internal/util/pipe';
 import { combineMiddlewares } from '../../effects/effects.combiner';
 import { IxBuilder, ichainCurry } from '../../+internal/fp/IxBuilder';
-import { HttpMiddlewareEffect, HttpEffect } from '../effects/http.effects.interface';
-import { HttpMethod } from '../http.interface';
+import { HttpMiddlewareEffect, HttpEffect, HttpEffectResponse } from '../effects/http.effects.interface';
+import { HttpMethod, HttpRequest } from '../http.interface';
+import { HttpEffectError } from '../error/http.error.model';
 import { RouteEffect, RouteMeta } from './http.router.interface';
 
 type Ready = 'Ready';
@@ -126,4 +130,83 @@ function pipe(
   )(route).run();
 }
 
-export const r = { matchPath, matchType, use, useEffect, applyMeta, pipe };
+type EffectFn = (input$: Observable<HttpRequest>) => Observable<HttpEffectResponse>;
+
+export function handle(): EffectFn;
+export function handle<A>(
+  op1: OperatorFunction<HttpRequest, A>,
+): EffectFn;
+export function handle<A, B>(
+  op1: OperatorFunction<HttpRequest, A>,
+  op2: OperatorFunction<A, B>,
+): EffectFn;
+export function handle<A, B, C>(
+  op1: OperatorFunction<HttpRequest, A>,
+  op2: OperatorFunction<A, B>,
+  op3: OperatorFunction<B, C>,
+): EffectFn;
+export function handle<A, B, C, D>(
+  op1: OperatorFunction<HttpRequest, A>,
+  op2: OperatorFunction<A, B>,
+  op3: OperatorFunction<B, C>,
+  op4: OperatorFunction<C, D>,
+): EffectFn;
+export function handle<A, B, C, D, E>(
+  op1: OperatorFunction<HttpRequest, A>,
+  op2: OperatorFunction<A, B>,
+  op3: OperatorFunction<B, C>,
+  op4: OperatorFunction<C, D>,
+  op5: OperatorFunction<D, E>,
+): EffectFn;
+export function handle<A, B, C, D, E, F>(
+  op1: OperatorFunction<HttpRequest, A>,
+  op2: OperatorFunction<A, B>,
+  op3: OperatorFunction<B, C>,
+  op4: OperatorFunction<C, D>,
+  op5: OperatorFunction<D, E>,
+  op6: OperatorFunction<E, F>,
+): EffectFn;
+export function handle<A, B, C, D, E, F, G>(
+  op1: OperatorFunction<HttpRequest, A>,
+  op2: OperatorFunction<A, B>,
+  op3: OperatorFunction<B, C>,
+  op4: OperatorFunction<C, D>,
+  op5: OperatorFunction<D, E>,
+  op6: OperatorFunction<E, F>,
+  op7: OperatorFunction<F, G>,
+): EffectFn;
+export function handle<A, B, C, D, E, F, G, H>(
+  op1: OperatorFunction<HttpRequest, A>,
+  op2: OperatorFunction<A, B>,
+  op3: OperatorFunction<B, C>,
+  op4: OperatorFunction<C, D>,
+  op5: OperatorFunction<D, E>,
+  op6: OperatorFunction<E, F>,
+  op7: OperatorFunction<F, G>,
+  op8: OperatorFunction<G, H>,
+): EffectFn;
+export function handle<A, B, C, D, E, F, G, H, I>(
+  op1: OperatorFunction<HttpRequest, A>,
+  op2: OperatorFunction<A, B>,
+  op3: OperatorFunction<B, C>,
+  op4: OperatorFunction<C, D>,
+  op5: OperatorFunction<D, E>,
+  op6: OperatorFunction<E, F>,
+  op7: OperatorFunction<F, G>,
+  op8: OperatorFunction<G, H>,
+  op9: OperatorFunction<H, I>,
+  ...operations: OperatorFunction<any, any>[]
+): EffectFn;
+
+export function handle(...operators: OperatorFunction<any, any>[]): EffectFn {
+  return input$ =>
+    input$.pipe(
+      mergeMap(request => pipeFromArray([
+        ...operators,
+        map(res => ({ ...res, request })),
+        catchError(error => throwError(new HttpEffectError(error, request))),
+      ])(of(request)) as Observable<HttpEffectResponse>),
+    );
+}
+
+export const r = { matchPath, matchType, use, useEffect, applyMeta, pipe, handle };

--- a/packages/core/src/http/router/http.router.matcher.ts
+++ b/packages/core/src/http/router/http.router.matcher.ts
@@ -21,7 +21,7 @@ export const matchRoute = (routing: BootstrappedRouting) => (url: string, method
     }
 
     return {
-      process: matchedMethod.process,
+      subject: matchedMethod.subject,
       params,
       path,
     };

--- a/packages/core/src/http/router/specs/http.router.factory.spec.ts
+++ b/packages/core/src/http/router/specs/http.router.factory.spec.ts
@@ -1,10 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
-import { of } from 'rxjs';
-import { mapTo, tap } from 'rxjs/operators';
+import { mapTo } from 'rxjs/operators';
 import { RouteEffect, RouteEffectGroup, Routing } from '../http.router.interface';
 import { factorizeRouting, factorizeRoutingWithDefaults } from '../http.router.factory';
-import { createHttpRequest, createMockEffectContext } from '../../../+internal';
 import { HttpEffect, HttpMiddlewareEffect } from '../../effects/http.effects.interface';
 import { factorizeRegExpWithParams } from '../http.router.params.factory';
 import { r } from '../http.router.ixbuilder';
@@ -86,75 +84,39 @@ describe('#factorizeRouting', () => {
         regExp: getRegExp('/'),
         path: '',
         methods: {
-          GET: { effect: e1$, middleware: undefined, parameters: undefined, },
+          GET: { middlewares: [], effect: e1$, parameters: undefined, meta: undefined },
         },
       },
       {
         regExp: getRegExp('/level_1'),
         path: '/level_1',
         methods: {
-          GET: { middleware: expect.any(Function), effect: e2$, parameters: undefined, },
+          GET: { middlewares: [m$, m$], effect: e2$, parameters: undefined, meta: undefined },
         },
       },
       {
         regExp: getRegExp('/level_1/:id1'),
         path: '/level_1/:id1',
         methods: {
-          POST: { middleware: expect.any(Function), effect: e3$, parameters: ['id1'] },
-          DELETE: { middleware: expect.any(Function), effect: e3$, parameters: ['id2'] },
+          POST: { middlewares: [m$, m$, m$], effect: e3$, parameters: ['id1'], meta: undefined},
+          DELETE: { middlewares: [m$, m$, m$], effect: e3$, parameters: ['id2'], meta: undefined },
         },
       },
       {
         regExp: getRegExp('/level_1/level_2'),
         path: '/level_1/level_2',
         methods: {
-          GET: { middleware: expect.any(Function), effect: e4$, parameters: undefined, },
+          GET: { middlewares: [m$, m$, m$, m$], effect: e4$, parameters: undefined, meta: undefined },
         },
       },
       {
         regExp: getRegExp('/level_1/*'),
         path: '/level_1/(.*)',
         methods: {
-          '*': { middleware: expect.any(Function), effect: e5$ },
+          '*': { middlewares: [m$, m$], effect: e5$, meta: undefined },
         },
       },
     ] as Routing);
-  });
-
-  test('composes routed middlewares', async () => {
-    // given
-    const spy = jest.fn();
-    const req = createHttpRequest();
-    const ctx = createMockEffectContext();
-    const m$: HttpMiddlewareEffect = req$ => req$.pipe(tap(spy));
-    const e$: HttpEffect = req$ => req$.pipe(mapTo({ body: 'test' }));
-
-    const routeEffect: RouteEffect = {
-      path: '/',
-      method: 'GET',
-      effect: e$,
-      middleware: m$,
-    };
-
-    const routeGroupNested: RouteEffectGroup = {
-      path: '/nested',
-      effects: [routeEffect],
-      middlewares: [m$],
-    };
-
-    const routing: (RouteEffect | RouteEffectGroup)[] = [{
-      path: '/test',
-      effects: [routeGroupNested],
-      middlewares: [m$, m$],
-    }];
-
-    // when
-    const factorizedRouting = factorizeRouting(routing);
-    const middleware$ = factorizedRouting[0].methods.GET!.middleware!;
-    await middleware$(of(req), ctx).toPromise();
-
-    // then
-    expect(spy).toHaveBeenCalledTimes(4);
   });
 
   test('throws error if route is redefined', () => {
@@ -188,7 +150,7 @@ describe('#factorizeRoutingWithDefaults', () => {
         methods: {
           '*': {
             effect: expect.any(Function),
-            middleware: undefined,
+            middlewares: [],
             parameters: undefined,
           },
         },
@@ -211,7 +173,7 @@ describe('#factorizeRoutingWithDefaults', () => {
         methods: {
           [fallback$.method]: {
             effect: fallback$.effect,
-            middleware: undefined,
+            middlewares: [],
             parameters: undefined,
           },
         },

--- a/packages/core/src/http/router/specs/http.router.resolver.v2.spec.ts
+++ b/packages/core/src/http/router/specs/http.router.resolver.v2.spec.ts
@@ -31,17 +31,17 @@ describe('#resolveRouting', () => {
       {
         regExp: path1.regExp,
         path: path1.path,
-        methods: { GET: { effect: e1$ }, POST: { effect: e2$ } },
+        methods: { GET: { effect: e1$, middlewares: [] }, POST: { effect: e2$, middlewares: [] } },
       },
       {
         regExp: path2.regExp,
         path: path2.path,
-        methods: { GET: { effect: e3$, parameters: ['id'] } },
+        methods: { GET: { effect: e3$, middlewares: [], parameters: ['id'] } },
       },
       {
         regExp: path3.regExp,
         path: path3.path,
-        methods: { POST: { effect: e4$ } },
+        methods: { POST: { effect: e4$, middlewares: [] } },
       },
     ];
 
@@ -51,10 +51,10 @@ describe('#resolveRouting', () => {
     // then
     outputSubject.pipe(take(4), toArray()).subscribe(
       result => {
-        expect(result[0].res).toEqual({ body: 'test_1' });
-        expect(result[1].res).toEqual({ body: 'test_2' });
-        expect(result[2].res).toEqual({ body: 'test_3' });
-        expect(result[3].res).toEqual({ body: 'test_4' });
+        expect(result[0].res).toEqual({ body: 'test_1', request: req1 });
+        expect(result[1].res).toEqual({ body: 'test_2', request: req2 });
+        expect(result[2].res).toEqual({ body: 'test_3', request: req3 });
+        expect(result[3].res).toEqual({ body: 'test_4', request: req4 });
         done();
       },
     );
@@ -78,7 +78,7 @@ describe('#resolveRouting', () => {
     const routing: Routing = [{
       regExp: path.regExp,
       path: path.path,
-      methods: { GET: { effect: effect$ } },
+      methods: { GET: { effect: effect$, middlewares: [] } },
     }];
 
     // when

--- a/packages/core/src/http/server/http.server.tokens.ts
+++ b/packages/core/src/http/server/http.server.tokens.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 import { createContextToken } from '../../context/context.token.factory';
 import { HttpServer } from '../http.interface';
-import { Routing } from '../router/http.router.helpers';
+import { Routing } from '../router/http.router.interface';
 import { AllServerEvents } from './http.server.event';
 import { ServerRequestMetadataStorage } from './http.server.metadata.storage';
 

--- a/packages/core/src/http/server/specs/http.server.listener.spec.ts
+++ b/packages/core/src/http/server/specs/http.server.listener.spec.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import { throwError } from 'rxjs';
-import { mapTo, mergeMap, map } from 'rxjs/operators';
+import { mapTo, mergeMap } from 'rxjs/operators';
 import { r } from '../../router/http.router.ixbuilder';
 import { httpListener } from '../http.server.listener';
 import { HttpMiddlewareEffect, HttpEffectResponse } from '../../effects/http.effects.interface';
@@ -32,12 +32,9 @@ describe('Http listener', () => {
     const effect$ = r.pipe(
       r.matchPath('/'),
       r.matchType('GET'),
-      r.useEffect(req$ => {
-
-        return r.handle(
-          mapTo(effectResponse),
-        )(req$);
-      }),
+      r.useEffect(req$ => req$.pipe(
+        mapTo(effectResponse),
+      )),
     );
 
     const middleware$: HttpMiddlewareEffect = req$ => req$;
@@ -59,27 +56,17 @@ describe('Http listener', () => {
     // given
     const req = { url: '/', method: 'GET' } as http.IncomingMessage;
     const res = {} as http.OutgoingMessage;
+    const effectResponse = { body: 'test' } as HttpEffectResponse;
     const sender = jest.fn();
 
     const effect$ = r.pipe(
       r.matchPath('/'),
       r.matchType('GET'),
-      r.useEffect(req$ => {
-
-        return r.handle(
-          mapTo(1),
-          map(x => x + 1),
-          map(x => x + 1),
-          map(x => x + 1),
-          map(x => x + 1),
-          map(x => x + 1),
-          map(x => x + 1),
-          map(x => ({
-            body: x + 1,
-          })),
-        )(req$);
-      }),
+      r.useEffect(req$ => req$.pipe(
+        mapTo(effectResponse),
+      )),
     );
+
 
     // when
     responseHandler.handleResponse = jest.fn(() => () => () => sender);
@@ -90,7 +77,7 @@ describe('Http listener', () => {
     })(context)(req, res);
 
     // then
-    expect(sender).toHaveBeenCalledWith({ body: 8, request: { ...req, response: res }});
+    expect(sender).toHaveBeenCalledWith({ body: 'test', request: { ...req, response: res }});
     done();
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 // http
 export { EffectFactory } from './http/effects/http.effects.factory';
 export { defaultError$ } from './http/error/http.error.effect';
-export { HttpError } from './http/error/http.error.model';
+export { HttpError, isHttpError } from './http/error/http.error.model';
 export { combineRoutes } from './http/router/http.router.combiner';
 export { r } from './http/router/http.router.ixbuilder';
 export * from './http/router/http.router.interface';

--- a/packages/middleware-body/src/body.middleware.ts
+++ b/packages/middleware-body/src/body.middleware.ts
@@ -1,6 +1,6 @@
 import { HttpError, HttpStatus, HttpMiddlewareEffect } from '@marblejs/core';
 import { of, throwError, iif } from 'rxjs';
-import { catchError, map, switchMap, tap, mapTo, mergeMap } from 'rxjs/operators';
+import { catchError, map, tap, mapTo, mergeMap } from 'rxjs/operators';
 import { defaultParser } from './parsers';
 import { RequestBodyParser } from './body.model';
 import { matchType, getBody, hasBody, isMultipart } from './body.util';
@@ -17,7 +17,7 @@ export const bodyParser$ = ({
   parser = defaultParser,
 }: BodyParserOptions = {}): HttpMiddlewareEffect => req$ =>
   req$.pipe(
-    switchMap(req => iif(
+    mergeMap(req => iif(
       () =>
         PARSEABLE_METHODS.includes(req.method)
         && !hasBody(req)
@@ -29,7 +29,7 @@ export const bodyParser$ = ({
         tap(body => req.body = body),
         mapTo(req),
         catchError(() => throwError(
-          new HttpError('Request body parse error', HttpStatus.BAD_REQUEST),
+          new HttpError('Request body parse error', HttpStatus.BAD_REQUEST, undefined, req),
         ))
       ),
       of(req),

--- a/packages/middleware-io/src/io.request.middleware.ts
+++ b/packages/middleware-io/src/io.request.middleware.ts
@@ -68,7 +68,7 @@ export const requestValidator$ = <
           >;
         }),
         catchError((error: IOError) => throwError(
-          new HttpError(error.message, HttpStatus.BAD_REQUEST, error.data, error.context),
+          new HttpError(error.message, HttpStatus.BAD_REQUEST, error.data, req, error.context),
         )),
       )
     ),

--- a/packages/middleware-multipart/src/multipart.middleware.ts
+++ b/packages/middleware-multipart/src/multipart.middleware.ts
@@ -11,7 +11,7 @@ export const multipart$ = <File extends string>(opts: ParserOpts = {}) => <T ext
     mergeMap(req => shouldParseMultipart(req)
       ? parseMultipart(opts)(req)
       : throwError(
-        new HttpError(`Content-Type must be of type ${ContentType.MULTIPART_FORM_DATA}`, HttpStatus.PRECONDITION_FAILED)
+        new HttpError(`Content-Type must be of type ${ContentType.MULTIPART_FORM_DATA}`, HttpStatus.PRECONDITION_FAILED, undefined, req)
       )),
     map(req => req as T & WithFile<File>),
   );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #206 


## What is the new behavior?
- **@marblejs/core** - rethink the way how HTTP request processing is made underhood of `@marblejs/core` package.
- **@marblejs/core** - propagate route metadata, applied by `r.applyMeta` function to app routing table
- **@marblejs/core** -initialize every route effect eagerly (only once) when the whole app is bootstraping
- **@marblejs/core** - introduced `continuous` metadata flag for dealing with continuous request streams, eg.

```typescript
const getUserBuffered$ = r.pipe(
  r.matchPath('/:id/buffered'),
  r.matchType('GET'),
  r.useEffect(req$ => {
    console.log('Effect bootstrapped: "getUserBuffered$"');

    return req$.pipe(
      bufferCount(2),
      mergeMap(out => from(out).pipe(
        mergeMap(request => of(request).pipe(
          use(getUserValidator$),
          map(req => req.params.id),
          switchMap(Dao.getUserById),
          map(user => ({ body: user, request })),
          catchError(() => throwError(
            new HttpError('User does not exist', HttpStatus.NOT_FOUND)
          )),
        )),
      )),
    );
  }),
  r.applyMeta({ continuous: true }),
);
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
