### PR TITLE
refactor(all): removed named listeners from server configs

### DIFF
--- a/benchmarks/middlewares.js
+++ b/benchmarks/middlewares.js
@@ -21,7 +21,7 @@ for (let i = 0; i < n; i++) {
 
 const server = createServer({
   port: 1337,
-  httpListener: httpListener({ effects, middlewares }),
+  listener: httpListener({ effects, middlewares }),
 });
 
 const bootstrap = async () => {

--- a/benchmarks/routing.js
+++ b/benchmarks/routing.js
@@ -29,11 +29,9 @@ effects.push(
   ),
 );
 
-const app = httpListener({ middlewares, effects });
-
 const server = createServer({
   port: 1337,
-  httpListener: httpListener({ middlewares, effects }),
+  listener: httpListener({ middlewares, effects }),
 });
 
 const bootstrap = async () => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postbuild": "rimraf packages/**/*.spec.js packages/**/*.spec.d.ts",
     "benchmark": "NODE_ENV=test make -C benchmarks",
     "watch": "lerna run --parallel --stream watch",
-    "lint": "eslint ./packages/**/src --ext .ts",
+    "lint": "eslint ./packages/**/src ./packages/**/test --ext .ts",
     "pretest": "yarn lint",
     "link:all": "lerna exec -- yarn link",
     "unlink:all": "lerna exec -- yarn unlink",

--- a/packages/@integration/src/cqrs/index.ts
+++ b/packages/@integration/src/cqrs/index.ts
@@ -7,14 +7,14 @@ import { logger$ } from '@marblejs/middleware-logger';
 import { postDocumentsGenerate$ } from './effects/http.effects';
 import { generateOfferDocument$, saveOfferDocument$ } from './effects/eventbus.effects';
 
-const messagingListenerReader = messagingListener({
+const eventBusListener = messagingListener({
   effects: [
     generateOfferDocument$,
     saveOfferDocument$,
   ],
 });
 
-const httpListenerReader = httpListener({
+const listener = httpListener({
   middlewares: [
     logger$({ silent: isTestEnv() }),
     bodyParser$(),
@@ -26,10 +26,10 @@ const httpListenerReader = httpListener({
 
 export const server = createServer({
   port: getPortEnv(),
-  httpListener: httpListenerReader,
+  listener,
   dependencies: [
     bindEagerlyTo(EventBusClientToken)(eventBusClient),
-    bindEagerlyTo(EventBusToken)(eventBus({ messagingListener: messagingListenerReader })),
+    bindEagerlyTo(EventBusToken)(eventBus({ listener: eventBusListener })),
   ],
 });
 

--- a/packages/@integration/src/http/index.ts
+++ b/packages/@integration/src/http/index.ts
@@ -6,7 +6,7 @@ import { bodyParser$ } from '@marblejs/middleware-body';
 import { api$ } from './effects/api.effects';
 import { cors$ } from './middlewares/cors.middleware';
 
-const httpListenerReader = httpListener({
+const listener = httpListener({
   middlewares: [
     logger$({ silent: isTestEnv() }),
     bodyParser$(),
@@ -19,7 +19,7 @@ const httpListenerReader = httpListener({
 
 export const server = createServer({
   port: getPortEnv(),
-  httpListener: httpListenerReader,
+  listener,
 });
 
 const main: IO<void> = async () =>

--- a/packages/@integration/src/messaging/client.ts
+++ b/packages/@integration/src/messaging/client.ts
@@ -90,7 +90,7 @@ const fib$ = r.pipe(
 
 export const server = createServer({
   port,
-  httpListener: httpListener({
+  listener: httpListener({
     middlewares: [logger$()],
     effects: [buffer$, timeout$, error$, fib$],
   }),

--- a/packages/@integration/src/messaging/server.ts
+++ b/packages/@integration/src/messaging/server.ts
@@ -59,7 +59,7 @@ export const microservice = createMicroservice({
     queue: 'test_queue',
     queueOptions: { durable: false },
   },
-  messagingListener: messagingListener({
+  listener: messagingListener({
     effects: [fibonacci$, buffer$, timeout$, error$],
   }),
 });

--- a/packages/@integration/src/websockets/http.server.ts
+++ b/packages/@integration/src/websockets/http.server.ts
@@ -42,7 +42,7 @@ const upgrade$: HttpServerEffect = (event$, { ask }) =>
 
 export const server = createServer({
   port: 1337,
-  httpListener: httpListener({
+  listener: httpListener({
     middlewares: [logger$()],
     effects: [root$],
   }),

--- a/packages/@integration/src/websockets/websockets.server.ts
+++ b/packages/@integration/src/websockets/websockets.server.ts
@@ -41,7 +41,7 @@ const connection$: WsConnectionEffect = req$ =>
 
 export const webSocketServer = createWebSocketServer({
   connection$,
-  webSocketListener: webSocketListener({
+  listener: webSocketListener({
     middlewares: [],
     effects: [add$, error$],
   }),

--- a/packages/core/src/http/server/http.server.interface.ts
+++ b/packages/core/src/http/server/http.server.interface.ts
@@ -8,7 +8,7 @@ export const DEFAULT_HOSTNAME = '127.0.0.1';
 export interface CreateServerConfig {
   port?: number;
   hostname?: string;
-  httpListener: ReturnType<typeof httpListener>;
+  listener: ReturnType<typeof httpListener>;
   event$?: HttpServerEffect;
   options?: ServerOptions;
   dependencies?: BoundDependency<any>[];

--- a/packages/core/src/http/server/http.server.ts
+++ b/packages/core/src/http/server/http.server.ts
@@ -17,7 +17,7 @@ import { httpRequestMetadataStorage } from './http.server.metadata.storage';
 import { CreateServerConfig } from './http.server.interface';
 
 export const createServer = async (config: CreateServerConfig) => {
-  const { httpListener, event$, port, hostname, dependencies = [], options = {} } = config;
+  const { listener, event$, port, hostname, dependencies = [], options = {} } = config;
 
   const server = options.httpsOptions ? https.createServer(options.httpsOptions) : http.createServer();
   const serverEvent$ = subscribeServerEvents(hostname)(server);
@@ -43,7 +43,7 @@ export const createServer = async (config: CreateServerConfig) => {
 
   const ask = lookup(context);
   const ctx = createEffectContext({ ask, client: server });
-  const listener = httpListener(context);
+  const httpListener = listener(context);
 
   merge(
     event$ ? event$(serverEvent$, ctx) : EMPTY,
@@ -57,7 +57,7 @@ export const createServer = async (config: CreateServerConfig) => {
 
     // @TODO: bind Routing
 
-    runningServer.on('request', listener);
+    runningServer.on('request', httpListener);
     runningServer.on('close', runningServer.removeAllListeners);
     runningServer.on('error', reject);
     runningServer.on('listening', () => resolve(runningServer));

--- a/packages/core/src/http/server/specs/http.server.factory.spec.ts
+++ b/packages/core/src/http/server/specs/http.server.factory.spec.ts
@@ -43,7 +43,7 @@ describe('#createServer', () => {
     const hostname = '127.0.0.1';
     const app = await createServer({
       hostname,
-      httpListener: httpListener(),
+      listener: httpListener(),
     });
 
     // when
@@ -56,7 +56,7 @@ describe('#createServer', () => {
   test('creates http server and starts listening without specified port and hostname', async () => {
     // given
     const app = await createServer({
-      httpListener: httpListener(),
+      listener: httpListener(),
     });
 
     // when
@@ -73,7 +73,7 @@ describe('#createServer', () => {
       cert: fs.readFileSync(path.resolve(__dirname, '../../../../../../assets/cert.pem')),
     };
     const app = await createServer({
-      httpListener: httpListener(),
+      listener: httpListener(),
       options: { httpsOptions },
     });
 
@@ -87,7 +87,7 @@ describe('#createServer', () => {
   test('returns server via context', async () => {
     // given
     const app = await createServer({
-      httpListener: httpListener(),
+      listener: httpListener(),
     });
 
     // when
@@ -101,7 +101,7 @@ describe('#createServer', () => {
 
   test(`emits server events`, async done => {
     const app = await createServer({
-      httpListener: httpListener(),
+      listener: httpListener(),
       event$: event$ => forkJoin(
         event$.pipe(filter(isErrorEvent), take(1)),
         event$.pipe(filter(isClientErrorEvent), take(1)),

--- a/packages/messaging/src/eventbus/messaging.eventBus.reader.ts
+++ b/packages/messaging/src/eventbus/messaging.eventBus.reader.ts
@@ -11,7 +11,7 @@ import { MessagingClient } from '../client/messaging.client.interface';
 import { messagingClient } from '../client/messaging.client';
 
 interface EventBusConfig {
-  messagingListener: ReturnType<typeof messagingListener>;
+  listener: ReturnType<typeof messagingListener>;
 }
 
 export const EventBusToken = createContextToken<TransportLayerConnection>('EventBusToken');
@@ -20,13 +20,14 @@ export const EventBusClientToken = createContextToken<MessagingClient>('EventBus
 export const eventBus = (config: EventBusConfig) => pipe(
   R.ask<Context>(),
   R.map(async rootContext => {
+    const { listener } = config;
     const ctx = deleteAt(setoidContextToken)(EventBusToken)(rootContext);
     const transportLayer = provideTransportLayer(Transport.LOCAL);
     const transportLayerConnection = await transportLayer.connect();
     const boundTransportLayer = bindTo(TransportLayerToken)(() => transportLayer);
     const context = await flow(register(boundTransportLayer), resolve)(ctx);
 
-    config.messagingListener(context)(transportLayerConnection);
+    listener(context)(transportLayerConnection);
 
     return transportLayerConnection;
   }),

--- a/packages/messaging/src/server/messaging.server.interface.ts
+++ b/packages/messaging/src/server/messaging.server.interface.ts
@@ -4,7 +4,7 @@ import { TransportStrategy, TransportLayerConnection } from '../transport/transp
 import { messagingListener } from './messaging.server.listener';
 
 type ConfigurationBase =  {
-  messagingListener: ReturnType<typeof messagingListener>;
+  listener: ReturnType<typeof messagingListener>;
   dependencies?: BoundDependency<any>[];
   event$?: MsgServerEffect;
 }

--- a/packages/messaging/src/server/messaging.server.ts
+++ b/packages/messaging/src/server/messaging.server.ts
@@ -30,7 +30,7 @@ export const createMicroservice = async (config: CreateMicroserviceConfig) => {
     options,
     transport,
     dependencies = [],
-    messagingListener,
+    listener,
   } = config;
 
   const serverEventsSubject = new Subject<AllServerEvents>();
@@ -50,7 +50,7 @@ export const createMicroservice = async (config: CreateMicroserviceConfig) => {
     resolve,
   )(createContext());
 
-  const listener = messagingListener(context);
+  const messagingListener = listener(context);
   const serverEvent$ = serverEventsSubject.asObservable().pipe(takeWhile(e => !isCloseEvent(e)));
   const ctx = createEffectContext({ ask: lookup(context), client: undefined });
   const combinedEvents = event$ ? combineEffects(statusLogger$, event$) : statusLogger$;
@@ -61,7 +61,7 @@ export const createMicroservice = async (config: CreateMicroserviceConfig) => {
     const { host, channel } = transportLayer.config;
     const connection = await transportLayer.connect({ isConsumer: true });
 
-    listener(connection);
+    messagingListener(connection);
 
     connection.status$
       .pipe(takeUntil(connection.close$))

--- a/packages/messaging/src/util/messaging.test.util.ts
+++ b/packages/messaging/src/util/messaging.test.util.ts
@@ -9,7 +9,9 @@ export const runServer = (transport: any, options: any) => (effect$?: MsgEffect,
   createMicroservice({
     options,
     transport,
-    messagingListener: messagingListener(effect$ ? { effects: [effect$], output$, error$ } : undefined),
+    listener: messagingListener(effect$
+      ? { effects: [effect$], output$, error$ }
+      : undefined),
   }).then(app => app());
 
 export const runClient = (transport: Transport, transportOptions: any) =>

--- a/packages/middleware-body/test/bodyParser.integration.spec.ts
+++ b/packages/middleware-body/test/bodyParser.integration.spec.ts
@@ -2,10 +2,10 @@ import { ContentType } from '@marblejs/core/dist/+internal/http';
 import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
 import { createServer } from '@marblejs/core';
 import * as request from 'supertest';
-import { app } from './bodyParser.integration';
+import { listener } from './bodyParser.integration';
 
 describe('@marblejs/middleware-body - integration', () => {
-  const server = createServer({ httpListener: app });
+  const server = createServer({ listener });
   const httpTestBed = createHttpServerTestBed(server);
 
   describe('POST /default-parser', () => {

--- a/packages/middleware-body/test/bodyParser.integration.ts
+++ b/packages/middleware-body/test/bodyParser.integration.ts
@@ -37,7 +37,7 @@ const multipleParsers$ = combineRoutes('/multiple-parsers', {
   effects: [effect$],
 });
 
-export const app = httpListener({
+export const listener = httpListener({
   effects: [
     defaultParser$,
     multipleParsers$,

--- a/packages/middleware-io/test/io-http.integration.spec.ts
+++ b/packages/middleware-io/test/io-http.integration.spec.ts
@@ -1,10 +1,10 @@
 import * as request from 'supertest';
 import { createServer } from '@marblejs/core';
 import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
-import { app } from './io-http.integration';
+import { listener } from './io-http.integration';
 
 describe('@marblejs/middleware-io - HTTP integration', () => {
-  const server = createServer({ httpListener: app });
+  const server = createServer({ listener });
   const httpTestBed = createHttpServerTestBed(server);
 
   test('POST / returns 200 with user object', async () => {

--- a/packages/middleware-io/test/io-http.integration.ts
+++ b/packages/middleware-io/test/io-http.integration.ts
@@ -19,7 +19,7 @@ const effect$ = EffectFactory
     map(req => ({ body: req.body.user })),
   ));
 
-export const app = httpListener({
+export const listener = httpListener({
   middlewares: [bodyParser$()],
   effects: [effect$],
 });

--- a/packages/middleware-io/test/io-ws.integration.spec.ts
+++ b/packages/middleware-io/test/io-ws.integration.spec.ts
@@ -16,7 +16,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
     const targetClient = testBed.getClient();
 
     // when
-    const app = await createWebSocketServer({ options: { server }, webSocketListener: listener });
+    const app = await createWebSocketServer({ options: { server }, listener });
     await app();
 
     targetClient.once('open', () => targetClient.send(event));
@@ -44,7 +44,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
     };
 
     // when
-    const app = await createWebSocketServer({ options: { server }, webSocketListener: listener });
+    const app = await createWebSocketServer({ options: { server }, listener });
     await app();
 
     targetClient.once('open', () => targetClient.send(event));

--- a/packages/middleware-joi/test/helpers/api.spec-util.ts
+++ b/packages/middleware-joi/test/helpers/api.spec-util.ts
@@ -1,7 +1,7 @@
-import { validator$, Joi } from '../../src';
 import { httpListener, use, EffectFactory, combineRoutes } from '@marblejs/core';
 import { bodyParser$ } from '@marblejs/middleware-body';
 import { map } from 'rxjs/operators';
+import { validator$, Joi } from '../../src';
 
 const getPost$ = EffectFactory
   .matchPath('/post')
@@ -68,4 +68,4 @@ const middlewares = [
 
 const effects = [api$];
 
-export const app = httpListener({ middlewares, effects });
+export const listener = httpListener({ middlewares, effects });

--- a/packages/middleware-joi/test/integration/integration.spec.ts
+++ b/packages/middleware-joi/test/integration/integration.spec.ts
@@ -1,11 +1,11 @@
 import * as request from 'supertest';
 import { createServer } from '@marblejs/core';
 import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
-import { app } from '../helpers/api.spec-util';
+import { listener } from '../helpers/api.spec-util';
 
 describe('Joi middleware - Integration', () => {
   const token = '181782881DB38D84';
-  const server = createServer({ httpListener: app });
+  const server = createServer({ listener });
   const httpTestBed = createHttpServerTestBed(server);
 
   beforeEach(() => {

--- a/packages/middleware-joi/test/unit/header.spec.ts
+++ b/packages/middleware-joi/test/unit/header.spec.ts
@@ -1,18 +1,20 @@
-import { validator$, Joi } from '../../src';
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 import { of } from 'rxjs';
 import { HttpRequest } from '@marblejs/core';
-const MockReq = require('mock-req');
+import { createHttpRequest } from '@marblejs/core/dist/+internal/testing';
+import { validator$, Joi } from '../../src';
 
 describe('Joi middleware - Header', () => {
-  it('should throws an error if dont pass a required field', done => {
+  test('should throws an error if dont pass a required field', done => {
     expect.assertions(2);
 
-    const request = new MockReq({
+    const request = createHttpRequest({
       method: 'GET',
       headers: {}
     });
 
-    const req$ = of(request as HttpRequest);
+    const req$ = of(request);
     const schema = {
       headers: Joi.object({
         token: Joi.string()
@@ -35,17 +37,15 @@ describe('Joi middleware - Header', () => {
     );
   });
 
-  it('should throws an error if pass a unknown field', done => {
+  test('should throws an error if pass a unknown field', done => {
     expect.assertions(2);
 
-    const request = new MockReq({
+    const request = createHttpRequest({
       method: 'GET',
-      headers: {
-        end: 1
-      }
+      headers: { end: 1 }
     });
 
-    const req$ = of(request as HttpRequest);
+    const req$ = of(request);
     const schema = {
       headers: Joi.object({
         start: Joi.date()
@@ -66,15 +66,12 @@ describe('Joi middleware - Header', () => {
     );
   });
 
-  it('should validates header with unknown field', done => {
+  test('should validates header with unknown field', done => {
     expect.assertions(2);
 
-    const request = new MockReq({
+    const request = createHttpRequest({
       method: 'GET',
-      headers: {
-        end: 1,
-        start: '2018'
-      }
+      headers: { end: 1, start: '2018' },
     });
 
     const req$ = of(request as HttpRequest);
@@ -92,10 +89,10 @@ describe('Joi middleware - Header', () => {
     });
   });
 
-  it('should validates header with two fields', done => {
+  test('should validates header with two fields', done => {
     expect.assertions(1);
 
-    const request = new MockReq({
+    const request = createHttpRequest({
       method: 'GET',
       headers: {
         token: '181782881DB38D84',

--- a/packages/middleware-joi/test/unit/params.spec.ts
+++ b/packages/middleware-joi/test/unit/params.spec.ts
@@ -1,6 +1,6 @@
-import { validator$, Joi } from '../../src';
 import { of } from 'rxjs';
 import { HttpRequest, RouteParameters } from '@marblejs/core';
+import { validator$, Joi } from '../../src';
 
 const reqMatched = (
   url: string,

--- a/packages/middleware-joi/test/unit/query.spec.ts
+++ b/packages/middleware-joi/test/unit/query.spec.ts
@@ -1,6 +1,6 @@
-import { validator$, Joi } from '../../src';
 import { of } from 'rxjs';
 import { HttpRequest, RouteParameters, QueryParameters } from '@marblejs/core';
+import { validator$, Joi } from '../../src';
 
 const reqMatched = (
   url: string,
@@ -10,7 +10,7 @@ const reqMatched = (
 ) => ({ url, matchers, params, query } as any as HttpRequest);
 
 describe('Joi middleware - Query', () => {
-  it('should throws an error if dont pass a required field', done => {
+  test('should throws an error if dont pass a required field', done => {
     expect.assertions(2);
 
     const req$ = of(reqMatched('/test', undefined, {}, {}));
@@ -36,7 +36,7 @@ describe('Joi middleware - Query', () => {
     );
   });
 
-  it('should throws an error if pass a invalid field', done => {
+  test('should throws an error if pass a invalid field', done => {
     expect.assertions(2);
 
     const req$ = of(reqMatched('/test', undefined, {}, { id: '@@@' }));
@@ -62,7 +62,7 @@ describe('Joi middleware - Query', () => {
     );
   });
 
-  it('should validates query with a valid value', done => {
+  test('should validates query with a valid value', done => {
     expect.assertions(2);
 
     const req$ = of(reqMatched('/test', undefined, {}, { id: '181782881DB38D84' }));

--- a/packages/middleware-jwt/test/jwt.integration.spec.ts
+++ b/packages/middleware-jwt/test/jwt.integration.spec.ts
@@ -1,13 +1,13 @@
 import * as request from 'supertest';
-import { verifyToken } from '../src';
-import { app, SECRET_KEY } from './jwt.integration';
 import { createServer } from '@marblejs/core';
 import { createHttpServerTestBed } from '@marblejs/core/dist/+internal/testing';
+import { verifyToken } from '../src';
+import { listener, SECRET_KEY } from './jwt.integration';
 
 const LOGIN_CREDENTIALS = { email: 'admin@admin.com', password: 'admin' };
 
 describe('@marblejs/middleware-jwt - HTTP integration', () => {
-  const server = createServer({ httpListener: app });
+  const server = createServer({ listener });
   const httpTestBed = createHttpServerTestBed(server);
 
   test('POST /api/login returns token and verifies its correctness', async () =>

--- a/packages/middleware-jwt/test/jwt.integration.ts
+++ b/packages/middleware-jwt/test/jwt.integration.ts
@@ -1,11 +1,11 @@
-import { authorize$ as authorizeMiddleware$, generateToken } from '../src';
 import { httpListener, EffectFactory, combineRoutes } from '@marblejs/core';
 import { bodyParser$ } from '@marblejs/middleware-body';
 import { map, flatMap } from 'rxjs/operators';
 import { of, iif, throwError } from 'rxjs';
+import { authorize$ as authorizeMiddleware$, generateToken } from '../src';
 
-type LoginCredentials = { email: string, password: string };
-type Payload = { id: string, email: string};
+type LoginCredentials = { email: string; password: string };
+type Payload = { id: string; email: string};
 
 export const SECRET_KEY = 'SOME_SSH_KEY';
 
@@ -50,4 +50,4 @@ const api$ = combineRoutes('/api', [login$, secured$]);
 const middlewares = [bodyParser$()];
 const effects = [api$];
 
-export const app = httpListener({ middlewares, effects });
+export const listener = httpListener({ middlewares, effects });

--- a/packages/middleware-multipart/src/specs/multipart.middleware.spec.ts
+++ b/packages/middleware-multipart/src/specs/multipart.middleware.spec.ts
@@ -50,7 +50,7 @@ const filesystemMultipart$ = r.pipe(
   )));
 
 const server = createServer({
-  httpListener: httpListener({
+  listener: httpListener({
     effects: [memoryMultipart$, memoryWithOptionsMultipart$, filesystemMultipart$],
   }),
 });

--- a/packages/websockets/src/server/specs/websocket.server.spec.ts
+++ b/packages/websockets/src/server/specs/websocket.server.spec.ts
@@ -24,7 +24,7 @@ describe('WebSocket server', () => {
       const listener = webSocketListener({ effects: [echo$] });
 
       // when
-      const app = await createWebSocketServer({ options: { server }, webSocketListener: listener });
+      const app = await createWebSocketServer({ options: { server }, listener });
       await app();
 
       targetClient.once('open', () => targetClient.send(event));
@@ -47,7 +47,7 @@ describe('WebSocket server', () => {
       const targetClient = testBed.getClient(0);
 
       // when
-      const app = await createWebSocketServer({ options: { server }, webSocketListener: listener });
+      const app = await createWebSocketServer({ options: { server }, listener });
       await app();
 
       targetClient.on('open', () => targetClient.send(JSON.stringify(event)));
@@ -72,7 +72,7 @@ describe('WebSocket server', () => {
       const targetClient = testBed.getClient(0);
 
       // when
-      const app = await createWebSocketServer({ webSocketListener: listener });
+      const app = await createWebSocketServer({ listener });
       const webSocketServer = await app();
 
       server.on('upgrade', (request, socket, head) => {
@@ -106,7 +106,7 @@ describe('WebSocket server', () => {
       });
 
       // when
-      const app = await createWebSocketServer({ options: { server }, webSocketListener: listener })
+      const app = await createWebSocketServer({ options: { server }, listener })
       await app();
 
       targetClient.once('open', () => targetClient.send(incomingEvent));
@@ -130,7 +130,7 @@ describe('WebSocket server', () => {
       const listener = webSocketListener();
 
       // when
-      const app = await createWebSocketServer({ options: { server }, webSocketListener: listener });
+      const app = await createWebSocketServer({ options: { server }, listener });
       await app();
 
       targetClient.once('open', () => {
@@ -163,7 +163,7 @@ describe('WebSocket server', () => {
       const listener = webSocketListener({ effects: [effect$] });
 
       // when
-      const app = await createWebSocketServer({ options: { server }, webSocketListener: listener });
+      const app = await createWebSocketServer({ options: { server }, listener });
       await app();
 
       targetClient.once('open', () => {
@@ -190,7 +190,7 @@ describe('WebSocket server', () => {
       const server = testBed.getServer();
 
       // when
-      const app = await createWebSocketServer({ options: { server }, connection$, webSocketListener: listener });
+      const app = await createWebSocketServer({ options: { server }, connection$, listener });
       await app();
 
       // then
@@ -212,7 +212,7 @@ describe('WebSocket server', () => {
       const server = testBed.getServer();
 
       // when
-      const app = await createWebSocketServer({ options: { server }, connection$, webSocketListener: listener });
+      const app = await createWebSocketServer({ options: { server }, connection$, listener });
       await app();
 
       // then
@@ -258,7 +258,7 @@ describe('WebSocket server', () => {
       const listener = webSocketListener({ effects: [effect$], eventTransformer });
 
       // when
-      const app = await createWebSocketServer({ options: { server }, webSocketListener: listener });
+      const app = await createWebSocketServer({ options: { server }, listener });
       await app();
 
       targetClient.once('open', () => {

--- a/packages/websockets/src/server/websocket.server.interface.ts
+++ b/packages/websockets/src/server/websocket.server.interface.ts
@@ -6,7 +6,7 @@ import { webSocketListener } from './websocket.server.listener';
 
 export interface WebSocketServerConfig {
   options?: WebSocket.ServerOptions;
-  webSocketListener: ReturnType<typeof webSocketListener>;
+  listener: ReturnType<typeof webSocketListener>;
   dependencies?: BoundDependency<any>[];
   connection$?: WsConnectionEffect;
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/core/websockets/messaging** - removed named listeners in server factory functions in place of common naming.

**websockets:**
```typescript
const webSocketServer = createWebSocketServer({
  // ...
  listener: webSocketListener({
    middlewares: [ ],
    effects: [ ],
  }),
});
```

**http:**
```typescript
const server = createServer({
  // ...
  listener: httpListener({
    middlewares: [ ],
    effects: [ ],
  }),
});
```

**messaging:**
```typescript
const microservice = createMicroservice({
  // ...
  listener: messagingListener({
    middlewares: [ ],
    effects: [ ],
  }),
});
```


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
I believe that this is the last breaking change that I had in my list of API improvements. Having this we can achieve a common interface for defining servers of any type.