### PR TITLE
feat(websockets): subscribe to closed client connections via ServerEvent.closeClient

### DIFF
--- a/packages/@integration/src/websockets/websockets.server.ts
+++ b/packages/@integration/src/websockets/websockets.server.ts
@@ -1,12 +1,5 @@
-import {
-  WsEffect,
-  WsConnectionEffect,
-  WebSocketConnectionError,
-  webSocketListener,
-  createWebSocketServer,
-} from '@marblejs/websockets';
-import { iif, throwError, of } from 'rxjs';
-import { mergeMap, buffer, map } from 'rxjs/operators';
+import { WsEffect, webSocketListener, createWebSocketServer } from '@marblejs/websockets';
+import { buffer, map } from 'rxjs/operators';
 import { matchEvent, use } from '@marblejs/core';
 import { eventValidator$, t } from '@marblejs/middleware-io';
 
@@ -24,25 +17,9 @@ const add$: WsEffect = (event$, ctx) =>
     map(payload => ({ type: 'SUM_RESULT', payload })),
   );
 
-const error$: WsEffect = event$ =>
-  event$.pipe(
-    matchEvent('ERROR'),
-    mergeMap(() => throwError(new Error('some_error_message'))),
-  );
-
-const connection$: WsConnectionEffect = req$ =>
-  req$.pipe(
-    mergeMap(req => iif(
-      () => req.headers.upgrade !== 'websocket',
-      throwError(new WebSocketConnectionError('Unauthorized', 4000)),
-      of(req),
-    )),
-  );
-
 export const webSocketServer = createWebSocketServer({
-  connection$,
   listener: webSocketListener({
     middlewares: [],
-    effects: [add$, error$],
+    effects: [add$],
   }),
 });

--- a/packages/websockets/src/index.ts
+++ b/packages/websockets/src/index.ts
@@ -1,6 +1,7 @@
 // server
 export { webSocketListener, WebSocketListenerConfig } from './server/websocket.server.listener';
 export { createWebSocketServer } from './server/websocket.server';
+export * from './server/websocket.server.event';
 export * from './server/websocket.server.interface';
 
 // common

--- a/packages/websockets/src/middlewares/websockets.statusLogger.middleware.ts
+++ b/packages/websockets/src/middlewares/websockets.statusLogger.middleware.ts
@@ -38,13 +38,27 @@ const close$: WsServerEffect = (event$, ctx) => {
 
   return event$.pipe(
     matchEvent(ServerEvent.close),
-    map(event => event.payload),
-    tap(logger({
+    tap(() => logger({
       type: 'Server',
       message: 'Server connection was closed',
       level: LoggerLevel.INFO,
       tag: LoggerTag.WEBSOCKETS,
-    }))
+    })())
+  );
+};
+
+const closeClient$: WsServerEffect = (event$, ctx) => {
+  const logger = useContext(LoggerToken)(ctx.ask);
+
+  return event$.pipe(
+    matchEvent(ServerEvent.closeClient),
+    map(event => event.payload),
+    tap(({ client }) => logger({
+      type: 'Server',
+      message: `Closed connection form client "${client.id}" (${client.address})`,
+      level: LoggerLevel.INFO,
+      tag: LoggerTag.WEBSOCKETS,
+    })())
   );
 };
 
@@ -68,4 +82,5 @@ export const statusLogger$ = combineEffects(
   listening$,
   error$,
   close$,
+  closeClient$,
 );

--- a/packages/websockets/src/server/specs/websocket.server.event.spec.ts
+++ b/packages/websockets/src/server/specs/websocket.server.event.spec.ts
@@ -1,0 +1,121 @@
+import { tap } from 'rxjs/operators';
+import { matchEvent } from '@marblejs/core';
+import { ServerEvent, ServerEventType } from '../websocket.server.event';
+import { webSocketListener } from '../websocket.server.listener';
+import { bootstrapHttpServer, bootstrapWebSocketClient, bootstrapWebSocketServer } from '../../+internal';
+import { WsServerEffect } from '../../effects/websocket.effects.interface';
+
+describe('WebSocket events', () => {
+
+  test(`emits "${ServerEventType.LISTENING}" when no server passed`, async done => {
+    const listening$: WsServerEffect = event$ =>
+      event$.pipe(
+        matchEvent(ServerEvent.listening),
+        tap(event => {
+          expect(event.type).toEqual(ServerEventType.LISTENING);
+          expect(event.payload.host).toEqual(expect.any(String));
+          expect(event.payload.port).toEqual(expect.any(Number));
+          done();
+        }),
+      );
+
+    const webSocketServer = await bootstrapWebSocketServer({ port: 8060 }, webSocketListener(), listening$);
+    webSocketServer.close();
+  });
+
+  test(`emits "${ServerEventType.LISTENING}" when server passed`, async done => {
+    const listening$: WsServerEffect = event$ =>
+      event$.pipe(
+        matchEvent(ServerEvent.listening),
+        tap(event => {
+          expect(event.type).toEqual(ServerEventType.LISTENING);
+          expect(event.payload.host).toEqual(expect.any(String));
+          expect(event.payload.port).toEqual(expect.any(Number));
+          done();
+        }),
+      );
+
+    const httpServer = await bootstrapHttpServer();
+    const webSocketServer = await bootstrapWebSocketServer({ server: httpServer }, webSocketListener(), listening$);
+    webSocketServer.close();
+    httpServer.close();
+  });
+
+  test(`emits "${ServerEventType.ERROR}"`, async done => {
+    const error = new Error('test');
+    const error$: WsServerEffect = event$ =>
+      event$.pipe(
+        matchEvent(ServerEvent.error),
+        tap(event => {
+          expect(event.type).toEqual(ServerEventType.ERROR);
+          expect(event.payload.error).toBeDefined();
+          done();
+        }),
+      );
+
+    const webSocketServer = await bootstrapWebSocketServer({ port: 8060 }, webSocketListener(), error$);
+    webSocketServer.emit('error', error);
+    webSocketServer.close();
+  });
+
+  test(`emits "${ServerEventType.HEADERS}"`, async () => {
+    const headers$: WsServerEffect = event$ =>
+      event$.pipe(
+        matchEvent(ServerEvent.headers),
+        tap(event => {
+          expect(event.type).toEqual(ServerEventType.HEADERS);
+          expect(event.payload.headers).toBeDefined();
+          expect(event.payload.req).toBeDefined();
+        }),
+      );
+
+    const httpServer = await bootstrapHttpServer();
+    const webSocketServer = await bootstrapWebSocketServer({ server: httpServer }, webSocketListener(), headers$);
+    const webSocketClient = await bootstrapWebSocketClient(httpServer);
+
+    webSocketServer.close();
+    webSocketClient.close();
+    httpServer.close();
+  });
+
+  test(`emits "${ServerEventType.CONNECTION}"`, async () => {
+    const connection$: WsServerEffect = event$ =>
+      event$.pipe(
+        matchEvent(ServerEvent.connection),
+        tap(event => {
+          expect(event.type).toEqual(ServerEventType.CONNECTION);
+          expect(event.payload.client).toBeDefined();
+          expect(event.payload.req).toBeDefined();
+        }),
+      );
+
+    const httpServer = await bootstrapHttpServer();
+    const webSocketServer = await bootstrapWebSocketServer({ server: httpServer }, webSocketListener(), connection$);
+    const webSocketClient = await bootstrapWebSocketClient(httpServer);
+
+    webSocketServer.close();
+    webSocketClient.close();
+    httpServer.close();
+  });
+
+  test(`emits "${ServerEventType.CLOSE_CLIENT}"`, async done => {
+    const connection$: WsServerEffect = event$ =>
+      event$.pipe(
+        matchEvent(ServerEvent.closeClient),
+        tap(event => {
+          expect(event.type).toEqual(ServerEventType.CLOSE_CLIENT);
+          expect(event.payload.client).toBeDefined();
+
+          // teardown
+          webSocketServer.close();
+          httpServer.close();
+          done();
+        }),
+      );
+
+    const httpServer = await bootstrapHttpServer();
+    const webSocketServer = await bootstrapWebSocketServer({ server: httpServer }, webSocketListener(), connection$);
+    const webSocketClient = await bootstrapWebSocketClient(httpServer);
+    webSocketClient.close();
+  });
+});

--- a/packages/websockets/src/server/websocket.server.event.ts
+++ b/packages/websockets/src/server/websocket.server.event.ts
@@ -7,6 +7,7 @@ export enum ServerEventType {
   HEADERS = 'headers',
   CONNECTION = 'connection',
   CLOSE = 'close',
+  CLOSE_CLIENT = 'close_client',
   ERROR = 'error',
 }
 
@@ -25,6 +26,10 @@ export const ServerEvent = {
   ),
   close: createEvent(
     ServerEventType.CLOSE,
+   ),
+  closeClient: createEvent(
+    ServerEventType.CLOSE_CLIENT,
+    (client: WebSocketClientConnection) => ({ client }),
   ),
   error: createEvent(
     ServerEventType.ERROR,
@@ -48,6 +53,10 @@ export function isConnectionEvent(event: Event): event is ReturnType<typeof Serv
 
 export function isCloseEvent(event: Event): event is ReturnType<typeof ServerEvent.close> {
   return event.type === ServerEventType.CLOSE;
+}
+
+export function isCloseClientEvent(event: Event): event is ReturnType<typeof ServerEvent.closeClient> {
+  return event.type === ServerEventType.CLOSE_CLIENT;
 }
 
 export function isErrorEvent(event: Event): event is ReturnType<typeof ServerEvent.error> {

--- a/packages/websockets/src/server/websocket.server.interface.ts
+++ b/packages/websockets/src/server/websocket.server.interface.ts
@@ -9,8 +9,11 @@ export const DEFAULT_HOSTNAME = '127.0.0.1';
 type WebSocketListenerFn = ReturnType<typeof webSocketListener>;
 
 export interface WebSocketServerConfig extends ServerConfig<WsServerEffect, WebSocketListenerFn> {
-  options?: WebSocket.ServerOptions;
+  /**
+   * @deprecated: validate connection on `upgrade` or `connection` events instead
+   */
   connection$?: WsConnectionEffect;
+  options?: WebSocket.ServerOptions;
 }
 
 export interface WebSocketServerConnection extends WebSocket.Server {

--- a/packages/websockets/src/server/websocket.server.ts
+++ b/packages/websockets/src/server/websocket.server.ts
@@ -76,7 +76,8 @@ export const createWebSocketServer = async (config: WebSocketServerConfig) => {
   const listen: ServerIO<WebSocketServerConnection> = () => new Promise((resolve, reject) => {
     handleServerBrokenConnections(server).subscribe();
 
-    server.once(ServerEventType.CONNECTION, (client: WebSocketClientConnection, req: http.IncomingMessage) => {
+    server.on(ServerEventType.CONNECTION, (client: WebSocketClientConnection, req: http.IncomingMessage) => {
+      client.once('close', () => serverEventSubject.next(ServerEvent.closeClient(client)));
       client.sendResponse = handleResponse(client, webSocketListener.eventTransformer);
       client.sendBroadcastResponse = handleBroadcastResponse(server, webSocketListener.eventTransformer);
       client.isAlive = true;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #160


## What is the new behavior?
- **@marblejs/websockets** - check and kill incoming connections either via HTTP server `upgrade` event or WebSocket `connection` event
- **@marblejs/websockets** - subscribe to closed client connections via `ServerEvent.closeClient` (`"close_client"`)
- **@marblejs/websockets** - additional status logging middleware for detecting closed client connections
- **@marblejs/websockets** - corrected predicates for `noServer` option
- **@marblejs/websockets** - deprecated `connection$`attribute in `WebSocketServerConfig`
- **@marblejs/websockets** - refactored integration tests (removed leaky "testbed")

```typescript
const connection$: WsServerEffect = (event$) =>
  event$.pipe(
    matchEvent(ServerEvent.connection),
    map(event => event.payload),
    tap(({ client }) => {
      // check if connections should be closed
      client.close();
    }),
  );

const closeClient$: WsServerEffect = (event$) =>
  event$.pipe(
    matchEvent(ServerEvent.closeClient),
    map(event => event.payload),
    tap(({ client }) => {
      // react accordingly
    }),
  );

export const webSocketServer = createWebSocketServer({
  listener: webSocketListener({
    middlewares: [...],
    effects: [...],
  }),
  event$: combineEffects(
    connection$,
    closeClient$,
  ),
});
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
