### PR TITLE
feat(testing): cleaned up HttpTestBed interface

### DIFF
--- a/packages/@integration/test/http.integration.spec.ts
+++ b/packages/@integration/test/http.integration.spec.ts
@@ -14,12 +14,12 @@ describe('API integration', () => {
   afterEach(testBedSetup.cleanup);
 
   test('POST "/" returns 404 when route not found', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('POST'),
-      testBed.withPath('/'),
-      testBed.send,
+      request('POST'),
+      request.withPath('/'),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(404);
@@ -30,12 +30,12 @@ describe('API integration', () => {
   });
 
   test('GET "/api/v1" returns status 200', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v1'),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v1'),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(200);
@@ -43,12 +43,12 @@ describe('API integration', () => {
   });
 
   test('GET "/api/v2" returns status 200', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v2'),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v2'),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(200);
@@ -56,12 +56,12 @@ describe('API integration', () => {
   });
 
   test('GET "/api/v3" returns status 400 if provided version is not supported', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v3'),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v3'),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(400);
@@ -82,12 +82,12 @@ describe('API integration', () => {
   });
 
   test('GET "/api/v1/foo" triggers 404 effect', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v1/foo'),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v1/foo'),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(404);
@@ -98,12 +98,12 @@ describe('API integration', () => {
   });
 
   test('GET "/api/v1/error" returns error response', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v1/error'),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v1/error'),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(HttpStatus.NOT_IMPLEMENTED);
@@ -115,13 +115,13 @@ describe('API integration', () => {
   });
 
   test('GET "/api/v1/user" returns collection', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v1/user'),
-      testBed.withHeaders({ 'Authorization': 'Bearer FAKE' }),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v1/user'),
+      request.withHeaders({ 'Authorization': 'Bearer FAKE' }),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(200);
@@ -129,13 +129,13 @@ describe('API integration', () => {
   });
 
   test(`GET "/api/v1/user?email=test%40test.com" returns 200 with "Content-Type": "application/json" `, async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v1/user?email=test%40test.com'),
-      testBed.withHeaders({ 'Authorization': 'Bearer FAKE' }),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v1/user?email=test%40test.com'),
+      request.withHeaders({ 'Authorization': 'Bearer FAKE' }),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(200);
@@ -143,13 +143,13 @@ describe('API integration', () => {
   });
 
   test(`GET "/api/v1/user/10" returns single object`, async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v1/user/10'),
-      testBed.withHeaders({ 'Authorization': 'Bearer FAKE' }),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v1/user/10'),
+      request.withHeaders({ 'Authorization': 'Bearer FAKE' }),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(200);
@@ -157,13 +157,13 @@ describe('API integration', () => {
   });
 
   test('GET "/api/v1/user/0" returns 404 not found', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v1/user/0'),
-      testBed.withHeaders({ 'Authorization': 'Bearer FAKE' }),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v1/user/0'),
+      request.withHeaders({ 'Authorization': 'Bearer FAKE' }),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(404);
@@ -174,12 +174,12 @@ describe('API integration', () => {
   });
 
   test('GET "/api/v1/user/10" returns 401 if not authorized', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/api/v1/user/0'),
-      testBed.send,
+      request('GET'),
+      request.withPath('/api/v1/user/0'),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(401);
@@ -190,15 +190,15 @@ describe('API integration', () => {
   });
 
   test('POST "/api/v1/user" parses body and returns echo for secured route', async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
     const data = { user: { id: 'test_id' } };
 
     const response = await pipe(
-      testBed.req('POST'),
-      testBed.withPath('/api/v1/user'),
-      testBed.withHeaders({ 'Authorization': 'Bearer FAKE' }),
-      testBed.withBody(data),
-      testBed.send,
+      request('POST'),
+      request.withPath('/api/v1/user'),
+      request.withHeaders({ 'Authorization': 'Bearer FAKE' }),
+      request.withBody(data),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(200);
@@ -206,16 +206,16 @@ describe('API integration', () => {
   });
 
   test(`POST "/api/v1/user" parses ${ContentType.APPLICATION_X_WWW_FORM_URLENCODED} body and echoes back for secured route`, async () => {
-    const testBed = await testBedSetup.useTestBed();
+    const { request } = await testBedSetup.useTestBed();
     const data = { user: { id: 'test_id' } };
 
     const response = await pipe(
-      testBed.req('POST'),
-      testBed.withPath('/api/v1/user'),
-      testBed.withHeaders({ 'Authorization': 'Bearer FAKE' }),
-      testBed.withHeaders({ 'Content-Type': ContentType.APPLICATION_X_WWW_FORM_URLENCODED }),
-      testBed.withBody(data),
-      testBed.send,
+      request('POST'),
+      request.withPath('/api/v1/user'),
+      request.withHeaders({ 'Authorization': 'Bearer FAKE' }),
+      request.withHeaders({ 'Content-Type': ContentType.APPLICATION_X_WWW_FORM_URLENCODED }),
+      request.withBody(data),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(200);
@@ -224,12 +224,12 @@ describe('API integration', () => {
 
   describe('files', () => {
     test(`GET "/api/v1/static/index.html" returns static file as "${ContentType.TEXT_HTML}"`, async () => {
-      const testBed = await testBedSetup.useTestBed();
+      const { request } = await testBedSetup.useTestBed();
 
       const response = await pipe(
-        testBed.req('GET'),
-        testBed.withPath('/api/v1/static/index.html'),
-        testBed.send,
+        request('GET'),
+        request.withPath('/api/v1/static/index.html'),
+        request.send,
       );
 
       expect(response.statusCode).toEqual(200);
@@ -238,12 +238,12 @@ describe('API integration', () => {
     });
 
     test(`GET "/api/v1/static/img/flow.png" returns static file as "${ContentType.IMAGE_PNG}"`, async () => {
-      const testBed = await testBedSetup.useTestBed();
+      const { request } = await testBedSetup.useTestBed();
 
       const response = await pipe(
-        testBed.req('GET'),
-        testBed.withPath('/api/v1/static/img/flow.png'),
-        testBed.send,
+        request('GET'),
+        request.withPath('/api/v1/static/img/flow.png'),
+        request.send,
       );
 
       expect(response.statusCode).toEqual(200);
@@ -253,13 +253,13 @@ describe('API integration', () => {
 
   describe('CORS', () => {
     test('OPTIONS "/api/v2" returns 204', async () => {
-      const testBed = await testBedSetup.useTestBed();
+      const { request } = await testBedSetup.useTestBed();
 
       const response = await pipe(
-        testBed.req('OPTIONS'),
-        testBed.withPath('/api/v2'),
-        testBed.withHeaders({ 'Origin': 'fake-origin' }),
-        testBed.send,
+        request('OPTIONS'),
+        request.withPath('/api/v2'),
+        request.withHeaders({ 'Origin': 'fake-origin' }),
+        request.send,
       );
 
       expect(response.statusCode).toEqual(204);
@@ -271,13 +271,13 @@ describe('API integration', () => {
     });
 
     test('GET "/api/v2" returns 200', async () => {
-      const testBed = await testBedSetup.useTestBed();
+      const { request } = await testBedSetup.useTestBed();
 
       const response = await pipe(
-        testBed.req('GET'),
-        testBed.withPath('/api/v2'),
-        testBed.withHeaders({ 'Origin': 'fake-origin' }),
-        testBed.send,
+        request('GET'),
+        request.withPath('/api/v2'),
+        request.withHeaders({ 'Origin': 'fake-origin' }),
+        request.send,
       );
 
       expect(response.statusCode).toEqual(200);

--- a/packages/@integration/test/messaging.integration.spec.ts
+++ b/packages/@integration/test/messaging.integration.spec.ts
@@ -21,12 +21,12 @@ describe('messaging integration', () => {
     'redis',
     'amqp',
   ])('GET /%s/fib returns 10, 11, 12, 13, 14 th fibonacci number', async type => {
-    const testBed = await httpTestBedSetup.useTestBed();
+    const { request } = await httpTestBedSetup.useTestBed();
 
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath(`/${type}/fib/10`),
-      testBed.send,
+      request('GET'),
+      request.withPath(`/${type}/fib/10`),
+      request.send,
     );
 
     expect(response.statusCode).toEqual(200);

--- a/packages/testing/src/testBed/http/http.testBed.interface.ts
+++ b/packages/testing/src/testBed/http/http.testBed.interface.ts
@@ -9,7 +9,8 @@ export interface HttpTestBedConfig {
   defaultHeaders?: HttpHeaders;
 }
 
-export interface HttpTestBed extends TestBed, HttpTestBedRequestBuilder {
+export interface HttpTestBed extends TestBed {
   type: TestBedType.HTTP;
   send: <T extends HttpMethod>(req: HttpTestBedRequest<T>) => Promise<HttpTestBedResponse>;
+  request: HttpTestBedRequestBuilder;
 }

--- a/packages/testing/src/testBed/http/http.testBed.request.interface.ts
+++ b/packages/testing/src/testBed/http/http.testBed.request.interface.ts
@@ -1,5 +1,6 @@
 import { HttpMethod, HttpHeaders } from '@marblejs/core';
-import { createRequest, withHeaders, withBody, withPath } from './http.testBed.request';
+import { withHeaders, withBody, withPath } from './http.testBed.request';
+import { HttpTestBedResponse } from './http.testBed.response.interface';
 
 export interface HttpTestBedRequest<T extends HttpMethod> extends Readonly<{
   host: string;
@@ -16,8 +17,9 @@ export interface WithBodyApplied<T> {
 }
 
 export interface HttpTestBedRequestBuilder {
-  req: ReturnType<typeof createRequest>;
+  <T extends HttpMethod>(method: T): HttpTestBedRequest<T>;
   withHeaders: typeof withHeaders;
   withBody: typeof withBody;
   withPath: typeof withPath;
+  send: <T extends HttpMethod>(req: HttpTestBedRequest<T>) => Promise<HttpTestBedResponse>;
 }

--- a/packages/testing/src/testBed/http/http.testBed.spec.ts
+++ b/packages/testing/src/testBed/http/http.testBed.spec.ts
@@ -25,7 +25,7 @@ describe('TetBed - HTTP', () => {
 
     const listener = httpListener();
     const testBed = await createHttpTestBed({ listener, defaultHeaders })();
-    const req = testBed.req('GET');
+    const req = testBed.request('GET');
 
     expect(req.method).toEqual('GET');
     expect(req.port).toEqual(expect.any(Number));
@@ -50,14 +50,14 @@ describe('TetBed - HTTP', () => {
       )));
 
     const listener = httpListener({ effects: [test$] });
-    const testBed = await createHttpTestBed({ listener })();
+    const { request: req, finish } = await createHttpTestBed({ listener })();
 
     // when
     const response = await pipe(
-      testBed.req('GET'),
-      testBed.withPath('/test'),
-      testBed.withHeaders({ 'Content-Type': 'application/json' }),
-      testBed.send,
+      req('GET'),
+      req.withPath('/test'),
+      req.withHeaders({ 'Content-Type': 'application/json' }),
+      req.send,
     );
 
     // then
@@ -77,7 +77,7 @@ describe('TetBed - HTTP', () => {
       statusMessage: 'OK',
     }));
 
-    await testBed.finish();
+    await finish();
   });
 
   test('creates request with body and sends it', async () => {
@@ -99,15 +99,15 @@ describe('TetBed - HTTP', () => {
       middlewares: [bodyParser$()],
     });
 
-    const testBed = await createHttpTestBed({ listener })();
+    const { request, finish } = await createHttpTestBed({ listener })();
 
     // when
     const response = await pipe(
-      testBed.req('POST'),
-      testBed.withPath('/test'),
-      testBed.withHeaders({ 'Content-Type': 'application/json' }),
-      testBed.withBody({ foo: 'bar' }),
-      testBed.send,
+      request('POST'),
+      request.withPath('/test'),
+      request.withHeaders({ 'Content-Type': 'application/json' }),
+      request.withBody({ foo: 'bar' }),
+      request.send,
     );
 
     // then
@@ -130,6 +130,6 @@ describe('TetBed - HTTP', () => {
     expect(response.metadata.params).not.toBeDefined();
     expect(response.metadata.headers).not.toBeDefined();
 
-    await testBed.finish();
+    await finish();
   });
 });

--- a/packages/testing/src/testBed/http/http.testBed.ts
+++ b/packages/testing/src/testBed/http/http.testBed.ts
@@ -9,7 +9,7 @@ import { TESTING_REQUEST_ID_HEADER, TestingMetadata } from '@marblejs/core/dist/
 import { TestBedType, TestBedFactory } from '../testBed.interface';
 import { HttpTestBedConfig, HttpTestBed } from './http.testBed.interface';
 import { createRequest, withBody, withHeaders, getHeader, withPath } from './http.testBed.request';
-import { HttpTestBedRequest } from './http.testBed.request.interface';
+import { HttpTestBedRequest, HttpTestBedRequestBuilder } from './http.testBed.request.interface';
 import { HttpTestBedResponse } from './http.testBed.response.interface';
 import { createResponse } from './http.testBed.response';
 import { setTestingMetadata } from './http.testBed.util';
@@ -74,7 +74,7 @@ export const createHttpTestBed = (config: HttpTestBedConfig): TestBedFactory<Htt
   const ask = lookup(app.context);
   const finish = closeServer(server);
   const address = getServerAddress(server);
-  const req = createRequest(address.port, address.host, config.defaultHeaders);
+  const request = createRequest(address.port, address.host, config.defaultHeaders) as HttpTestBedRequestBuilder;
 
   const send: typeof sendRequest = async request => {
     const response = await sendRequest(request);
@@ -82,14 +82,16 @@ export const createHttpTestBed = (config: HttpTestBedConfig): TestBedFactory<Htt
     return { ...response, metadata };
   };
 
+  request.withHeaders = withHeaders;
+  request.withBody = withBody;
+  request.withPath = withPath;
+  request.send = send;
+
   return {
     type: TestBedType.HTTP,
-    ask,
     finish,
-    withHeaders,
-    withBody,
-    withPath,
     send,
-    req
+    ask,
+    request
   };
 };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```


## What is the new behavior?
- **@marblejs/testing** - cleaned up HttpTestBed interface (request builder)

**Previous API:**
```typescript
const testBed = await testBedSetup.useTestBed();

const response = await pipe(
  testBed.req('POST'),
  testBed.withPath('/api/v1/user'),
  testBed.withHeaders({ 'Authorization': 'Bearer FAKE' }),
  testBed.withHeaders({ 'Content-Type': 'application/x-www-form-urlencoded' }),
  testBed.withBody(data),
  testBed.send,
);
```

**New API:**
```typescript
const { request } = await testBedSetup.useTestBed();

const response = await pipe(
  request('POST'),
  request.withPath('/api/v1/user'),
  request.withHeaders({ 'Authorization': 'Bearer FAKE' }),
  request.withHeaders({ 'Content-Type': 'application/x-www-form-urlencoded' }),
  request.withBody(data),
  request.send,
);
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```