### PR TITLE
feat(middleware-io): `validateEvent` + API deprecations

### DIFF
--- a/packages/@integration/src/cqrs/effects/http.effects.ts
+++ b/packages/@integration/src/cqrs/effects/http.effects.ts
@@ -1,10 +1,10 @@
-import { r, HttpStatus, useContext, use } from '@marblejs/core';
+import { r, HttpStatus, useContext } from '@marblejs/core';
 import { tap, mapTo, map } from 'rxjs/operators';
 import { EventBusClientToken } from '@marblejs/messaging';
-import { requestValidator$, t } from '@marblejs/middleware-io';
+import { validateRequest, t } from '@marblejs/middleware-io';
 import { GenerateOfferDocumentCommand } from '../domain/Offer.command';
 
-const generateDocumentValidator$ = requestValidator$({
+const validate = validateRequest({
   params: t.type({
     id: t.string,
   }),
@@ -17,7 +17,7 @@ export const postDocumentsGenerate$ = r.pipe(
     const eventBusClient = useContext(EventBusClientToken)(ctx.ask);
 
     return req$.pipe(
-      use(generateDocumentValidator$),
+      validate,
       map(req => GenerateOfferDocumentCommand.create({ offerId: req.params.id })),
       tap(eventBusClient.emit),
       mapTo({ status: HttpStatus.ACCEPTED }),

--- a/packages/@integration/src/http/effects/api.effects.ts
+++ b/packages/@integration/src/http/effects/api.effects.ts
@@ -1,11 +1,11 @@
-import { r, HttpError, HttpStatus, combineRoutes, use } from '@marblejs/core';
-import { requestValidator$, t } from '@marblejs/middleware-io';
+import { r, HttpError, HttpStatus, combineRoutes } from '@marblejs/core';
+import { validateRequest, t } from '@marblejs/middleware-io';
 import { throwError } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import { user$ } from './user.effects';
 import { static$ } from './static.effects';
 
-const rootValiadtor$ = requestValidator$({
+const validate = validateRequest({
   params: t.type({
     version: t.union([
       t.literal('v1'),
@@ -18,7 +18,7 @@ const root$ = r.pipe(
   r.matchPath('/'),
   r.matchType('GET'),
   r.useEffect(req$ => req$.pipe(
-    use(rootValiadtor$),
+    validate,
     map(req => req.params.version),
     map(version => `API version: ${version}`),
     map(message => ({ body: message })),

--- a/packages/@integration/src/messaging/client.ts
+++ b/packages/@integration/src/messaging/client.ts
@@ -1,7 +1,7 @@
 import { logger$ } from '@marblejs/middleware-logger';
-import { requestValidator$, t } from '@marblejs/middleware-io';
+import { validateRequest, t } from '@marblejs/middleware-io';
 import { messagingClient, MessagingClient, Transport } from '@marblejs/messaging';
-import { r, createServer, createContextToken, httpListener, use, useContext, bindEagerlyTo, combineRoutes, ContextToken } from '@marblejs/core';
+import { r, createServer, createContextToken, httpListener, useContext, bindEagerlyTo, combineRoutes, ContextToken } from '@marblejs/core';
 import { isTestEnv, getPortEnv } from '@marblejs/core/dist/+internal/utils';
 import * as T from 'fp-ts/lib/Task';
 import { pipe } from 'fp-ts/lib/pipeable';
@@ -30,7 +30,7 @@ const redisClient = messagingClient({
   },
 });
 
-const rootValiadtor$ = requestValidator$({
+const validateFib$ = validateRequest({
   params: t.type({
     number: t.string,
   }),
@@ -43,7 +43,7 @@ const fib$ = (clientToken: ContextToken<MessagingClient>) => r.pipe(
     const client = useContext(clientToken)(ctx.ask);
 
     return req$.pipe(
-      use(rootValiadtor$),
+      validateFib$,
       map(req => Number(req.params.number)),
       mergeMap(number => forkJoin(
         client.send({ type: 'FIB', payload: number + 0 }),

--- a/packages/@integration/src/messaging/server.ts
+++ b/packages/@integration/src/messaging/server.ts
@@ -1,10 +1,11 @@
 import { of } from 'rxjs';
 import { map, tap, catchError } from 'rxjs/operators';
-import { matchEvent, use, act } from '@marblejs/core';
-import { isTestEnv } from '@marblejs/core/dist/+internal/utils';
-import { eventValidator$, t } from '@marblejs/middleware-io';
-import { createMicroservice, messagingListener, Transport, MsgEffect, reply } from '@marblejs/messaging';
 import { IO } from 'fp-ts/lib/IO';
+import { pipe } from 'fp-ts/lib/pipeable';
+import { matchEvent, act } from '@marblejs/core';
+import { isTestEnv } from '@marblejs/core/dist/+internal/utils';
+import { validateEvent, t } from '@marblejs/middleware-io';
+import { createMicroservice, messagingListener, Transport, MsgEffect, reply } from '@marblejs/messaging';
 
 const fib = (n: number): number =>
   (n === 0 || n === 1) ? n : fib(n - 1) + fib(n - 2);
@@ -12,8 +13,8 @@ const fib = (n: number): number =>
 const fibonacci$: MsgEffect = event$ =>
   event$.pipe(
     matchEvent('FIB'),
-    act(event => of(event).pipe(
-      use(eventValidator$(t.number)),
+    act(event => pipe(
+      validateEvent(t.number)(event),
       tap(event => { if (event.payload >= 45) throw new Error('Too high number!') }),
       map(event => fib(event.payload)),
       map(payload => reply(event)({ type: 'FIB_RESULT', payload })),

--- a/packages/core/src/+internal/utils/error.util.ts
+++ b/packages/core/src/+internal/utils/error.util.ts
@@ -1,5 +1,5 @@
 export class NamedError extends Error {
-  constructor(public name: string, message: string) {
+  constructor(public name: string, public message: string) {
     super(message);
   }
 }
@@ -9,3 +9,11 @@ export const isNamedError = (data: any): data is NamedError =>
 
 export const isError = (data: any): data is Error =>
   !!data?.stack && !!data?.name;
+
+export const encodeError = (error: any) =>
+  ['name', ...Object.getOwnPropertyNames(error)]
+    .filter(key => !['stack'].includes(key))
+    .reduce((acc, key) => {
+      acc[key] = error[key];
+      return acc;
+    }, Object.create(null));

--- a/packages/core/src/operators/act/act.operator.ts
+++ b/packages/core/src/operators/act/act.operator.ts
@@ -2,6 +2,7 @@ import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { Observable, of, defer, isObservable } from 'rxjs';
 import { mergeMap, catchError } from 'rxjs/operators';
+import { encodeError } from '../../+internal/utils/error.util';
 import { Event } from '../../event/event.interface';
 
 export function act<
@@ -31,7 +32,7 @@ export function act<
 
   const getDefaultErrorEvent = (error: any) => (event: Event) => of({
     type: event.type,
-    error: { name: error.name, message: error.message, data: error.data },
+    error: encodeError(error),
     metadata: event.metadata,
   } as ErrorEvent);
 

--- a/packages/messaging/src/eventbus/messaging.eventBus.reader.spec.ts
+++ b/packages/messaging/src/eventbus/messaging.eventBus.reader.spec.ts
@@ -1,8 +1,9 @@
-import { Event, matchEvent, use, combineEffects, act, EventError } from '@marblejs/core';
+import { Event, matchEvent, combineEffects, act, EventError } from '@marblejs/core';
 import { wait, NamedError } from '@marblejs/core/dist/+internal/utils';
-import { eventValidator$, t } from '@marblejs/middleware-io';
-import { throwError, of } from 'rxjs';
+import { validateEvent, t } from '@marblejs/middleware-io';
+import { throwError } from 'rxjs';
 import { delay, map, tap, ignoreElements } from 'rxjs/operators';
+import { flow } from 'fp-ts/lib/function';
 import { MsgEffect } from '../effects/messaging.effects.interface';
 import { runEventBus, runEventBusClient } from '../util/messaging.test.util';
 import { reply } from '../reply/reply';
@@ -12,9 +13,11 @@ describe('#eventBus', () => {
     const rpc$: MsgEffect = event$ =>
       event$.pipe(
         matchEvent('RPC_TEST'),
-        use(eventValidator$(t.number)),
-        delay(10),
-        map(event => reply(event)({ type: 'RPC_TEST_RESULT', payload: event.payload + 1 })),
+        act(flow(
+          validateEvent(t.number),
+          delay(10),
+          map(event => reply(event)({ type: 'RPC_TEST_RESULT', payload: event.payload + 1 })),
+        ))
       );
 
     const eventBus = await runEventBus({ effects: [rpc$] });
@@ -33,17 +36,21 @@ describe('#eventBus', () => {
     const rpc1$: MsgEffect = event$ =>
       event$.pipe(
         matchEvent('RPC_1_TEST'),
-        use(eventValidator$(t.number)),
-        delay(10),
-        map(event => reply(event)({ type: 'RPC_1_TEST_RESULT', payload: event.payload + 1 })),
+        act(flow(
+          validateEvent(t.number),
+          delay(10),
+          map(event => reply(event)({ type: 'RPC_1_TEST_RESULT', payload: event.payload + 1 })),
+        )),
       );
 
     const rpc2$: MsgEffect = event$ =>
       event$.pipe(
         matchEvent('RPC_2_TEST'),
-        use(eventValidator$(t.number)),
-        delay(10),
-        map(event => reply(event)({ type: 'RPC_2_TEST_RESULT', payload: event.payload + 1 })),
+        act(flow(
+          validateEvent(t.number),
+          delay(10),
+          map(event => reply(event)({ type: 'RPC_2_TEST_RESULT', payload: event.payload + 1 })),
+        )),
       );
 
     const eventBus = await runEventBus({ effects: [combineEffects(rpc1$, rpc2$)] });
@@ -76,8 +83,8 @@ describe('#eventBus', () => {
     const rpc1$: MsgEffect = event$ =>
       event$.pipe(
         matchEvent('RPC_TEST'),
-        act(event => of(event).pipe(
-          use(eventValidator$(t.number)),
+        act(flow(
+          validateEvent(t.number),
           delay(10),
         )),
       );

--- a/packages/messaging/src/middlewares/messaging.eventOutput.middleware.ts
+++ b/packages/messaging/src/middlewares/messaging.eventOutput.middleware.ts
@@ -1,14 +1,8 @@
 import { Event, useContext } from '@marblejs/core';
-import { createUuid, isNonNullable } from '@marblejs/core/dist/+internal/utils';
+import { createUuid, isNonNullable, encodeError } from '@marblejs/core/dist/+internal/utils';
 import { map } from 'rxjs/operators';
 import { MsgOutputEffect } from '../effects/messaging.effects.interface';
 import { TransportLayerToken } from '../server/messaging.server.tokens';
-
-export const encodeError = (error: any) =>
-  ['name', ...Object.getOwnPropertyNames(error)].reduce((acc, key) => {
-    acc[key] = error[key];
-    return acc;
-  }, Object.create(null))
 
 export const outputRouter$: MsgOutputEffect = (event$, ctx) => {
   const transportLayer = useContext(TransportLayerToken)(ctx.ask);

--- a/packages/messaging/src/server/specs/messaging.server.amqp.spec.ts
+++ b/packages/messaging/src/server/specs/messaging.server.amqp.spec.ts
@@ -1,8 +1,9 @@
-import { matchEvent, use } from '@marblejs/core';
+import { matchEvent, act } from '@marblejs/core';
 import { createUuid } from '@marblejs/core/dist/+internal/utils';
-import { eventValidator$, t } from '@marblejs/middleware-io';
+import { validateEvent, t } from '@marblejs/middleware-io';
 import { forkJoin, TimeoutError } from 'rxjs';
 import { map, tap, delay, mapTo } from 'rxjs/operators';
+import { flow } from 'fp-ts/lib/function';
 import { TransportLayerConnection } from '../../transport/transport.interface';
 import { MsgEffect } from '../../effects/messaging.effects.interface';
 import { MessagingClient } from '../../client/messaging.client.interface';
@@ -36,9 +37,11 @@ describe('messagingServer::AMQP', () => {
     const increment$: MsgEffect = event$ =>
       event$.pipe(
         matchEvent('INCREMENT'),
-        use(eventValidator$(t.number)),
-        delay(50),
-        map(event => ({ ...event, type: 'INCREMENT_RESULT', payload: event.payload + 1 })),
+        act(flow(
+          validateEvent(t.number),
+          delay(50),
+          map(event => ({ ...event, type: 'INCREMENT_RESULT', payload: event.payload + 1 })),
+        )),
       );
 
     // when
@@ -97,9 +100,11 @@ describe('messagingServer::AMQP', () => {
     const increment$: MsgEffect = event$ =>
       event$.pipe(
         matchEvent('INCREMENT'),
-        use(eventValidator$(t.number)),
-        delay(50),
-        map(event => ({ ...event, type: 'INCREMENT_RESULT', payload: event.payload + 1 })),
+        act(flow(
+          validateEvent(t.number),
+          delay(50),
+          map(event => ({ ...event, type: 'INCREMENT_RESULT', payload: event.payload + 1 })),
+        )),
       );
 
     // then

--- a/packages/messaging/src/server/specs/messaging.server.redis.spec.ts
+++ b/packages/messaging/src/server/specs/messaging.server.redis.spec.ts
@@ -1,8 +1,9 @@
-import { matchEvent, use } from '@marblejs/core';
+import { matchEvent, act } from '@marblejs/core';
 import { createUuid } from '@marblejs/core/dist/+internal/utils';
-import { eventValidator$, t } from '@marblejs/middleware-io';
+import { validateEvent, t } from '@marblejs/middleware-io';
 import { forkJoin, TimeoutError } from 'rxjs';
 import { map, tap, delay, mapTo } from 'rxjs/operators';
+import { flow } from 'fp-ts/lib/function';
 import { TransportLayerConnection } from '../../transport/transport.interface';
 import { MsgEffect } from '../../effects/messaging.effects.interface';
 import { MessagingClient } from '../../client/messaging.client.interface';
@@ -40,9 +41,11 @@ describe('messagingServer::Redis', () => {
     const increment$: MsgEffect = event$ =>
       event$.pipe(
         matchEvent('INCREMENT'),
-        use(eventValidator$(t.number)),
-        delay(50),
-        map(event => ({ ...event, type: 'INCREMENT_RESULT', payload: event.payload + 1 })),
+        act(flow(
+          validateEvent(t.number),
+          delay(50),
+          map(event => ({ ...event, type: 'INCREMENT_RESULT', payload: event.payload + 1 })),
+        )),
       );
 
     // when
@@ -101,9 +104,11 @@ describe('messagingServer::Redis', () => {
     const increment$: MsgEffect = event$ =>
       event$.pipe(
         matchEvent('INCREMENT'),
-        use(eventValidator$(t.number)),
-        delay(50),
-        map(event => ({ ...event, type: 'INCREMENT_RESULT', payload: event.payload + 1 })),
+        act(flow(
+          validateEvent(t.number),
+          delay(50),
+          map(event => ({ ...event, type: 'INCREMENT_RESULT', payload: event.payload + 1 })),
+        )),
       );
 
     // then

--- a/packages/middleware-io/README.md
+++ b/packages/middleware-io/README.md
@@ -23,7 +23,7 @@ For the latest updates, documentation, change log, and release information visit
 
 ```typescript
 import { use, r } from '@marblejs/core';
-import { requestValidator$, t } from '@marblejs/middleware-io';
+import { validateRequest, t } from '@marblejs/middleware-io';
 
 const userSchema = t.type({
   id: t.string,
@@ -41,7 +41,7 @@ const effect$ = r.pipe(
   r.matchPath('/'),
   r.matchType('POST'),
   r.useEffect(req$ => req$.pipe(
-    use(requestValidator$({ body: userSchema })),
+    validateRequest({ body: userSchema }),
     // ..
   )));
 ```

--- a/packages/middleware-io/src/index.ts
+++ b/packages/middleware-io/src/index.ts
@@ -2,8 +2,8 @@ import * as t from 'io-ts';
 
 // package public API
 export { Schema, ValidatorOptions, validator$ } from './io.middleware';
-export { requestValidator$ } from './io.request.middleware';
-export { eventValidator$ } from './io.event.middleware';
+export { requestValidator$, validateRequest } from './io.request.middleware';
+export { eventValidator$, validateEvent } from './io.event.middleware';
 export { defaultReporter } from './io.reporter';
 export { ioTypeToJsonSchema, withJsonSchema } from './io.json-schema';
 export { t };

--- a/packages/middleware-io/src/io.request.middleware.ts
+++ b/packages/middleware-io/src/io.request.middleware.ts
@@ -21,7 +21,7 @@ enum Context {
   HEADERS = 'headers',
 }
 
-export const requestValidator$ = <
+export const validateRequest = <
   TBody extends Schema = t.UnknownC,
   TParams extends Schema = t.UnknownC,
   TQuery extends Schema = t.UnknownC,
@@ -74,3 +74,9 @@ export const requestValidator$ = <
     ),
   );
 };
+
+/**
+ * @deprecated [#1] since version 3.3.0,
+ * [#2] use `validateRequest` instead,
+ */
+export const requestValidator$ = validateRequest;

--- a/packages/middleware-io/src/specs/index.spec.ts
+++ b/packages/middleware-io/src/specs/index.spec.ts
@@ -3,9 +3,13 @@ import * as API from '../index';
 describe('@marblejs/middleware-io public API', () => {
   test('apis are defined', () => {
     expect(API.defaultReporter).toBeDefined();
-    expect(API.eventValidator$).toBeDefined();
-    expect(API.requestValidator$).toBeDefined();
+    expect(API.validateEvent).toBeDefined();
+    expect(API.validateRequest).toBeDefined();
     expect(API.validator$).toBeDefined();
     expect(API.t).toBeDefined();
+
+    // deprecated API
+    expect(API.requestValidator$).toBeDefined();
+    expect(API.eventValidator$).toBeDefined();
   });
 });

--- a/packages/middleware-io/src/specs/io.event.middleware.spec.ts
+++ b/packages/middleware-io/src/specs/io.event.middleware.spec.ts
@@ -1,9 +1,9 @@
 import * as t from 'io-ts';
 import { of } from 'rxjs';
 import { event } from '@marblejs/core';
-import { eventValidator$ } from '../io.event.middleware';
+import { validateEvent } from '../io.event.middleware';
 
-describe('#eventValidator$', () => {
+describe('#validateEvent', () => {
   test('validates payload schema and passes incoming event if input is successfuly validated', async () => {
     // given
     const input = {
@@ -20,7 +20,7 @@ describe('#eventValidator$', () => {
     });
 
     // when
-    const result = await eventValidator$(schema)(of(input)).toPromise();
+    const result = await validateEvent(schema)(of(input)).toPromise();
 
     // then
     expect(result.type).toEqual(input.type);
@@ -43,7 +43,7 @@ describe('#eventValidator$', () => {
     }));
 
     // when
-    const result = await eventValidator$(schema)(of(input)).toPromise();
+    const result = await validateEvent(schema)(input).toPromise();
 
     // then
     expect(result.type).toEqual(input.type);
@@ -59,14 +59,14 @@ describe('#eventValidator$', () => {
     const schema = event('TEST_EVENT')();
 
     // when
-    const result = await eventValidator$(schema)(of(input)).toPromise();
+    const result = await validateEvent(schema)(of(input)).toPromise();
 
     // then
     expect(result.type).toEqual(input.type);
     expect(result.payload).toBeUndefined();
   });
 
-  test('throws validation error if incoming data are not valid', async () => {
+  test('throws an error if incoming event is not valid', async () => {
     // given
     const input = {
       type: 'TEST_EVENT',
@@ -82,10 +82,12 @@ describe('#eventValidator$', () => {
     });
 
     // when
-    const result = eventValidator$(schema)(of(input)).toPromise();
+    const result = validateEvent(schema)(of(input)).toPromise();
 
     // then
     await expect(result).rejects.toEqual(expect.objectContaining({
+      event: expect.objectContaining(input),
+      name: 'EventError',
       message: 'Validation error',
       data: [{
         path: 'age',

--- a/packages/middleware-io/test/io-http.integration.ts
+++ b/packages/middleware-io/test/io-http.integration.ts
@@ -1,7 +1,7 @@
-import { EffectFactory, httpListener, use } from '@marblejs/core';
+import { r, httpListener } from '@marblejs/core';
 import { bodyParser$ } from '@marblejs/middleware-body';
 import { map } from 'rxjs/operators';
-import { requestValidator$, t } from '../src';
+import { validateRequest, t } from '../src';
 
 const user = t.type({
   id: t.string,
@@ -9,15 +9,14 @@ const user = t.type({
   age: t.number,
 });
 
-const effect$ = EffectFactory
-  .matchPath('/')
-  .matchType('POST')
-  .use(req$ => req$.pipe(
-    use(requestValidator$({
-      body: t.type({ user })
-    })),
+const effect$ = r.pipe(
+  r.matchPath('/'),
+  r.matchType('POST'),
+  r.useEffect(req$ => req$.pipe(
+    validateRequest({ body: t.type({ user }) }),
     map(req => ({ body: req.body.user })),
-  ));
+  )),
+);
 
 export const listener = httpListener({
   middlewares: [bodyParser$()],

--- a/packages/middleware-io/test/io-ws.integration.spec.ts
+++ b/packages/middleware-io/test/io-ws.integration.spec.ts
@@ -29,7 +29,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
     // given
     const user = { id: 'id', age: '100', };
     const event = { type: 'POST_USER', payload: user };
-    const expectedError = {
+    const expectedEvent = {
       type: 'POST_USER',
       error: {
         name: 'EventError',
@@ -47,7 +47,7 @@ describe('@marblejs/middleware-io - WebSocket integration', () => {
 
     // then
     webSocketClient.once('message', message => {
-      expect(JSON.parse(message)).toEqual(expectedError);
+      expect(JSON.parse(message)).toEqual(expectedEvent);
       webSocketClient.close();
       webSocketServer.close();
       httpServer.close();

--- a/packages/middleware-io/test/io-ws.integration.ts
+++ b/packages/middleware-io/test/io-ws.integration.ts
@@ -1,9 +1,8 @@
-import { use, matchEvent } from '@marblejs/core';
+import { matchEvent, act } from '@marblejs/core';
 import { webSocketListener, WsEffect } from '@marblejs/websockets';
-import { map } from 'rxjs/operators';
-import { eventValidator$, t } from '../src';
+import { validateEvent, t } from '../src';
 
-const user = t.type({
+const userSchema = t.type({
   id: t.string,
   age: t.number,
 });
@@ -11,8 +10,7 @@ const user = t.type({
 const postUser$: WsEffect = event$ =>
   event$.pipe(
     matchEvent('POST_USER'),
-    use(eventValidator$(user)),
-    map(event => event),
+    act(validateEvent(userSchema)),
   );
 
 export const listener = webSocketListener({


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/middleware-io** - `validateRequest` + `validateEvent` - new validator entrypoints
- **@marblejs/middleware-io** - `validateEvent` can take single event object instead of `Observable<Event>`
- **@marblejs/middleware-io** - deprecated `requestValidator$` and `eventValidator$`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
