### PR TITLE
feat(core): act - pass through error events

### DIFF
--- a/packages/core/src/+internal/utils/error.util.ts
+++ b/packages/core/src/+internal/utils/error.util.ts
@@ -9,3 +9,11 @@ export const isNamedError = (data: any): data is NamedError =>
 
 export const isError = (data: any): data is Error =>
   !!data?.stack && !!data?.name;
+
+export const encodeError = (error: any) =>
+  !isError(error) ? error : ['name', ...Object.getOwnPropertyNames(error)]
+    .filter(key => !['stack'].includes(key))
+    .reduce((acc, key) => {
+      acc[key] = error[key];
+      return acc;
+    }, Object.create(null));

--- a/packages/core/src/operators/act/act.operator.spec.ts
+++ b/packages/core/src/operators/act/act.operator.spec.ts
@@ -1,4 +1,4 @@
-import { Observable, of, concat } from 'rxjs';
+import { Observable, of, concat, throwError } from 'rxjs';
 import { filter, tap, mergeMap } from 'rxjs/operators';
 import { Event } from '../../event/event.interface';
 import { Marbles } from '../../+internal/testing';
@@ -79,7 +79,7 @@ describe('#act operator', () => {
     const event2: Event = { type: 'TEST_EVENT_2', payload: 2, metadata: { replyTo: 'channel_2' } };
     const event3: Event = { type: 'TEST_EVENT_3', payload: 3, metadata: { replyTo: 'channel_3' } };
     const event4: Event = { type: 'TEST_EVENT_4', payload: 4, metadata: { replyTo: 'channel_4' } };
-    const eventErrored: Event = { type: 'TEST_EVENT_2', error, metadata: { replyTo: 'channel_2' } };
+    const event_error: Event = { type: 'TEST_EVENT_2', error, metadata: { replyTo: 'channel_2' } };
 
     // when
     const effect$ = (event$: Observable<Event>) =>
@@ -91,8 +91,8 @@ describe('#act operator', () => {
 
     // then
     Marbles.assertEffect(effect$, [
-      ['-a-b-c-d---', { a: event1, b: event2,       c: event3, d: event4 }],
-      ['-a-b-c-d---', { a: event1, b: eventErrored, c: event3, d: event4 }],
+      ['-a-b-c-d---', { a: event1, b: event2,      c: event3, d: event4 }],
+      ['-a-b-c-d---', { a: event1, b: event_error, c: event3, d: event4 }],
     ]);
   });
 
@@ -102,7 +102,7 @@ describe('#act operator', () => {
     const event2: Event = { type: 'TEST_EVENT_2', payload: 2 };
     const event3: Event = { type: 'TEST_EVENT_3', payload: 3 };
     const event4: Event = { type: 'TEST_EVENT_4', payload: 4 };
-    const eventErrored: Event = { type: 'TEST_ERROR', error: 'something went wrong' };
+    const event_error: Event = { type: 'TEST_ERROR', error: 'something went wrong' };
 
     // when
     const effect$ = (event$: Observable<Event>) =>
@@ -120,8 +120,8 @@ describe('#act operator', () => {
 
     // then
     Marbles.assertEffect(effect$, [
-      ['-a-b-c-d---', { a: event1, b: event2,       c: event3, d: event4 }],
-      ['-a-b-c-d---', { a: event1, b: eventErrored, c: event3, d: event4 }],
+      ['-a-b-c-d---', { a: event1, b: event2,      c: event3, d: event4 }],
+      ['-a-b-c-d---', { a: event1, b: event_error, c: event3, d: event4 }],
     ]);
   });
 
@@ -131,7 +131,7 @@ describe('#act operator', () => {
     const event2: Event = { type: 'TEST_EVENT_2', payload: 2 };
     const event3: Event = { type: 'TEST_EVENT_3', payload: 3 };
     const event4: Event = { type: 'TEST_EVENT_4', payload: 4 };
-    const eventErrored: Event = { type: 'TEST_EVENT_2', error: 'something went wrong' };
+    const event_error: Event = { type: 'TEST_EVENT_2', error: 'something went wrong' };
 
     // when
     const effect$ = (event$: Observable<Event>) =>
@@ -149,8 +149,8 @@ describe('#act operator', () => {
 
     // then
     Marbles.assertEffect(effect$, [
-      ['-a-b-c-d---', { a: event1, b: event2,       c: event3, d: event4 }],
-      ['-a-b-c-d---', { a: event1, b: eventErrored, c: event3, d: event4 }],
+      ['-a-b-c-d---', { a: event1, b: event2,      c: event3, d: event4 }],
+      ['-a-b-c-d---', { a: event1, b: event_error, c: event3, d: event4 }],
     ]);
   });
 
@@ -160,7 +160,7 @@ describe('#act operator', () => {
     const event2: Event = { type: 'TEST_EVENT_2', payload: 2 };
     const event3: Event = { type: 'TEST_EVENT_3', payload: 3 };
     const event4: Event = { type: 'TEST_EVENT_4', payload: 4 };
-    const eventErrored: Event = { type: 'TEST_ERROR' };
+    const event_error: Event = { type: 'TEST_ERROR' };
 
     // when
     const effect$ = (event$: Observable<Event>) =>
@@ -170,16 +170,16 @@ describe('#act operator', () => {
             tap(e => { if (e.payload === 2) throw new Error('something went wrong') }),
           ),
           () => concat(
-            of(eventErrored),
-            of(eventErrored),
+            of(event_error),
+            of(event_error),
           ),
         ),
       );
 
     // then
     Marbles.assertEffect(effect$, [
-      ['-a-b----c-d---', { a: event1, b: event2,       c: event3, d: event4 }],
-      ['-a-(bb)-c-d---', { a: event1, b: eventErrored, c: event3, d: event4 }],
+      ['-a-b----c-d---', { a: event1, b: event2,                          c: event3, d: event4 }],
+      ['-a-(bb)-c-d---', { a: event1, b: { ...event_error, error: true }, c: event3, d: event4 }],
     ]);
   });
 
@@ -189,7 +189,7 @@ describe('#act operator', () => {
     const event2: Event = { type: 'TEST_EVENT_2', payload: 2 };
     const event3: Event = { type: 'TEST_EVENT_3', payload: 3 };
     const event4: Event = { type: 'TEST_EVENT_4', payload: 4 };
-    const eventErrored: Event = { type: 'TEST_ERROR' };
+    const event_error: Event = { type: 'TEST_ERROR' };
 
     // when
     const effect$ = (event$: Observable<Event>) =>
@@ -200,16 +200,94 @@ describe('#act operator', () => {
             else return of(event);
           },
           () => concat(
-            of(eventErrored),
-            of(eventErrored),
+            of(event_error),
+            of(event_error),
           ),
         ),
       );
 
     // then
     Marbles.assertEffect(effect$, [
-      ['-a-b----c-d---', { a: event1, b: event2,       c: event3, d: event4 }],
-      ['-a-(bb)-c-d---', { a: event1, b: eventErrored, c: event3, d: event4 }],
+      ['-a-b----c-d---', { a: event1, b: event2,                          c: event3, d: event4 }],
+      ['-a-(bb)-c-d---', { a: event1, b: { ...event_error, error: true }, c: event3, d: event4 }],
+    ]);
+  });
+
+  test('passes through errored event', () => {
+    // given
+    const event1: Event = { type: 'TEST_EVENT_1', payload: 1 };
+    const event2: Event = { type: 'TEST_EVENT_2', error: 'some_error' };
+    const event3: Event = { type: 'TEST_EVENT_3', payload: 3 };
+    const event4: Event = { type: 'TEST_EVENT_4', payload: 4 };
+    const eventP: Event = { type: 'TEST_EVENT_PROCESSED', payload: 0 };
+
+    const eventE: Event = { type: 'TEST_EVENT_2', error: 'some_error' };
+
+    // when
+    const effect$ = (event$: Observable<Event>) =>
+      event$.pipe(
+        act(_ => of(eventP)),
+      );
+
+    // then
+    Marbles.assertEffect(effect$, [
+      ['-a-b-c-d---', { a: event1, b: event2, c: event3, d: event4 }],
+      ['-a-b-c-d---', { a: eventP, b: eventE, c: eventP, d: eventP }],
+    ]);
+  });
+
+  test('chains "act" operators', () => {
+    // given
+    const event1: Event<number> = { type: 'TEST_EVENT_1', payload: 1 };
+    const event2: Event<number, string> = { type: 'TEST_EVENT_2', error: 'some_error' };
+    const event3: Event<number> = { type: 'TEST_EVENT_3', payload: 3 };
+    const event4: Event<number> = { type: 'TEST_EVENT_4', payload: 4 };
+
+    const event_ok: Event<boolean> = { type: 'TEST_EVENT_PROCESSED', payload: true };
+    const event_ok_out: Event<number> = { type: 'TEST_EVENT_PROCESSED', payload: 0 };
+
+    const event_err1: Event<string> = { type: 'TEST_EVENT_ERROR', payload: 'test_1' };
+    const event_err2: Event<string> = { type: 'TEST_EVENT_ERROR', payload: 'test_2' };
+
+    // when
+    const effect$ = (event$: Observable<Event>) =>
+      event$.pipe(
+        act(_ => of(event_ok),     _ => event_err1),
+        act(_ => of(event_ok_out), _ => event_err2),
+      );
+
+    // then
+    Marbles.assertEffect(effect$, [
+      ['-a-b-c-d---', { a: event1,       b: event2,                         c: event3,       d: event4 }],
+      ['-a-b-c-d---', { a: event_ok_out, b: { ...event_err2, error: true }, c: event_ok_out, d: event_ok_out }],
+    ]);
+  });
+
+  test('triggers subsequent "act" error handler if previous "act" operator did not handled the exception', () => {
+    // given
+    const event1: Event<number> = { type: 'TEST_EVENT_1', payload: 1 };
+    const event2: Event<number> = { type: 'TEST_EVENT_2', payload: 2 };
+    const event3: Event<number> = { type: 'TEST_EVENT_3', payload: 3 };
+    const event4: Event<number> = { type: 'TEST_EVENT_4', payload: 4 };
+
+    const event_ok: Event<boolean> = { type: 'TEST_EVENT_PROCESSED', payload: true };
+    const event_err: Event<string> = { type: 'TEST_EVENT_ERROR', payload: 'test_error' };
+
+    // when
+    const effect$ = (event$: Observable<Event>) =>
+      event$.pipe(
+        act(e => e.payload === 2 ? throwError('test_error') : of(e as Event<number>)),
+        act(_ => of(event_ok), (error, event) => {
+          expect(error).toEqual('test_error');
+          expect(event).toEqual({ type: 'TEST_EVENT_2', error: 'test_error' });
+          return event_err;
+        }),
+      );
+
+    // then
+    Marbles.assertEffect(effect$, [
+      ['-a-b-c-d---', { a: event1,   b: event2,                        c: event3,   d: event4 }],
+      ['-a-b-c-d---', { a: event_ok, b: { ...event_err, error: true }, c: event_ok, d: event_ok }],
     ]);
   });
 });

--- a/packages/core/src/operators/act/act.operator.spec.ts
+++ b/packages/core/src/operators/act/act.operator.spec.ts
@@ -79,7 +79,7 @@ describe('#act operator', () => {
     const event2: Event = { type: 'TEST_EVENT_2', payload: 2, metadata: { replyTo: 'channel_2' } };
     const event3: Event = { type: 'TEST_EVENT_3', payload: 3, metadata: { replyTo: 'channel_3' } };
     const event4: Event = { type: 'TEST_EVENT_4', payload: 4, metadata: { replyTo: 'channel_4' } };
-    const event_error: Event = { type: 'TEST_EVENT_2', error, metadata: { replyTo: 'channel_2' } };
+    const event_error: Event = { type: 'TEST_EVENT_2_UNHANDLED_ERROR', error, metadata: { replyTo: 'channel_2' } };
 
     // when
     const effect$ = (event$: Observable<Event>) =>
@@ -219,20 +219,20 @@ describe('#act operator', () => {
     const event2: Event = { type: 'TEST_EVENT_2', error: 'some_error' };
     const event3: Event = { type: 'TEST_EVENT_3', payload: 3 };
     const event4: Event = { type: 'TEST_EVENT_4', payload: 4 };
-    const eventP: Event = { type: 'TEST_EVENT_PROCESSED', payload: 0 };
 
-    const eventE: Event = { type: 'TEST_EVENT_2', error: 'some_error' };
+    const event_ok: Event = { type: 'TEST_EVENT_PROCESSED', payload: 0 };
+    const event_err: Event = { type: 'TEST_EVENT_2_UNHANDLED_ERROR', error: 'some_error' };
 
     // when
     const effect$ = (event$: Observable<Event>) =>
       event$.pipe(
-        act(_ => of(eventP)),
+        act(_ => of(event_ok)),
       );
 
     // then
     Marbles.assertEffect(effect$, [
-      ['-a-b-c-d---', { a: event1, b: event2, c: event3, d: event4 }],
-      ['-a-b-c-d---', { a: eventP, b: eventE, c: eventP, d: eventP }],
+      ['-a-b-c-d---', { a: event1,   b: event2,    c: event3,   d: event4 }],
+      ['-a-b-c-d---', { a: event_ok, b: event_err, c: event_ok, d: event_ok }],
     ]);
   });
 
@@ -279,7 +279,7 @@ describe('#act operator', () => {
         act(e => e.payload === 2 ? throwError('test_error') : of(e as Event<number>)),
         act(_ => of(event_ok), (error, event) => {
           expect(error).toEqual('test_error');
-          expect(event).toEqual({ type: 'TEST_EVENT_2', error: 'test_error' });
+          expect(event).toEqual({ type: 'TEST_EVENT_2_UNHANDLED_ERROR', error: 'test_error' });
           return event_err;
         }),
       );

--- a/packages/core/src/operators/act/act.operator.ts
+++ b/packages/core/src/operators/act/act.operator.ts
@@ -18,7 +18,7 @@ export function act<
   ErrorEvent extends Event,
 >(
   callFn: (event: InputEvent) => Observable<CallEvent>,
-  errorFn: (error: any, event: InputEvent) => ErrorEvent | Observable<ErrorEvent>,
+  errorFn: (error: any, event: Event) => ErrorEvent | Observable<ErrorEvent>,
 ): (source: Observable<InputEvent>) => Observable<CallEvent>;
 
 export function act<
@@ -27,7 +27,7 @@ export function act<
   ErrorEvent extends Event,
 >(
   callFn: (event: InputEvent) => Observable<CallEvent>,
-  errorFn?: (error: any, event: InputEvent) => ErrorEvent | Observable<ErrorEvent>,
+  errorFn?: (error: any, event: Event) => ErrorEvent | Observable<ErrorEvent>,
 ) {
 
   const DEFAULT_ERROR_SUFFIX = '_UNHANDLED_ERROR';

--- a/packages/core/src/operators/act/act.operator.ts
+++ b/packages/core/src/operators/act/act.operator.ts
@@ -30,8 +30,12 @@ export function act<
   errorFn?: (error: any, event: InputEvent) => ErrorEvent | Observable<ErrorEvent>,
 ) {
 
+  const DEFAULT_ERROR_SUFFIX = '_UNHANDLED_ERROR';
+
   const getDefaultErrorEvent = (error: any) => (event: Event) => of({
-    type: event.type,
+    type: !event.type.includes(DEFAULT_ERROR_SUFFIX)
+      ? event.type + DEFAULT_ERROR_SUFFIX
+      : event.type,
     error: encodeError(error) ?? true,
     metadata: event.metadata,
   } as ErrorEvent);

--- a/packages/messaging/src/middlewares/messaging.eventLogger.middleware.ts
+++ b/packages/messaging/src/middlewares/messaging.eventLogger.middleware.ts
@@ -1,5 +1,6 @@
 import { tap } from 'rxjs/operators';
 import { useContext, LoggerToken, LoggerLevel } from '@marblejs/core';
+import { isNamedError } from '@marblejs/core/dist/+internal/utils';
 import { MsgMiddlewareEffect, MsgOutputEffect } from '../effects/messaging.effects.interface';
 import { TransportLayerToken } from '../server/messaging.server.tokens';
 
@@ -32,7 +33,7 @@ export const outputLogger$: MsgOutputEffect = (event$, ctx) => {
       const { error, metadata, type } = event;
       const tag = transportLayer.config.channel;
       const message = error
-        ? `"${error.name}", "${error.message}" for event ${type}`
+        ? `${isNamedError(error) ? `"${error.name}", "${error.message}"` : 'error'} for event ${type}`
         : metadata?.replyTo
           ? `${event.type}, id: ${metadata?.correlationId || '-'} and sent to "${metadata.replyTo || '-'}"`
           : metadata?.correlationId

--- a/packages/messaging/src/middlewares/messaging.eventOutput.middleware.ts
+++ b/packages/messaging/src/middlewares/messaging.eventOutput.middleware.ts
@@ -1,14 +1,8 @@
 import { Event, useContext } from '@marblejs/core';
-import { createUuid, isNonNullable } from '@marblejs/core/dist/+internal/utils';
+import { createUuid, isNonNullable, encodeError } from '@marblejs/core/dist/+internal/utils';
 import { map } from 'rxjs/operators';
 import { MsgOutputEffect } from '../effects/messaging.effects.interface';
 import { TransportLayerToken } from '../server/messaging.server.tokens';
-
-export const encodeError = (error: any) =>
-  ['name', ...Object.getOwnPropertyNames(error)].reduce((acc, key) => {
-    acc[key] = error[key];
-    return acc;
-  }, Object.create(null))
 
 export const outputRouter$: MsgOutputEffect = (event$, ctx) => {
   const transportLayer = useContext(TransportLayerToken)(ctx.ask);

--- a/packages/messaging/src/server/messaging.server.listener.ts
+++ b/packages/messaging/src/server/messaging.server.listener.ts
@@ -11,7 +11,7 @@ import {
 } from '@marblejs/core';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { Observable, Subject, defer } from 'rxjs';
-import { map, catchError, takeUntil, filter } from 'rxjs/operators';
+import { map, catchError, takeUntil } from 'rxjs/operators';
 import { TransportMessageTransformer, TransportLayerConnection } from '../transport/transport.interface';
 import { jsonTransformer, decodeMessage } from '../transport/transport.transformer';
 import { MsgEffect, MsgMiddlewareEffect, MsgErrorEffect, MsgOutputEffect } from '../effects/messaging.effects.interface';
@@ -77,7 +77,6 @@ export const messagingListener = createListener<MessagingListenerConfig, Messagi
     const incomingEvent$ = pipe(
       connection.message$,
       map(decode),
-      filter(event => !event.error),
       e$ => combinedMiddlewares(e$, ctx),
       e$ => defer(() => processError(e$)),
     );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/core** - `act` - pass through error events. It allows us to build the following flow:
```typescript
event$.pipe(
  matchEvent(Codec),
  act(eventValidator$(Codec)),
  act(event => ...),
);
```
With this feature we can trigger subsequent `act` error handler if previous `act` operator did not handled the exception.
- **@marblejs/messaing** - server doesn't have to skip error events since `act` operator maps default errors to `*_UNHANDLED_ERROR` suffixed event types to avoid event handler dead loop
(TBH, I don't know why I didn't do it earlier... 🤦 )

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
