### PR TITLE
fix(messaging): apply unknown tag when replying to event-like message

### DIFF
--- a/packages/messaging/src/effects/messaging.effects.helper.ts
+++ b/packages/messaging/src/effects/messaging.effects.helper.ts
@@ -1,6 +1,8 @@
 import { Event, EventMetadata } from '@marblejs/core';
 import { isString, NamedError } from '@marblejs/core/dist/+internal/utils';
 
+export const UNKNOWN_TAG = '_UNKNOWN_';
+
 export class MissingEventTypeError extends NamedError {
   constructor() {
     super('MissingEventTypeError', `#reply - Missing type literal`);
@@ -15,12 +17,18 @@ function isEventMetadata(metadata: any): metadata is EventMetadata {
   return metadata.correlationId || metadata.replyTo;
 }
 
+const composeMetadata = (originMetadata?: EventMetadata) => (customMetadata?: EventMetadata): EventMetadata => ({
+  raw: originMetadata?.raw ?? customMetadata?.raw,
+  correlationId: originMetadata?.correlationId ?? customMetadata?.correlationId,
+  replyTo: originMetadata?.replyTo ?? customMetadata?.replyTo ?? UNKNOWN_TAG,
+});
+
 export const reply = (to: string | EventMetadata | Event) => <T extends Event>(event: T): T => {
   assertEventType(event);
 
   return isString(to)
-    ? { ...event, metadata: { replyTo: to } }
+    ? { ...event, metadata: composeMetadata(event.metadata)({ replyTo: to }) }
     :  isEventMetadata(to)
-      ? { ...event, metadata: to }
-      : { ...to, ...event };
+      ? { ...event, metadata: composeMetadata(event.metadata)(to) }
+      : { ...to, ...event, metadata: composeMetadata(event.metadata)(to.metadata) };
 };

--- a/packages/messaging/src/effects/specs/messaging.effects.helper.spec.ts
+++ b/packages/messaging/src/effects/specs/messaging.effects.helper.spec.ts
@@ -1,5 +1,5 @@
 import { Event, EventMetadata } from '@marblejs/core';
-import { reply, MissingEventTypeError } from '../messaging.effects.helper';
+import { reply, MissingEventTypeError, UNKNOWN_TAG } from '../messaging.effects.helper';
 
 describe('#reply', () => {
   test('creates success response based on originated event', () => {
@@ -82,6 +82,25 @@ describe('#reply', () => {
       metadata: {
         replyTo,
       },
+    });
+  });
+
+  test(`creates response and applies ${UNKNOWN_TAG} to "replyTo" attribute if incoming event routing metadata is undefined`, () => {
+    // given
+    const origin: Event = {
+      type: 'TEST',
+      metadata: {},
+    };
+
+    // when
+    const response = reply(origin)({
+      type: 'TEST_RESPONSE',
+    });
+
+    // then
+    expect(response).toEqual({
+      type: 'TEST_RESPONSE',
+      metadata: { replyTo: '_UNKNOWN_' },
     });
   });
 

--- a/packages/messaging/src/index.spec.ts
+++ b/packages/messaging/src/index.spec.ts
@@ -8,5 +8,6 @@ describe('@marblejs/messaging', () => {
     expect(API.createMicroservice).toBeDefined();
     expect(API.messagingClient).toBeDefined();
     expect(API.messagingListener).toBeDefined();
+    expect(API.reply).toBeDefined();
   });
 });

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -10,7 +10,7 @@ export { LocalStrategyOptions, EVENT_BUS_CHANNEL } from './transport/strategies/
 
 // effects
 export * from './effects/messaging.effects.interface';
-export * from './effects/messaging.effects.helper';
+export { reply } from './effects/messaging.effects.helper';
 
 // server
 export * from './server/messaging.server';


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/messaging** - `EventBus` - when acting and replying to incoming event without changing the origin event type and having the routing metadata undefined, the event is sent back to event bus which can cause dead event loop

## What is the new behavior?
- **@marblejs/messaging** - `#reply` applies `_UNKNOWN_` tag in case of the origin event/meta doesn't provide `replyTo` attribute - it will prevent sending back the same event type to event bus

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
