### PR TITLE
fix(core): RxJS operator order correction + jest "node" environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ const config = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest'
   },
+  testEnvironment: 'node',
   testRegex: 'spec\.ts$',
   coverageDirectory: './coverage/',
   coveragePathIgnorePatterns: [

--- a/packages/@integration/src/messaging/client.ts
+++ b/packages/@integration/src/messaging/client.ts
@@ -19,6 +19,9 @@ const client = messagingClient({
     host: 'amqp://localhost:5672',
     queue: 'test_queue',
     queueOptions: { durable: false },
+    timeout: isTestEnv()
+      ? 500
+      : 30 * 1000,
   },
 });
 

--- a/packages/core/src/http/server/http.server.event.subscriber.ts
+++ b/packages/core/src/http/server/http.server.event.subscriber.ts
@@ -1,9 +1,8 @@
 import * as http from 'http';
 import * as net from 'net';
 import { Subject, Observable } from 'rxjs';
-import { takeWhile } from 'rxjs/operators';
 import { HttpServer } from '../http.interface';
-import { ServerEventType, ServerEvent, AllServerEvents, isCloseEvent } from './http.server.event';
+import { ServerEventType, ServerEvent, AllServerEvents } from './http.server.event';
 import { DEFAULT_HOSTNAME } from './http.server.interface';
 
 export const subscribeServerEvents = (hostname?: string) => (httpServer: HttpServer): Observable<AllServerEvents> => {
@@ -50,7 +49,5 @@ export const subscribeServerEvents = (hostname?: string) => (httpServer: HttpSer
     event$.next(ServerEvent.listening(serverAddressInfo.port, hostname ?? DEFAULT_HOSTNAME));
   });
 
-  return event$
-    .asObservable()
-    .pipe(takeWhile(e => !isCloseEvent(e), true));
+  return event$.asObservable();
 };

--- a/packages/core/src/http/server/http.server.ts
+++ b/packages/core/src/http/server/http.server.ts
@@ -2,6 +2,7 @@ import * as http from 'http';
 import * as https from 'https';
 import { flow } from 'fp-ts/lib/function';
 import { Subject, merge, EMPTY } from 'rxjs';
+import { takeWhile } from 'rxjs/operators';
 import { createContext, lookup, registerAll, bindTo, resolve } from '../../context/context.factory';
 import { createEffectContext } from '../../effects/effectsContext.factory';
 import { isTestingMetadataOn } from '../../+internal/testing';
@@ -15,6 +16,7 @@ import { subscribeServerEvents } from './http.server.event.subscriber';
 import { HttpServerClientToken, HttpServerEventStreamToken, HttpRequestMetadataStorageToken, HttpRequestBusToken } from './http.server.tokens';
 import { httpRequestMetadataStorage } from './http.server.metadata.storage';
 import { CreateServerConfig } from './http.server.interface';
+import { isCloseEvent } from './http.server.event';
 
 export const createServer = async (config: CreateServerConfig) => {
   const { listener, event$, port, hostname, dependencies = [], options = {} } = config;
@@ -50,6 +52,8 @@ export const createServer = async (config: CreateServerConfig) => {
     listening$(serverEvent$, ctx),
     error$(serverEvent$, ctx),
     close$(serverEvent$, ctx),
+  ).pipe(
+    takeWhile(e => !isCloseEvent(e), true)
   ).subscribe();
 
   const listen: ServerIO<HttpServer> = () => new Promise((resolve, reject) => {

--- a/packages/messaging/src/server/specs/messaging.server.amqp.spec.ts
+++ b/packages/messaging/src/server/specs/messaging.server.amqp.spec.ts
@@ -12,6 +12,7 @@ const createOptions = (config: { expectAck?: boolean; queue?: string } = {}): Am
   queue: config.queue || 'test_queue_server',
   expectAck: config.expectAck,
   queueOptions: { durable: false },
+  timeout: 500,
 });
 
 describe('messagingServer::AMQP', () => {
@@ -40,6 +41,7 @@ describe('messagingServer::AMQP', () => {
     expect(parsedResult1).toEqual({ type: 'RPC_TEST_RESULT', payload: 11 });
 
     await microservice.close();
+    await client.close();
   });
 
   test('handles published event', async done => {
@@ -47,7 +49,11 @@ describe('messagingServer::AMQP', () => {
 
     eventSubject.subscribe(event => {
       expect(event).toEqual({ type: 'EVENT_TEST_RESPONSE', payload: 2 });
-      setTimeout(() => microservice.close().then(done), 1000);
+      setTimeout(async () => {
+        await microservice.close();
+        await client.close();
+        done();
+      }, 1000);
     });
 
     const event$: MsgEffect = event$ =>
@@ -72,7 +78,11 @@ describe('messagingServer::AMQP', () => {
 
     eventSubject.subscribe(event => {
       expect(event).toEqual({ type: 'EVENT_TEST_RESPONSE', payload: 2 });
-      setTimeout(() => microservice.close().then(done), 1000);
+      setTimeout(async () => {
+        await microservice.close();
+        await client.close();
+        done();
+      }, 1000);
     });
 
     const event$: MsgEffect = (event$, { client }) =>
@@ -107,7 +117,11 @@ describe('messagingServer::AMQP', () => {
         expect(data[0][1]).toEqual(error);
         expect(data[1][0]).toEqual(event2);
         expect(data[1][1]).toBeUndefined();
-        setTimeout(() => microservice.close().then(done), 1000);
+        setTimeout(async () => {
+          await microservice.close();
+          await client.close();
+          done();
+        }, 1000);
       });
 
     const event1$: MsgEffect = event$ =>

--- a/packages/middleware-io/test/io-ws.integration.spec.ts
+++ b/packages/middleware-io/test/io-ws.integration.spec.ts
@@ -17,14 +17,14 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
 
     // when
     const app = await createWebSocketServer({ options: { server }, listener });
-    await app();
+    const webSocketServer = await app();
 
     targetClient.once('open', () => targetClient.send(event));
 
     // then
     targetClient.once('message', message => {
       expect(message).toEqual(event);
-      done();
+      webSocketServer.close(done);
     });
   });
 
@@ -45,7 +45,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
 
     // when
     const app = await createWebSocketServer({ options: { server }, listener });
-    await app();
+    const webSocketServer = await app();
 
     targetClient.once('open', () => targetClient.send(event));
 
@@ -53,7 +53,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
     targetClient.once('message', message => {
       const parsedMessage = JSON.parse(message);
       expect(parsedMessage).toEqual(expectedError);
-      done();
+      webSocketServer.close(done);
     });
   });
 });

--- a/packages/middleware-logger/src/logger.handler.ts
+++ b/packages/middleware-logger/src/logger.handler.ts
@@ -17,13 +17,13 @@ export const loggerHandler = (opts: LoggerOptions, logger: Logger) => (stamp: Ti
     map(factorizeLog(stamp)),
     tap(message => {
       const level = res.statusCode >= 500
-        ? LoggerLevel.ERROR
-        : res.statusCode >= 400
-          ? LoggerLevel.WARN
-          : LoggerLevel.INFO;
+      ? LoggerLevel.ERROR
+      : res.statusCode >= 400
+        ? LoggerLevel.WARN
+        : LoggerLevel.INFO;
 
       const log = logger({ tag: LoggerTag.HTTP, type: 'RequestLogger', message, level });
       return log();
-    })
+    }),
   );
 }

--- a/packages/middleware-logger/src/spec/logger.middleware.spec.ts
+++ b/packages/middleware-logger/src/spec/logger.middleware.spec.ts
@@ -9,7 +9,7 @@ describe('logger$', () => {
 
   beforeEach(() => {
     const client = jest.fn() as any as HttpServer;
-    logger = jest.fn() as any as Logger;
+    logger = jest.fn(() => jest.fn());
 
     const boundLogger = bindTo(LoggerToken)(() => logger);
     const context = register(boundLogger)(createContext());

--- a/packages/websockets/src/server/specs/websocket.server.spec.ts
+++ b/packages/websockets/src/server/specs/websocket.server.spec.ts
@@ -25,14 +25,14 @@ describe('WebSocket server', () => {
 
       // when
       const app = await createWebSocketServer({ options: { server }, listener });
-      await app();
+      const webSocketServer = await app();
 
       targetClient.once('open', () => targetClient.send(event));
 
       // then
       targetClient.once('message', message => {
         expect(message).toEqual(event);
-        done();
+        webSocketServer.close(done);
       });
     });
 
@@ -48,7 +48,7 @@ describe('WebSocket server', () => {
 
       // when
       const app = await createWebSocketServer({ options: { server }, listener });
-      await app();
+      const webSocketServer = await app();
 
       targetClient.on('open', () => targetClient.send(JSON.stringify(event)));
 
@@ -59,7 +59,7 @@ describe('WebSocket server', () => {
       forkJoin(client1$, client2$).subscribe(([ message1, message2 ]: [any, any]) => {
         expect(JSON.parse(message1.data)).toEqual(expect.objectContaining(event));
         expect(JSON.parse(message2.data)).toEqual(expect.objectContaining(event));
-        done();
+        webSocketServer.close(done);
       });
     });
 
@@ -86,7 +86,7 @@ describe('WebSocket server', () => {
       // then
       targetClient.once('message', message => {
         expect(message).toEqual(event);
-        done();
+        webSocketServer.close(done);
       });
     });
 
@@ -107,14 +107,14 @@ describe('WebSocket server', () => {
 
       // when
       const app = await createWebSocketServer({ options: { server }, listener })
-      await app();
+      const webSocketServer = await app();
 
       targetClient.once('open', () => targetClient.send(incomingEvent));
 
       // then
       targetClient.once('message', message => {
         expect(message).toEqual(outgoingEvent);
-        done();
+        webSocketServer.close(done);
       });
     });
 
@@ -131,7 +131,7 @@ describe('WebSocket server', () => {
 
       // when
       const app = await createWebSocketServer({ options: { server }, listener });
-      await app();
+      const webSocketServer = await app();
 
       targetClient.once('open', () => {
         targetClient.send(incomingEvent);
@@ -144,7 +144,7 @@ describe('WebSocket server', () => {
         .subscribe((messages: any[]) => {
           expect(messages[0].data).toEqual(outgoingEvent);
           expect(messages[1].data).toEqual(outgoingEvent);
-          done();
+          webSocketServer.close(done);
         });
     });
 
@@ -164,7 +164,7 @@ describe('WebSocket server', () => {
 
       // when
       const app = await createWebSocketServer({ options: { server }, listener });
-      await app();
+      const webSocketServer = await app();
 
       targetClient.once('open', () => {
         targetClient.send(incomingEvent);
@@ -177,7 +177,7 @@ describe('WebSocket server', () => {
         .subscribe((messages: any[]) => {
           expect(messages[0].data).toEqual(outgoingEvent);
           expect(messages[1].data).toEqual(outgoingEvent);
-          done();
+          webSocketServer.close(done);
         });
     });
 
@@ -191,7 +191,7 @@ describe('WebSocket server', () => {
 
       // when
       const app = await createWebSocketServer({ options: { server }, connection$, listener });
-      await app();
+      const webSocketServer = await app();
 
       // then
       merge(
@@ -199,7 +199,7 @@ describe('WebSocket server', () => {
         fromEvent(targetClient2, 'open'),
       )
       .pipe(take(2), toArray())
-      .subscribe(() => done());
+      .subscribe(() => webSocketServer.close(done));
     });
 
     test('triggers connection error', async done => {
@@ -213,7 +213,7 @@ describe('WebSocket server', () => {
 
       // when
       const app = await createWebSocketServer({ options: { server }, connection$, listener });
-      await app();
+      const webSocketServer = await app();
 
       // then
       merge(
@@ -227,7 +227,7 @@ describe('WebSocket server', () => {
           expect(data[1][1].statusCode).toEqual(error.status);
           expect(data[0][1].statusMessage).toEqual(error.message);
           expect(data[1][1].statusMessage).toEqual(error.message);
-          done();
+          webSocketServer.close(done);
         },
       );
     });
@@ -259,7 +259,7 @@ describe('WebSocket server', () => {
 
       // when
       const app = await createWebSocketServer({ options: { server }, listener });
-      await app();
+      const webSocketServer = await app();
 
       targetClient.once('open', () => {
         targetClient.send(Buffer.from(message));
@@ -268,7 +268,7 @@ describe('WebSocket server', () => {
       // then
       targetClient.once('message', (incomingMessage: Buffer) => {
         expect(incomingMessage.toString('utf8')).toEqual(message);
-        done();
+        webSocketServer.close(done);
       });
     });
   });


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/core** - Corrected RxJS `takeWhile`, `takeUntil` and `take` order as described in [Nicholas Jamieson article](https://ncjamieson.com/avoiding-takeuntil-leaks/).
- Added `node` test environment to `jest` config.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
