### PR TITLE
fix(messaging): map to UNKNOWN event if event decoder fails

### DIFF
--- a/packages/messaging/src/client/messaging.client.interface.ts
+++ b/packages/messaging/src/client/messaging.client.interface.ts
@@ -3,13 +3,13 @@ import { Observable } from 'rxjs';
 import { TransportMessageTransformer, TransportStrategy } from '../transport/transport.interface';
 
 export interface MessagingClient {
-  send: <T = Event, U = Event>(data: U) => Observable<T>;
-  emit: <T = Event>(data: T) => Promise<void>;
+  send: <T extends Event = Event, U extends Event = Event>(data: U) => Observable<T>;
+  emit: <T extends Event = Event>(data: T) => Promise<void>;
   close: () => Promise<void>;
 }
 
 type ConfigurationBase =  {
-  msgTransformer?: TransportMessageTransformer<any>;
+  msgTransformer?: TransportMessageTransformer;
 }
 
 export type MessagingClientConfig =

--- a/packages/messaging/src/transport/transport.interface.ts
+++ b/packages/messaging/src/transport/transport.interface.ts
@@ -49,9 +49,9 @@ export interface TransportLayerConnection {
   close$: Observable<any>;
 }
 
-export interface TransportMessageTransformer<T> {
-  decode: (incomingEvent: Buffer) => T;
-  encode: (outgoingEvent: T) => Buffer;
+export interface TransportMessageTransformer {
+  decode: <T extends Event = Event>(incomingEvent: Buffer) => T;
+  encode: (outgoingEvent: Event) => Buffer;
 }
 
 export interface TransportMessage<T = Event> {

--- a/packages/messaging/src/transport/transport.transformer.spec.ts
+++ b/packages/messaging/src/transport/transport.transformer.spec.ts
@@ -1,0 +1,73 @@
+import { ReplaySubject } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { createUuid } from '@marblejs/core/dist/+internal/utils';
+import { TransportMessage } from './transport.interface';
+import { jsonTransformer, decodeMessage } from './transport.transformer';
+
+describe('#decodeMessage', () => {
+  const errorSubject = new ReplaySubject<Error>(1);
+
+  describe('#jsonTransformer', () => {
+    const msgTransformer = jsonTransformer;
+
+    test('decodes JSON message to Event with routing metadata', () => {
+      // given
+      const incomingEvent = { type: 'TEST', payload: { test: 'test' } };
+      const message: TransportMessage<Buffer> = {
+        data: msgTransformer.encode(incomingEvent),
+        correlationId: createUuid(),
+        replyTo: createUuid(),
+      };
+
+      // when
+      const decodedEvent = decodeMessage({ errorSubject, msgTransformer })(message);
+
+      // then
+      expect(decodedEvent).toEqual({
+        ...incomingEvent,
+        metadata: {
+          correlationId: message.correlationId,
+          replyTo: message.replyTo,
+          raw: message,
+        },
+      });
+    });
+
+    test('decodes JSON message to Event without routing metadata', () => {
+      // given
+      const incomingEvent = { type: 'TEST', payload: { test: 'test' } };
+      const message: TransportMessage<Buffer> = {
+        data: msgTransformer.encode(incomingEvent),
+      };
+
+      // when
+      const decodedEvent = decodeMessage({ errorSubject, msgTransformer })(message);
+
+      // then
+      expect(decodedEvent).toEqual({
+        ...incomingEvent,
+        metadata: { raw: message },
+      });
+    });
+
+    test('decodes invalid JSON message to unknown Event and emits error to given subject', done => {
+      // given
+      const message: TransportMessage<Buffer> = {
+        data: Buffer.from('{ type }'),
+      };
+
+      // when
+      const decodedEvent = decodeMessage({ errorSubject, msgTransformer })(message);
+
+      // then
+      expect(decodedEvent).toEqual({ type: 'UNKNOWN' });
+
+      errorSubject
+        .pipe(take(1))
+        .subscribe(error => {
+          expect(error).toBeDefined();
+          done();
+        });
+    });
+  });
+});

--- a/packages/messaging/src/transport/transport.transformer.ts
+++ b/packages/messaging/src/transport/transport.transformer.ts
@@ -1,8 +1,35 @@
+import { Subject } from 'rxjs';
+import { flow, identity } from 'fp-ts/lib/function';
+import { pipe } from 'fp-ts/lib/pipeable';
+import * as E from 'fp-ts/lib/Either';
 import { Event } from '@marblejs/core';
-import { flow } from 'fp-ts/lib/function';
-import { TransportMessageTransformer } from './transport.interface';
+import { TransportMessageTransformer, TransportMessage } from './transport.interface';
 
-export const jsonTransformer: TransportMessageTransformer<Event> = {
+export type DecodeMessageConfig = { msgTransformer: TransportMessageTransformer; errorSubject: Subject<Error> };
+export type DecodeMessage = (config: DecodeMessageConfig) => (msg: TransportMessage<Buffer>) => Event;
+
+const UNKNOWN_EVENT = { type: 'UNKNOWN' };
+
+export const jsonTransformer: TransportMessageTransformer = {
   decode: event => JSON.parse(event.toString()),
   encode: event => flow(JSON.stringify, Buffer.from)(event),
 };
+
+export const decodeMessage: DecodeMessage = ({ msgTransformer, errorSubject }) => msg =>
+  pipe(
+    E.tryCatch(
+      () => msgTransformer.decode(msg.data),
+      error => {
+        errorSubject.next(error as Error);
+        return UNKNOWN_EVENT;
+      }),
+    E.map(event => ({
+      ...event,
+      metadata: {
+        replyTo: msg.replyTo,
+        correlationId: msg.correlationId,
+        raw: msg,
+      },
+    })),
+    E.fold(identity, identity),
+  );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/messaging** - if event transformer fails to decode the event, it breaks the listener stream continuity

## What is the new behavior?
- **@marblejs/messaging** - if event transformer fails to decode the event it won't break the internal event stream since it will be mapped to `UNKNOWN` event and additionally propagated to `error$`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
