### PR TITLE
fix(testing): auto detect `Content-Type` when passing HTTP request body

### DIFF
--- a/packages/testing/src/testBed/http/http.testBed.request.spec.ts
+++ b/packages/testing/src/testBed/http/http.testBed.request.spec.ts
@@ -6,7 +6,7 @@ describe('TestBed - HTTP request', () => {
     // given
     const port = 8080;
     const host = '127.0.0.1';
-    const defaultHeaders = { 'Content-Type': 'application/json' };
+    const defaultHeaders = { 'X-User-Id': '123' };
     const req = createRequest(port, host, defaultHeaders);
 
     // when
@@ -31,7 +31,47 @@ describe('TestBed - HTTP request', () => {
         'Authorization': 'Bearer TOKEN',
         'Content-Type': 'application/json',
         'X-Testing-Request-Id': expect.any(String),
+        'X-User-Id': '123',
       },
+    });
+  });
+
+  test('doesn\'t detect "Content-Type" header if defined', () => {
+    // given
+    const port = 8080;
+    const host = '127.0.0.1';
+    const req = createRequest(port, host);
+
+    // when
+    const builtRequest = pipe(
+      req('POST'),
+      withPath('/test'),
+      withHeaders({ 'Content-Type': 'text/html' }),
+      withBody({ foo: 'bar' }),
+    );
+
+    expect(builtRequest.headers).toEqual({
+      'Content-Type': 'text/html',
+      'X-Testing-Request-Id': expect.any(String),
+    });
+  });
+
+  test('detects "Content-Type" header if not defined', () => {
+    // given
+    const port = 8080;
+    const host = '127.0.0.1';
+    const req = createRequest(port, host);
+
+    // when
+    const builtRequest = pipe(
+      req('POST'),
+      withPath('/test'),
+      withBody({ foo: 'bar' }),
+    );
+
+    expect(builtRequest.headers).toEqual({
+      'Content-Type': 'application/json',
+      'X-Testing-Request-Id': expect.any(String),
     });
   });
 });

--- a/packages/testing/src/testBed/http/http.testBed.request.ts
+++ b/packages/testing/src/testBed/http/http.testBed.request.ts
@@ -2,6 +2,7 @@ import { HttpMethod, HttpHeaders } from '@marblejs/core'
 import * as O from 'fp-ts/lib/Option';
 import * as A from 'fp-ts/lib/Array';
 import { pipe } from 'fp-ts/lib/pipeable';
+import { getMimeType } from '@marblejs/core/dist/http/response/http.responseContentType.factory';
 import { HttpTestBedRequest, WithBodyApplied } from './http.testBed.request.interface';
 import { createTestingRequestHeader } from './http.testBed.util';
 
@@ -28,10 +29,16 @@ export const withHeaders = (headers: HttpHeaders) => <T extends HttpMethod>(req:
   headers: { ...req.headers, ...headers },
 });
 
-export const withBody = <T>(body: T) => <U extends 'POST' | 'PUT' | 'PATCH'>(req: HttpTestBedRequest<U>): HttpTestBedRequest<U> & WithBodyApplied<T> => ({
-  ...req,
-  body,
-});
+export const withBody = <T>(body: T) => <U extends 'POST' | 'PUT' | 'PATCH'>(req: HttpTestBedRequest<U>): HttpTestBedRequest<U> & WithBodyApplied<T> =>
+  pipe(
+    getHeader('Content-Type')(req),
+    O.map(() => ({ ...req, body })),
+    O.getOrElse(() => pipe(
+      getMimeType(body, req.path),
+      type => withHeaders({ 'Content-Type': type })(req),
+      req => ({ ...req, body }),
+    ))
+  );
 
 export const getHeader = <T extends string = string>(key: string) => (req: HttpTestBedRequest<any>): O.Option<T> =>
   pipe(


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/testing** - when no `Content-Type` header is defined the `send` method cannot detect the provided body mime type automatically, causing an error.

## What is the new behavior?
- **@marblejs/testing** - corrected `setTestingMetadata` function call
- **@marblejs/testing** - auto detect `Content-Type` when passing HTTP request body 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
