### PR TITLE
fix(core, testing): incoming/outgoing body parsing

### DIFF
--- a/packages/core/src/+internal/http/contentType.util.ts
+++ b/packages/core/src/+internal/http/contentType.util.ts
@@ -42,3 +42,6 @@ export const getContentType = (headers: HttpHeaders): string => {
     ? Array.isArray(contentType) ? contentType[0] : String(contentType)
     : '';
 };
+
+export const isJsonContentType = (headerValue: string) =>
+  headerValue.includes('json');

--- a/packages/core/src/+internal/utils/any.util.ts
+++ b/packages/core/src/+internal/utils/any.util.ts
@@ -1,5 +1,9 @@
 import { pipe } from 'fp-ts/lib/pipeable';
+import { identity } from 'fp-ts/lib/function';
 import * as O from 'fp-ts/lib/Option';
+import * as E from 'fp-ts/lib/Either';
+import * as qs from 'qs';
+import { isString } from './string.util';
 
 export const isNonNullable = <T>(value: T): value is NonNullable<T> =>
   value !== undefined && value !== null;
@@ -20,3 +24,20 @@ export const wait = (seconds = 1) =>
   new Promise(res => {
     setTimeout(() => res(), seconds * 1000);
   });
+
+export const bufferFrom = (data: any): Buffer =>
+  Buffer.from(data);
+
+export const transformUrlEncoded = (data: any): string =>
+  !isString(data) ? qs.stringify(data) : data;
+
+export const stringifyJson = (data: any): string =>
+  !isString(data) ? JSON.stringify(data) : data;
+
+export const parseJson = (data: any) =>
+  pipe(
+    E.tryCatch(
+      () => JSON.parse(data),
+      () => data),
+    E.fold(identity, identity),
+  );

--- a/packages/core/src/http/response/http.responseBody.factory.ts
+++ b/packages/core/src/http/response/http.responseBody.factory.ts
@@ -1,25 +1,28 @@
-import * as qs from 'qs';
+import { isBuffer } from 'util';
+import { Stream } from 'stream';
+import { pipe } from 'fp-ts/lib/pipeable';
 import { HttpHeaders } from '../http.interface';
-import { ContentType, getContentType } from '../../+internal/http';
-import { isStream, isString } from '../../+internal/utils';
+import { ContentType, getContentType, isJsonContentType } from '../../+internal/http';
+import { isStream, stringifyJson, transformUrlEncoded, bufferFrom } from '../../+internal/utils';
 
-export type ResponseBodyFactory = (headers: HttpHeaders) => (body: any) => any;
-export type BodyTransformer = (body: any) => string;
-
-const transformUrlEncoded: BodyTransformer = body =>
-  !isString(body) ? qs.stringify(body) : body;
-
-const transformJson: BodyTransformer = body =>
-  JSON.stringify(body);
+export type ResponseBodyFactory = (headers: HttpHeaders) => (body: any) => string | Stream | Buffer;
 
 export const bodyFactory: ResponseBodyFactory = headers => body => {
-  if (isStream(body)) return body;
+  const contentType = getContentType(headers);
 
-  switch (getContentType(headers)) {
+  if (isStream(body))
+    return body;
+
+  if (isJsonContentType(contentType))
+    return stringifyJson(body);
+
+  switch (contentType) {
     case ContentType.APPLICATION_X_WWW_FORM_URLENCODED:
       return transformUrlEncoded(body);
-    case ContentType.APPLICATION_JSON:
-      return transformJson(body);
+    case ContentType.APPLICATION_OCTET_STREAM:
+      return !isBuffer(body)
+        ? pipe(body, stringifyJson, bufferFrom)
+        : body;
     case ContentType.TEXT_PLAIN:
       return String(body);
     default:

--- a/packages/middleware-body/test/bodyParser.integration.spec.ts
+++ b/packages/middleware-body/test/bodyParser.integration.spec.ts
@@ -59,7 +59,7 @@ describe('@marblejs/middleware-body - integration', () => {
         .post('/multiple-parsers')
         .set({ 'Content-Type': ContentType.TEXT_PLAIN })
         .send(text)
-        .expect(200, `"${text}"`)
+        .expect(200, text)
     );
 
     test(`parses ${ContentType.APPLICATION_OCTET_STREAM} content-type`, async () =>
@@ -68,7 +68,7 @@ describe('@marblejs/middleware-body - integration', () => {
         .set({ 'Content-Type': ContentType.APPLICATION_OCTET_STREAM })
         .send(text)
         .expect(200)
-        .then(({ body }) => expect(body.type).toBe('Buffer'))
+        .then(({ body }) => expect(body).toEqual(Buffer.from(body)))
     );
   });
 

--- a/packages/middleware-body/test/bodyParser.integration.ts
+++ b/packages/middleware-body/test/bodyParser.integration.ts
@@ -1,5 +1,5 @@
 import { EffectFactory, httpListener, combineRoutes } from '@marblejs/core';
-import { ContentType } from '@marblejs/core/dist/+internal/http';
+import { ContentType, getContentType } from '@marblejs/core/dist/+internal/http';
 import { map } from 'rxjs/operators';
 import { bodyParser$, urlEncodedParser, jsonParser, textParser, rawParser } from '../src';
 
@@ -7,7 +7,16 @@ const effect$ = EffectFactory
   .matchPath('/')
   .matchType('POST')
   .use(req$ => req$.pipe(
-    map(req => ({ body: req.body })),
+    map(req => {
+      const incomingContentType = getContentType(req.headers) as ContentType;
+      const outgoingContentType = [ContentType.APPLICATION_OCTET_STREAM, ContentType.TEXT_PLAIN].includes(incomingContentType)
+        ? incomingContentType
+        : ContentType.APPLICATION_JSON;
+      return {
+        body: req.body,
+        headers: { 'Content-Type': outgoingContentType },
+      };
+    }),
   ));
 
 const defaultParser$ = combineRoutes('/default-parser', {

--- a/packages/testing/src/testBed/http/http.testBed.response.ts
+++ b/packages/testing/src/testBed/http/http.testBed.response.ts
@@ -1,6 +1,7 @@
 import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { HttpStatus } from '@marblejs/core';
+import { parseJson } from '@marblejs/core/dist/+internal/utils';
 import { getContentType, ContentType } from '@marblejs/core/dist/+internal/http/contentType.util';
 import { HttpTestBedResponseProps, HttpTestBedResponse } from './http.testBed.response.interface';
 import { HttpTestBedRequest } from './http.testBed.request.interface';
@@ -12,7 +13,7 @@ const parseResponseBody = (props: HttpTestBedResponseProps): string | Array<any>
     O.map(body => {
       switch (getContentType(props.headers)) {
         case ContentType.APPLICATION_JSON:
-          return JSON.parse(body);
+          return parseJson(body);
         default:
           return body;
       }

--- a/packages/testing/src/testBed/http/http.testBed.response.ts
+++ b/packages/testing/src/testBed/http/http.testBed.response.ts
@@ -9,11 +9,13 @@ import { HttpTestBedRequest } from './http.testBed.request.interface';
 const parseResponseBody = (props: HttpTestBedResponseProps): string | Array<any> | Record<string, any> | undefined =>
   pipe(
     O.fromNullable(props.body),
-    O.map(body => body.toString()),
     O.map(body => {
       switch (getContentType(props.headers)) {
         case ContentType.APPLICATION_JSON:
-          return parseJson(body);
+          return pipe(body.toString(), parseJson);
+        case ContentType.TEXT_PLAIN:
+        case ContentType.TEXT_HTML:
+          return body.toString();
         default:
           return body;
       }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/core** - `#bodyFactory` - parse all sort of different `json`-like content types
- **@marblejs/core** - `#bodyFactory` - added missing support for parsing `application/octet-stream` body types
- **@marblejs/testing** - parse response body to string conditionally 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```