### PR TITLE
fix(core): bodyFactory - support for "application/x-www-form-urlencoded"

### DIFF
--- a/packages/core/src/http/response/http.responseBody.factory.ts
+++ b/packages/core/src/http/response/http.responseBody.factory.ts
@@ -1,17 +1,25 @@
+import * as qs from 'qs';
 import { HttpHeaders } from '../http.interface';
 import { ContentType, getContentType } from '../../+internal/http';
-import { isStream } from '../../+internal/utils';
+import { isStream, isString } from '../../+internal/utils';
 
 export type ResponseBodyFactory = (headers: HttpHeaders) => (body: any) => any;
+export type BodyTransformer = (body: any) => string;
+
+const transformUrlEncoded: BodyTransformer = body =>
+  !isString(body) ? qs.stringify(body) : body;
+
+const transformJson: BodyTransformer = body =>
+  JSON.stringify(body);
 
 export const bodyFactory: ResponseBodyFactory = headers => body => {
-  if (isStream(body)) {
-    return body;
-  }
+  if (isStream(body)) return body;
 
   switch (getContentType(headers)) {
+    case ContentType.APPLICATION_X_WWW_FORM_URLENCODED:
+      return transformUrlEncoded(body);
     case ContentType.APPLICATION_JSON:
-      return JSON.stringify(body);
+      return transformJson(body);
     case ContentType.TEXT_PLAIN:
       return String(body);
     default:

--- a/packages/core/src/http/response/http.responseContentType.factory.ts
+++ b/packages/core/src/http/response/http.responseContentType.factory.ts
@@ -18,7 +18,7 @@ export const contentTypeFactory = (data: {
   status: HttpStatus;
 }) => ({
   'Content-Type':
-    data.status === 200
+    data.status < 400
       ? getMimeType(data.body, data.path)
       : DEFAULT_CONTENT_TYPE,
 });

--- a/packages/core/src/http/response/specs/http.responseBody.factory.spec.ts
+++ b/packages/core/src/http/response/specs/http.responseBody.factory.spec.ts
@@ -3,6 +3,30 @@ import { bodyFactory } from '../http.responseBody.factory';
 
 describe('Response body factory', () => {
 
+  it('#bodyFactory factorizes body for urlencoded', () => {
+    // given
+    const headers = { 'Content-Type': ContentType.APPLICATION_X_WWW_FORM_URLENCODED };
+    const body = { test: 'test' };
+
+    // when
+    const factorizedBody = bodyFactory(headers)(body);
+
+    // then
+    expect(factorizedBody).toEqual('test=test');
+  });
+
+  it('#bodyFactory doesn\'t factorize body for urlencoded if body is stringified', () => {
+    // given
+    const headers = { 'Content-Type': ContentType.APPLICATION_X_WWW_FORM_URLENCODED };
+    const body = 'test=test';
+
+    // when
+    const factorizedBody = bodyFactory(headers)(body);
+
+    // then
+    expect(factorizedBody).toEqual('test=test');
+  });
+
   it('#bodyFactory factorizes body for JSON', () => {
     // given
     const headers = { 'Content-Type': ContentType.APPLICATION_JSON };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/core** - when sending a HTTP response, the handler doesn't detect and transforms `application/x-www-form-urlencoded` body types

## What is the new behavior?
- **@marblejs/core** - added support for auto transforming "application/x-www-form-urlencoded" body types if not already "stringified"
-  **@marblejs/core** - auto detect body `Content-Type` for ALL success responses (< 400)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
