### PR TITLE
feat(messaging): expose transport layer raw options

### DIFF
--- a/packages/core/src/index.spec.ts
+++ b/packages/core/src/index.spec.ts
@@ -3,11 +3,30 @@ import * as API from './index';
 describe('@marblejs/core public API', () => {
   test('apis are defined', () => {
     expect(API.httpListener).toBeDefined();
-    expect(API.HttpError).toBeDefined();
-    expect(API.CoreError).toBeDefined();
     expect(API.defaultError$).toBeDefined();
     expect(API.EffectFactory).toBeDefined();
     expect(API.combineRoutes).toBeDefined();
+    expect(API.combineEffects).toBeDefined();
+    expect(API.combineMiddlewares).toBeDefined();
+    expect(API.createEffectContext).toBeDefined();
     expect(API.event).toBeDefined();
+    expect(API.coreErrorFactory).toBeDefined();
+    expect(API.r).toBeDefined();
+
+    // errors
+    expect(API.HttpError).toBeDefined();
+    expect(API.HttpRequestError).toBeDefined();
+    expect(API.CoreError).toBeDefined();
+    expect(API.EventError).toBeDefined();
+    expect(API.isEventError).toBeDefined();
+    expect(API.isCoreError).toBeDefined();
+    expect(API.isHttpError).toBeDefined();
+    expect(API.isHttpRequestError).toBeDefined();
+
+    // operators
+    expect(API.use).toBeDefined();
+    expect(API.act).toBeDefined();
+    expect(API.switchToProtocol).toBeDefined();
+    expect(API.matchEvent).toBeDefined();
   });
 });

--- a/packages/messaging/src/eventbus/messaging.eventBus.reader.ts
+++ b/packages/messaging/src/eventbus/messaging.eventBus.reader.ts
@@ -1,14 +1,14 @@
 import { pipe } from 'fp-ts/lib/pipeable';
-import { flow } from 'fp-ts/lib/function';
 import { deleteAt } from 'fp-ts/lib/Map';
 import * as R from 'fp-ts/lib/Reader';
-import { Context, resolve, bindTo, register, setoidContextToken, createContextToken } from '@marblejs/core';
+import { Context, resolve, bindTo, setoidContextToken, createContextToken, registerAll } from '@marblejs/core';
 import { TransportLayerToken } from '../server/messaging.server.tokens';
 import { Transport, TransportLayerConnection } from '../transport/transport.interface';
 import { provideTransportLayer } from '../transport/transport.provider';
 import { messagingListener } from '../server/messaging.server.listener';
 import { MessagingClient } from '../client/messaging.client.interface';
 import { messagingClient } from '../client/messaging.client';
+import { EventTimerStoreToken, EventTimerStore } from '../eventStore/eventTimerStore';
 
 export interface EventBusConfig {
   listener: ReturnType<typeof messagingListener>;
@@ -24,8 +24,11 @@ export const eventBus = (config: EventBusConfig) => pipe(
     const ctx = deleteAt(setoidContextToken)(EventBusToken)(rootContext);
     const transportLayer = provideTransportLayer(Transport.LOCAL);
     const transportLayerConnection = await transportLayer.connect();
-    const boundTransportLayer = bindTo(TransportLayerToken)(() => transportLayer);
-    const context = await flow(register(boundTransportLayer), resolve)(ctx);
+    const registerDependencies = registerAll([
+      bindTo(TransportLayerToken)(() => transportLayer),
+      bindTo(EventTimerStoreToken)(EventTimerStore),
+    ]);
+    const context = await pipe(ctx, registerDependencies, resolve);
 
     listener(context)(transportLayerConnection);
 

--- a/packages/messaging/src/index.spec.ts
+++ b/packages/messaging/src/index.spec.ts
@@ -9,5 +9,11 @@ describe('@marblejs/messaging', () => {
     expect(API.messagingClient).toBeDefined();
     expect(API.messagingListener).toBeDefined();
     expect(API.reply).toBeDefined();
+    expect(API.ackEvent).toBeDefined();
+    expect(API.nackEvent).toBeDefined();
+    expect(API.nackAndResendEvent).toBeDefined();
+    expect(API.EVENT_BUS_CHANNEL).toBeDefined();
+    expect(API.AmqpConnectionStatus).toBeDefined();
+    expect(API.RedisConnectionStatus).toBeDefined();
   });
 });

--- a/packages/messaging/src/index.ts
+++ b/packages/messaging/src/index.ts
@@ -10,7 +10,6 @@ export { LocalStrategyOptions, EVENT_BUS_CHANNEL } from './transport/strategies/
 
 // effects, middlewares
 export * from './effects/messaging.effects.interface';
-export * from './middlewares/messaging.ack.middleware';
 
 // handy functions
 export { reply } from './reply/reply';

--- a/packages/messaging/src/server/messaging.server.listener.ts
+++ b/packages/messaging/src/server/messaging.server.listener.ts
@@ -18,6 +18,7 @@ import { MsgEffect, MsgMiddlewareEffect, MsgErrorEffect, MsgOutputEffect } from 
 import { inputLogger$, outputLogger$, errorLogger$ } from '../middlewares/messaging.eventLogger.middleware';
 import { outputRouter$, outputErrorEncoder$ } from '../middlewares/messaging.eventOutput.middleware';
 import { idApplier$ } from '../middlewares/messaging.eventInput.middleware';
+import { rejectUnhandled$ } from '../middlewares/messaging.ack.middleware';
 
 export interface MessagingListenerConfig {
   effects?: MsgEffect[];
@@ -53,7 +54,7 @@ export const messagingListener = createListener<MessagingListenerConfig, Messagi
 
   const logger = useContext(LoggerToken)(ask);
   const combinedEffects = combineEffects(...effects);
-  const combinedMiddlewares = combineMiddlewares(idApplier$, inputLogger$, ...middlewares);
+  const combinedMiddlewares = combineMiddlewares(idApplier$, rejectUnhandled$, inputLogger$, ...middlewares);
 
   return connection => {
     const errorSubject = new Subject<Error>();

--- a/packages/messaging/src/server/specs/messaging.server.amqp.spec.ts
+++ b/packages/messaging/src/server/specs/messaging.server.amqp.spec.ts
@@ -249,4 +249,15 @@ describe('messagingServer::AMQP', () => {
 
     microservice = await Util.createAmqpMicroservice(options)({ effects: [test$], output$ });
   });
+
+  test('microservice connection exposes raw configuration object', async () => {
+    // given
+    const options = Util.createAmqpOptions();
+
+    // when
+    microservice = await Util.createAmqpMicroservice(options)();
+
+    // then
+    expect(microservice.config.raw).toEqual(options);
+  });
 });

--- a/packages/messaging/src/server/specs/messaging.server.amqp.spec.ts
+++ b/packages/messaging/src/server/specs/messaging.server.amqp.spec.ts
@@ -5,7 +5,6 @@ import { forkJoin, TimeoutError } from 'rxjs';
 import { map, tap, delay, mapTo } from 'rxjs/operators';
 import { TransportLayerConnection } from '../../transport/transport.interface';
 import { MsgEffect } from '../../effects/messaging.effects.interface';
-import { rejectUnhandled$ } from '../../middlewares/messaging.ack.middleware';
 import { MessagingClient } from '../../client/messaging.client.interface';
 import { reply } from '../../reply/reply';
 import * as Util from '../../util/messaging.test.util';
@@ -138,7 +137,7 @@ describe('messagingServer::AMQP', () => {
     )(done);
 
     // when
-    microservice = await Util.createAmqpMicroservice(optionsMicroservice)({ middlewares: [rejectUnhandled$], effects: [ack$], output$ });
+    microservice = await Util.createAmqpMicroservice(optionsMicroservice)({ effects: [ack$], output$ });
     client = await Util.createAmqpClient(optionsClient);
 
     await client.emit({ type: 'ACK', payload: 1 });
@@ -164,7 +163,7 @@ describe('messagingServer::AMQP', () => {
     )(done);
 
     // when
-    microservice = await Util.createAmqpMicroservice(optionsMicroservice)({ middlewares: [rejectUnhandled$], effects: [ack$], output$ });
+    microservice = await Util.createAmqpMicroservice(optionsMicroservice)({ effects: [ack$], output$ });
     client = await Util.createAmqpClient(optionsClient);
 
     await client.emit({ type: 'TEST' });

--- a/packages/messaging/src/server/specs/messaging.server.redis.spec.ts
+++ b/packages/messaging/src/server/specs/messaging.server.redis.spec.ts
@@ -196,4 +196,15 @@ describe('messagingServer::Redis', () => {
 
     await client.emit({ type: 'TEST' });
   });
+
+  test('microservice connection exposes raw configuration object', async () => {
+    // given
+    const options = Util.createRedisOptions();
+
+    // when
+    microservice = await Util.createRedisMicroservice(options)();
+
+    // then
+    expect(microservice.config.raw).toEqual(options);
+  });
 });

--- a/packages/messaging/src/transport/strategies/local.strategy.provider.ts
+++ b/packages/messaging/src/transport/strategies/local.strategy.provider.ts
@@ -1,12 +1,12 @@
 import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { TransportLayer, TransportLayerConnection } from '../transport.interface';
+import { TransportLayer, TransportLayerConnection, Transport } from '../transport.interface';
 import { createLocalStrategy } from './local.strategy';
 
-class LocalStrategyProvider implements TransportLayer {
+export class LocalStrategyProvider implements TransportLayer<Transport.LOCAL> {
   private static instance: LocalStrategyProvider;
-  private readonly strategy: TransportLayer;
-  private readonly strategyConnection: Promise<TransportLayerConnection>;
+  private readonly strategy: TransportLayer<Transport.LOCAL>;
+  private readonly strategyConnection: Promise<TransportLayerConnection<Transport.LOCAL>>;
 
   private constructor() {
     this.strategy = createLocalStrategy({});

--- a/packages/messaging/src/transport/strategies/tcp.strategy.ts
+++ b/packages/messaging/src/transport/strategies/tcp.strategy.ts
@@ -1,8 +1,8 @@
 
-import { TransportLayer } from '../transport.interface';
+import { TransportLayer, Transport } from '../transport.interface';
 
 /* istanbul ignore next */
-export const createTcpStrategy = (): TransportLayer => {
+export const createTcpStrategy = (): TransportLayer<Transport.TCP> => {
   // @TODO
   return {} as any;
 };

--- a/packages/messaging/src/transport/transport.interface.ts
+++ b/packages/messaging/src/transport/transport.interface.ts
@@ -24,9 +24,9 @@ export type TransportStrategy =
   | LocalStrategy
   ;
 
-export interface TransportLayer {
-  connect: (opts?: { isConsumer: boolean }) => Promise<TransportLayerConnection>;
-  type: Transport;
+export interface TransportLayer<T extends Transport = Transport> {
+  connect: (opts?: { isConsumer: boolean }) => Promise<TransportLayerConnection<T>>;
+  type: T;
   config: TransportLayerConfig;
 }
 
@@ -36,15 +36,15 @@ export interface TransportLayerConfig {
   timeout: number;
 }
 
-export interface TransportLayerConnection {
+export interface TransportLayerConnection<T extends Transport = Transport> {
   sendMessage: (channel: string, message: TransportMessage<Buffer>) => Promise<TransportMessage<Buffer>>;
   emitMessage: (channel: string, message: TransportMessage<Buffer>) => Promise<boolean>;
   ackMessage: (message: TransportMessage | undefined) => void;
   nackMessage: (message: TransportMessage | undefined, resend?: boolean) => void;
   close: () => Promise<any>;
   getChannel(): string;
-  type: Transport;
-  config: { timeout: number };
+  type: T;
+  config: { timeout: number, channel: string; raw: any; };
   message$: Observable<TransportMessage<Buffer>>;
   status$: Observable<string>;
   error$: Observable<Error>;

--- a/packages/messaging/src/transport/transport.provider.ts
+++ b/packages/messaging/src/transport/transport.provider.ts
@@ -1,9 +1,9 @@
-import { Transport, TransportLayer } from './transport.interface';
+import { Transport } from './transport.interface';
 import { createAmqpStrategy } from './strategies/amqp.strategy';
 import { createRedisStrategy } from './strategies/redis.strategy';
 import { provideLocalStrategy } from './strategies/local.strategy.provider';
 
-export const provideTransportLayer = (transport: Transport, transportOptions: any = {}): TransportLayer => {
+export const provideTransportLayer = <T extends Transport>(transport: T, transportOptions: any = {}) => {
   switch (transport) {
     case Transport.AMQP:
       return createAmqpStrategy(transportOptions);


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/messaging** - transport layer specific options are exposed via `TransportLayerConnection.config.raw`
- **@marblejs/messaging** - register `rejectUnhandled$` as a build-in middleware. From now there is no need to register it manually in each supported transport layer.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
