### PR TITLE
feat(websockets): event handler

### DIFF
--- a/packages/core/src/http/server/http.server.interface.ts
+++ b/packages/core/src/http/server/http.server.interface.ts
@@ -1,17 +1,16 @@
 import * as https from 'https';
 import { HttpServerEffect } from '../effects/http.effects.interface';
-import { BoundDependency } from '../../context/context.factory';
+import { ServerConfig } from '../../listener/listener.interface';
 import { httpListener } from './http.server.listener';
 
 export const DEFAULT_HOSTNAME = '127.0.0.1';
 
-export interface CreateServerConfig {
+type HttpListenerFn = ReturnType<typeof httpListener>;
+
+export interface CreateServerConfig extends ServerConfig<HttpServerEffect, HttpListenerFn> {
   port?: number;
   hostname?: string;
-  listener: ReturnType<typeof httpListener>;
-  event$?: HttpServerEffect;
   options?: ServerOptions;
-  dependencies?: BoundDependency<any>[];
 }
 
 export interface ServerOptions {

--- a/packages/core/src/listener/listener.interface.ts
+++ b/packages/core/src/listener/listener.interface.ts
@@ -1,7 +1,7 @@
 import { IO } from 'fp-ts/lib/IO';
 import { Reader } from 'fp-ts/lib/Reader';
 import { Effect } from '../effects/effects.interface';
-import { Context } from '../context/context.factory';
+import { Context, BoundDependency } from '../context/context.factory';
 
 export interface ListenerConfig<T = any> {
   effects?: any[];
@@ -12,10 +12,22 @@ export interface ListenerConfig<T = any> {
 
 export type ListenerHandler = (...args: any[]) => void;
 
-export interface Listener<T extends ListenerConfig, U extends ListenerHandler> {
+export interface Listener<
+  T extends ListenerConfig = ListenerConfig,
+  U extends ListenerHandler = ListenerHandler,
+> {
   (config?: T): Reader<Context, U>;
 }
 
 export interface ServerIO<T> extends IO<Promise<T>> {
   context: Context;
+}
+
+export interface ServerConfig<
+  T extends Effect<any, any, any>,
+  U extends ReturnType<Listener> = ReturnType<Listener>,
+> {
+  event$?: T;
+  listener: U;
+  dependencies?: BoundDependency<any>[];
 }

--- a/packages/messaging/src/server/messaging.server.interface.ts
+++ b/packages/messaging/src/server/messaging.server.interface.ts
@@ -1,13 +1,10 @@
-import { BoundDependency, ServerIO } from '@marblejs/core';
+import { ServerConfig, ServerIO } from '@marblejs/core';
 import { MsgServerEffect } from '../effects/messaging.effects.interface';
 import { TransportStrategy, TransportLayerConnection } from '../transport/transport.interface';
 import { messagingListener } from './messaging.server.listener';
 
-type ConfigurationBase =  {
-  listener: ReturnType<typeof messagingListener>;
-  dependencies?: BoundDependency<any>[];
-  event$?: MsgServerEffect;
-}
+type MessagingListenerFn = ReturnType<typeof messagingListener>;
+type ConfigurationBase = ServerConfig<MsgServerEffect, MessagingListenerFn>;
 
 export type CreateMicroserviceConfig =
   & TransportStrategy

--- a/packages/middleware-joi/test/unit/body.spec.ts
+++ b/packages/middleware-joi/test/unit/body.spec.ts
@@ -10,6 +10,10 @@ const MockReq = require('mock-req');
 describe('Joi middleware - Body', () => {
   const ctx = createMockEffectContext();
 
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => jest.fn());
+  });
+
   it(`throws an error if doesn't pass a required field`, done => {
     expect.assertions(2);
 

--- a/packages/middleware-joi/test/unit/header.spec.ts
+++ b/packages/middleware-joi/test/unit/header.spec.ts
@@ -6,6 +6,10 @@ import { createHttpRequest } from '@marblejs/core/dist/+internal/testing';
 import { validator$, Joi } from '../../src';
 
 describe('Joi middleware - Header', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => jest.fn());
+  });
+
   test('should throws an error if dont pass a required field', done => {
     expect.assertions(2);
 

--- a/packages/middleware-joi/test/unit/params.spec.ts
+++ b/packages/middleware-joi/test/unit/params.spec.ts
@@ -15,6 +15,10 @@ const reqMatched = (
   } as any) as HttpRequest);
 
 describe('Joi middleware - Params', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => jest.fn());
+  });
+
   it('should throws an error if dont pass a required field', done => {
     expect.assertions(2);
 
@@ -31,7 +35,6 @@ describe('Joi middleware - Params', () => {
     http$.subscribe(
       () => {
         fail('Exceptions should be thrown');
-        done();
       },
       error => {
         expect(error).toBeDefined();
@@ -55,7 +58,6 @@ describe('Joi middleware - Params', () => {
     http$.subscribe(
       () => {
         fail('Exceptions should be thrown');
-        done();
       },
       error => {
         expect(error).toBeDefined();

--- a/packages/middleware-joi/test/unit/query.spec.ts
+++ b/packages/middleware-joi/test/unit/query.spec.ts
@@ -10,6 +10,10 @@ const reqMatched = (
 ) => ({ url, matchers, params, query } as any as HttpRequest);
 
 describe('Joi middleware - Query', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => jest.fn());
+  });
+
   test('should throws an error if dont pass a required field', done => {
     expect.assertions(2);
 

--- a/packages/middleware-joi/test/unit/schema.spec.ts
+++ b/packages/middleware-joi/test/unit/schema.spec.ts
@@ -3,6 +3,10 @@ import { Observable } from 'rxjs';
 import { validator$ } from '../../src';
 
 describe('Joi middleware - Schema', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => jest.fn());
+  });
+
   it('should throws an error if using an invalid schema', done => {
     const schema = { headers: 'foo' };
     const http$ = validator$(schema)(undefined as unknown as Observable<HttpRequest>);
@@ -23,7 +27,6 @@ describe('Joi middleware - Schema', () => {
     http$.subscribe(
       () => {
         fail('Exceptions should be thrown');
-        done();
       },
       error => {
         expect(error).toBeDefined();

--- a/packages/websockets/src/effects/websocket.effects.interface.ts
+++ b/packages/websockets/src/effects/websocket.effects.interface.ts
@@ -15,6 +15,9 @@ export interface WsConnectionEffect<
   T extends http.IncomingMessage = http.IncomingMessage
 > extends WsEffect<T, T, undefined> {}
 
+export interface WsServerEffect<T extends Event = Event>
+  extends WsEffect<T, any, undefined> {}
+
 export interface WsOutputEffect<
   T extends Event = Event
 > extends WsEffect<T, Event> {}

--- a/packages/websockets/src/middlewares/websockets.statusLogger.middleware.ts
+++ b/packages/websockets/src/middlewares/websockets.statusLogger.middleware.ts
@@ -1,0 +1,71 @@
+import { matchEvent, useContext, combineEffects, LoggerToken, LoggerLevel, LoggerTag } from '@marblejs/core';
+import { map, tap } from 'rxjs/operators';
+import { WsServerEffect } from '../effects/websocket.effects.interface';
+import { ServerEvent } from '../server/websocket.server.event';
+
+const connection$: WsServerEffect = (event$, ctx) => {
+  const logger = useContext(LoggerToken)(ctx.ask);
+
+  return event$.pipe(
+    matchEvent(ServerEvent.connection),
+    map(event => event.payload),
+    tap(({ client }) => logger({
+      type: 'Server',
+      message: `Connected incoming client "${client.id}" (${client.address})`,
+      level: LoggerLevel.INFO,
+      tag: LoggerTag.WEBSOCKETS,
+    })()),
+  );
+};
+
+const listening$: WsServerEffect = (event$, ctx) => {
+  const logger = useContext(LoggerToken)(ctx.ask);
+
+  return event$.pipe(
+    matchEvent(ServerEvent.listening),
+    map(event => event.payload),
+    tap(({ host, port }) => logger({
+      type: 'Server',
+      message: `WebSocket server running @ http://${host}:${port}/ 🚀`,
+      level: LoggerLevel.INFO,
+      tag: LoggerTag.WEBSOCKETS,
+    })())
+  );
+};
+
+const close$: WsServerEffect = (event$, ctx) => {
+  const logger = useContext(LoggerToken)(ctx.ask);
+
+  return event$.pipe(
+    matchEvent(ServerEvent.close),
+    map(event => event.payload),
+    tap(logger({
+      type: 'Server',
+      message: 'Server connection was closed',
+      level: LoggerLevel.INFO,
+      tag: LoggerTag.WEBSOCKETS,
+    }))
+  );
+};
+
+const error$: WsServerEffect = (event$, ctx) => {
+  const logger = useContext(LoggerToken)(ctx.ask);
+
+  return event$.pipe(
+    matchEvent(ServerEvent.error),
+    map(event => event.payload),
+    tap(({ error }) => logger({
+      type: 'Server',
+      message: `Unexpected error occured: "${error.name}", "${error.message}"`,
+      level: LoggerLevel.ERROR,
+      tag: LoggerTag.WEBSOCKETS,
+    })())
+  );
+};
+
+export const statusLogger$ = combineEffects(
+  connection$,
+  listening$,
+  error$,
+  close$,
+);

--- a/packages/websockets/src/server/websocket.server.event.subscriber.ts
+++ b/packages/websockets/src/server/websocket.server.event.subscriber.ts
@@ -1,0 +1,35 @@
+import * as http from 'http';
+import * as WebSocket from 'ws';
+import { Subject, Observable } from 'rxjs';
+import { ServerEventType, ServerEvent, AllServerEvents } from './websocket.server.event';
+import { DEFAULT_HOSTNAME, WebSocketServerConnection } from './websocket.server.interface';
+
+export const subscribeWebSocketEvents = (server: WebSocketServerConnection): {
+  serverEvent$: Observable<AllServerEvents>;
+  serverEventSubject: Subject<AllServerEvents>;
+} => {
+  const serverEventSubject = new Subject<AllServerEvents>();
+
+  server.on(ServerEventType.HEADERS, (headers: string[], req: http.IncomingMessage) =>
+    serverEventSubject.next(ServerEvent.headers(headers, req)),
+  );
+
+  server.on(ServerEventType.CLOSE, () =>
+    serverEventSubject.next(ServerEvent.close()),
+  );
+
+  server.on(ServerEventType.ERROR, (error: Error) =>
+    serverEventSubject.next(ServerEvent.error(error)),
+  );
+
+  server.on(ServerEventType.LISTENING, () => {
+    const hostname = server.options.host ?? DEFAULT_HOSTNAME;
+    const port = (server.address() as WebSocket.AddressInfo).port;
+    serverEventSubject.next(ServerEvent.listening(port, hostname));
+  });
+
+  return {
+    serverEvent$: serverEventSubject.asObservable(),
+    serverEventSubject,
+  };
+};

--- a/packages/websockets/src/server/websocket.server.event.ts
+++ b/packages/websockets/src/server/websocket.server.event.ts
@@ -1,0 +1,55 @@
+import * as http from 'http';
+import { createEvent, EventsUnion, Event  } from '@marblejs/core';
+import { WebSocketClientConnection } from './websocket.server.interface';
+
+export enum ServerEventType {
+  LISTENING = 'listening',
+  HEADERS = 'headers',
+  CONNECTION = 'connection',
+  CLOSE = 'close',
+  ERROR = 'error',
+}
+
+export const ServerEvent = {
+  listening: createEvent(
+    ServerEventType.LISTENING,
+    (port: number, host: string) => ({ port, host }),
+  ),
+  headers: createEvent(
+    ServerEventType.HEADERS,
+    (headers: string[], req: http.IncomingMessage) => ({ headers, req }),
+  ),
+  connection: createEvent(
+    ServerEventType.CONNECTION,
+    (client: WebSocketClientConnection, req: http.IncomingMessage) => ({ client, req }),
+  ),
+  close: createEvent(
+    ServerEventType.CLOSE,
+  ),
+  error: createEvent(
+    ServerEventType.ERROR,
+    (error: Error) => ({ error }),
+  )
+};
+
+export type AllServerEvents = EventsUnion<typeof ServerEvent>;
+
+export function isListeningEvent(event: Event): event is ReturnType<typeof ServerEvent.listening> {
+  return event.type === ServerEventType.LISTENING;
+}
+
+export function isHeadersEvent(event: Event): event is ReturnType<typeof ServerEvent.headers> {
+  return event.type === ServerEventType.HEADERS;
+}
+
+export function isConnectionEvent(event: Event): event is ReturnType<typeof ServerEvent.connection> {
+  return event.type === ServerEventType.CONNECTION;
+}
+
+export function isCloseEvent(event: Event): event is ReturnType<typeof ServerEvent.close> {
+  return event.type === ServerEventType.CLOSE;
+}
+
+export function isErrorEvent(event: Event): event is ReturnType<typeof ServerEvent.error> {
+  return event.type === ServerEventType.ERROR;
+}

--- a/packages/websockets/src/server/websocket.server.interface.ts
+++ b/packages/websockets/src/server/websocket.server.interface.ts
@@ -1,13 +1,15 @@
 import * as WebSocket from 'ws';
 import { Observable } from 'rxjs';
-import { BoundDependency, Event } from '@marblejs/core';
-import { WsConnectionEffect } from '../effects/websocket.effects.interface';
+import { Event, ServerConfig } from '@marblejs/core';
+import { WsConnectionEffect, WsServerEffect } from '../effects/websocket.effects.interface';
 import { webSocketListener } from './websocket.server.listener';
 
-export interface WebSocketServerConfig {
+export const DEFAULT_HOSTNAME = '127.0.0.1';
+
+type WebSocketListenerFn = ReturnType<typeof webSocketListener>;
+
+export interface WebSocketServerConfig extends ServerConfig<WsServerEffect, WebSocketListenerFn> {
   options?: WebSocket.ServerOptions;
-  listener: ReturnType<typeof webSocketListener>;
-  dependencies?: BoundDependency<any>[];
   connection$?: WsConnectionEffect;
 }
 

--- a/packages/websockets/src/server/websocket.server.ts
+++ b/packages/websockets/src/server/websocket.server.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import * as WebSocket from 'ws';
 import { Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, takeWhile } from 'rxjs/operators';
 import { flow } from 'fp-ts/lib/function';
 import {
   bindTo,
@@ -17,23 +17,29 @@ import {
   lookup,
   logger,
   logContext,
-  useContext,
-  LoggerLevel,
+  combineEffects,
 } from '@marblejs/core';
 import { isTestEnv, createUuid } from '@marblejs/core/dist/+internal/utils';
 import { createServer, handleServerBrokenConnections, handleClientBrokenConnection } from '../server/websocket.server.helper';
 import { handleBroadcastResponse, handleResponse } from '../response/websocket.response.handler';
 import { WebSocketConnectionError } from '../error/websocket.error.model';
+import { statusLogger$ } from '../middlewares/websockets.statusLogger.middleware';
 import { WebSocketServerConfig, WebSocketClientConnection, WebSocketServerConnection } from './websocket.server.interface';
+import { subscribeWebSocketEvents } from './websocket.server.event.subscriber';
+import { isCloseEvent, ServerEventType, ServerEvent } from './websocket.server.event';
 
 export const createWebSocketServer = async (config: WebSocketServerConfig) => {
   const {
+    event$,
     options,
     dependencies = [],
     listener,
     connection$ = (req$: Observable<http.IncomingMessage>) => req$,
   } = config;
 
+  /**
+   * @deprecated legacy API - will be removed in version v4
+   */
   const verifyClient = (context: Context): WebSocket.VerifyClientCallbackAsync => (info, callback) => {
     connection$(of(info.req), createEffectContext({ ask: lookup(context), client: undefined }))
       .pipe(map(Boolean))
@@ -46,16 +52,14 @@ export const createWebSocketServer = async (config: WebSocketServerConfig) => {
   const boundLogger = bindTo(LoggerToken)(isTestEnv() ? mockLogger : logger);
 
   const context = await flow(
-    registerAll([
-      boundLogger,
-      ...dependencies,
-    ]),
+    registerAll([boundLogger, ...dependencies]),
     logContext(LoggerTag.WEBSOCKETS),
     resolve,
   )(createContext());
-  const ask = lookup(context);
-  const providedLogger = useContext(LoggerToken)(ask);
+
   const webSocketListener = listener(context);
+  const ctx = createEffectContext({ ask: lookup(context), client: undefined });
+  const combinedEvents = event$ ? combineEffects(statusLogger$, event$) : statusLogger$;
 
   const server = createServer({
     noServer: true,
@@ -63,47 +67,34 @@ export const createWebSocketServer = async (config: WebSocketServerConfig) => {
     ...options
   }, webSocketListener.eventTransformer);
 
+  const { serverEvent$, serverEventSubject }  = subscribeWebSocketEvents(server);
+
+  combinedEvents(serverEvent$, ctx)
+    .pipe(takeWhile(e => !isCloseEvent(e), true))
+    .subscribe();
+
   const listen: ServerIO<WebSocketServerConnection> = () => new Promise((resolve, reject) => {
     handleServerBrokenConnections(server).subscribe();
 
-    server.on('connection', (client: WebSocketClientConnection, req: http.IncomingMessage) => {
+    server.once(ServerEventType.CONNECTION, (client: WebSocketClientConnection, req: http.IncomingMessage) => {
       client.sendResponse = handleResponse(client, webSocketListener.eventTransformer);
       client.sendBroadcastResponse = handleBroadcastResponse(server, webSocketListener.eventTransformer);
       client.isAlive = true;
       client.id = createUuid();
       client.address = req.connection.remoteAddress ?? '-';
 
-      const message = `Connected incoming client "${client.id}" (${client.address})`;
-      const log = providedLogger({ tag: LoggerTag.WEBSOCKETS, type: 'Server', message });
+      serverEventSubject.next(ServerEvent.connection(client, req));
 
       handleClientBrokenConnection(client).subscribe();
       webSocketListener(client);
-      log();
     });
 
     if (server.options.noServer) {
       return resolve(server);
     }
 
-    const { port } = server.address() as WebSocket.AddressInfo;
-    const DEFAULT_HOSTNAME = '127.0.0.1';
-    const hostname = server.options.host ?? DEFAULT_HOSTNAME;
-
-    server.once('error', error => {
-      const message = `An error occured while connecting to WebSocket server @ http://${hostname}:${port}/`;
-      const log = providedLogger({ tag: LoggerTag.WEBSOCKETS, type: 'Server', message, level: LoggerLevel.ERROR });
-
-      log();
-      reject(error);
-    });
-
-    server.once('listening', () => {
-      const message = `WebSocket server running @ http://${hostname}:${port}/ 🚀`;
-      const log = providedLogger({ tag: LoggerTag.WEBSOCKETS, type: 'Server', message });
-
-      log();
-      resolve(server);
-    });
+    server.once(ServerEventType.ERROR, error => reject(error));
+    server.once(ServerEventType.LISTENING, () => resolve(server));
   });
 
   listen.context = context;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no easy way to subscribe to WebSocket server events, like: `connection`, `error`, etc.

Issue Number: #160 

## What is the new behavior?

Developer can subscribe to incoming server events, eg. incoming connections and also watch for broken connections:

```typescript
const connection$: WsServerEffect = (event$, ctx) =>
  event$.pipe(
    matchEvent(ServerEvent.connection),
    tap(event => {
      const { client } = event.payload;

      client.once('close', () => {
        // do some cleanup...
      });
    }),
  );

export const webSocketServer = createWebSocketServer({
  event$: combineEffects(connection$),
  listener: webSocketListener({ ... }),
});
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
