### PR TITLE
fix(middleware-io): incompatible codecs with io-ts

### DIFF
--- a/packages/middleware-io/package.json
+++ b/packages/middleware-io/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@types/json-schema": "^7.0.3",
-    "io-ts": "~2.0.1"
+    "io-ts": "~2.2.1"
   },
   "devDependencies": {
     "@marblejs/core": "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4304,10 +4304,10 @@ inquirer@^7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-io-ts@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.0.1.tgz#1261c12f915c2f48d16393a36966636b48a45aa1"
-  integrity sha512-RezD+WcCfW4VkMkEcQWL/Nmy/nqsWTvTYg7oUmTGzglvSSV2P9h2z1PVeREPFf0GWNzruYleAt1XCMQZSg1xxQ==
+io-ts@~2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.1.tgz#d8cb21a23cf8fbe697d78445a65bab42c0eb467f"
+  integrity sha512-RufppkTV58MfDKF2gXlHVBvi+WIyL7nUcAQMkJ1O3SiQcqwlxf6dBOJP/LV19UxHRkGKJZ6ImSj7LqYcELIejQ==
 
 ip-regex@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This commit bumps the version of io-ts dependency, fixing issues when
using codecs that are defined directly via io-ts in the context of
`requestValidator$`.

## PR Type

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #256

## What is the new behavior?

Codecs defined via io-ts or marble/middleware-io should now be interchangeable.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
