### PR TITLE
fix(middleware-multipart): middleware hangs if only file is sent or only field

### DIFF
--- a/packages/middleware-multipart/src/multipart.parser.field.ts
+++ b/packages/middleware-multipart/src/multipart.parser.field.ts
@@ -1,6 +1,6 @@
 import { HttpRequest } from '@marblejs/core';
 import { Observable } from 'rxjs';
-import { takeUntil, tap } from 'rxjs/operators';
+import { takeUntil, tap, defaultIfEmpty, mapTo } from 'rxjs/operators';
 
 type FieldEvent = [string, any, boolean, boolean, string, string];
 
@@ -13,4 +13,6 @@ export const parseField = (req: HttpRequest<any>) => (event$: Observable<FieldEv
         [fieldname]: value,
       };
     }),
+    mapTo(req),
+    defaultIfEmpty(req),
   );

--- a/packages/middleware-multipart/src/multipart.parser.file.ts
+++ b/packages/middleware-multipart/src/multipart.parser.file.ts
@@ -3,7 +3,7 @@ import { HttpRequest, HttpError, HttpStatus } from '@marblejs/core';
 import { isNonNullable } from '@marblejs/core/dist/+internal/utils';
 import { fromReadableStream } from '@marblejs/core/dist/+internal/observable';
 import { fromEvent, Observable, of, throwError, merge, iif } from 'rxjs';
-import { mapTo, map, mergeMap, takeUntil, toArray, tap, mergeMapTo, ignoreElements } from 'rxjs/operators';
+import { mapTo, map, mergeMap, takeUntil, toArray, tap, mergeMapTo, ignoreElements, defaultIfEmpty } from 'rxjs/operators';
 import { FileIncomingData, ParserOpts } from './multipart.interface';
 import { setRequestData, shouldParseFieldname } from './multipart.util';
 
@@ -46,4 +46,6 @@ export const parseFile = (req: HttpRequest) => (opts: ParserOpts) => (event$: Ob
           mapTo(data),
         ),
     ),
+    mapTo(req),
+    defaultIfEmpty(req),
   );

--- a/packages/middleware-multipart/src/specs/multipart.middleware.spec.ts
+++ b/packages/middleware-multipart/src/specs/multipart.middleware.spec.ts
@@ -121,6 +121,19 @@ describe('multipart$', () => {
       });
   });
 
+  test('parses multipart/form-data request with fields only (no files)', async () =>
+    request(httpTestBed.getInstance())
+      .post('/memory')
+      .field('field_1', 'test_1')
+      .field('field_2', 'test_2')
+      .expect(200)
+      .then(({ body }) => {
+        // field_1, field_2
+        expect(body.fields.field_1).toEqual('test_1');
+        expect(body.fields.field_2).toEqual('test_2');
+      }),
+  );
+
   test('throws an error if incoming request is not multipart/form-data', async () =>
     request(httpTestBed.getInstance())
       .post('/memory')


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/middleware-multipart** - middleware hangs if only file is sent or only field

Issue Number: #186 


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
