### PR TITLE
feat(core): allowed to put `r.applyMeta` on top of route builder

### DIFF
--- a/packages/@integration/src/http/effects/user.effects.ts
+++ b/packages/@integration/src/http/effects/user.effects.ts
@@ -40,10 +40,10 @@ const getUser$ = r.pipe(
         new HttpError('User does not exist', HttpStatus.NOT_FOUND)
       )),
     );
-  }),
-);
+  }));
 
 const getUserBuffered$ = r.pipe(
+  r.applyMeta({ continuous: true }),
   r.matchPath('/:id/buffered'),
   r.matchType('GET'),
   r.useEffect(req$ => {
@@ -62,9 +62,7 @@ const getUserBuffered$ = r.pipe(
         )),
       )),
     );
-  }),
-  r.applyMeta({ continuous: true }),
-);
+  }));
 
 const postUser$ = r.pipe(
   r.matchPath('/'),

--- a/packages/core/src/http/router/http.router.ixbuilder.ts
+++ b/packages/core/src/http/router/http.router.ixbuilder.ts
@@ -20,7 +20,7 @@ const route =
   new IxBuilder<Ready, Empty, RouteEffectSpec>({});
 
 const matchPath = (path: string) => ichainCurry((spec: RouteEffectSpec) =>
-  new IxBuilder<Empty, PathApplied, RouteEffectSpec>({ ...spec, path }));
+  new IxBuilder<Empty | MetaApplied, PathApplied, RouteEffectSpec>({ ...spec, path }));
 
 const matchType = (method: HttpMethod) => ichainCurry((spec: RouteEffectSpec) =>
   new IxBuilder<PathApplied, TypeApplied, RouteEffectSpec>({ ...spec, method }));

--- a/packages/core/src/http/router/specs/http.router.ixbuilder.spec.ts
+++ b/packages/core/src/http/router/specs/http.router.ixbuilder.spec.ts
@@ -43,6 +43,7 @@ describe('#IxRouteBuilder', () => {
     const e$: HttpEffect = req$ => req$;
 
     const route = r.pipe(
+      r.applyMeta({ test0: 0 }),
       r.matchPath('/'),
       r.matchType('GET'),
       r.useEffect(e$),
@@ -53,6 +54,6 @@ describe('#IxRouteBuilder', () => {
     expect(route.path).toEqual('/');
     expect(route.method).toEqual('GET');
     expect(route.effect).toEqual(e$);
-    expect(route.meta).toEqual({ test1: 1, test2: 2 });
+    expect(route.meta).toEqual({ test0: 0, test1: 1, test2: 2 });
   });
 });


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/core** - This improvement allows to put metadata on top of route builder.
```typescript
const foo$ = r.pipe(
  r.applyMeta({ continuous: true }),
  r.matchPath('/'),
  r.matchType('GET'),
  r.useEffect(req$ => {

    return req$.pipe(
      // ...
    );
  }));
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
