### PR TITLE
feat(core): derived context

### DIFF
--- a/packages/core/src/context/context.helper.ts
+++ b/packages/core/src/context/context.helper.ts
@@ -5,8 +5,6 @@ import { registerAll, BoundDependency, createContext, bindTo, resolve, Context }
 
 /**
  * Constructs and resolves a new or derived context based on provided dependencies
- * @param context (optional) empty or derived context
- * @param dependencies list of bound dependencies to register in the context
  * @since v3.4.0
  */
 export const constructContext = (context?: Context) => (...dependencies: BoundDependency<any>[]) =>
@@ -21,7 +19,6 @@ export const constructContext = (context?: Context) => (...dependencies: BoundDe
 
 /**
  * Constructs and resolves a new context based on provided dependencies
- * @param dependencies list of bound dependencies to register in the context
  * @since v3.2.0
  */
 export const contextFactory = constructContext();

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -2,11 +2,12 @@ import * as R from 'fp-ts/lib/Reader';
 import * as M from 'fp-ts/lib/Map';
 import * as O from 'fp-ts/lib/Option';
 import * as E from 'fp-ts/lib/Eq';
+import * as T from 'fp-ts/lib/Task';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { contramap, ordString, Ord } from 'fp-ts/lib/Ord';
-import { ContextToken } from './context.token.factory';
+import { ContextToken, createContextToken } from './context.token.factory';
 
-export const ordContextToken: Ord<ContextToken<any>> = contramap((t: ContextToken) => t._id)(ordString);
+export const ordContextToken: Ord<ContextToken<unknown>> = contramap((t: ContextToken<unknown>) => t._id)(ordString);
 export const setoidContextToken: E.Eq<ContextToken> = { equals: ordContextToken.equals };
 
 export interface Context extends Map<ContextToken, ContextDependency | any> {}
@@ -37,6 +38,8 @@ export interface BoundDependency<T, U extends ContextDependency = ContextDepende
   dependency: U;
 }
 
+export const DerivedContextToken = createContextToken<Context>('DerivedContext');
+
 const isEagerDependency = (x: any): x is ContextEagerReader => {
   return x.eval && x.tag === ContextReaderTag.EAGER_READER;
 };
@@ -59,45 +62,71 @@ export const registerAll = (boundDependencies: BoundDependency<any, any>[]) => (
     context,
   );
 
+/**
+ * Resolves eager dependencies within the context
+ * @since v2.0.0
+ */
 export const resolve = async (context: Context): Promise<Context> => {
+  const resolveEagerDependency = ({ token, dependency }: BoundDependency<unknown, ContextEagerReader>): T.Task<Context> => pipe(
+    () => pipe(context, dependency.eval, d => Promise.resolve(d)),
+    T.chain(resolvedDependency => T.fromIO(() => context.set(token, resolvedDependency))));
+
   for (const [token, dependency] of context) {
-    context.set(
-      token,
-      isEagerDependency(dependency)
-        ? await Promise.resolve(dependency.eval(context))
-        : dependency,
-    );
+    if (!isEagerDependency(dependency)) continue;
+    await resolveEagerDependency({ token, dependency })();
   }
 
   return context;
 }
 
-export const lookup = (context: Context) => <T>(token: ContextToken<T>): O.Option<T> => pipe(
-  M.lookup(ordContextToken)(token, context),
-  O.map(dependency => {
-    if (!dependency.eval) {
-      return dependency;
-    }
+/**
+ * Lookup the dependency for a token in a `Context`
+ * @since v2.0.0
+ */
+export const lookup = (context: Context) => <T>(token: ContextToken<T>): O.Option<T> =>
+  pipe(
+    M.lookup(ordContextToken)(token, context),
+    O.map(dependency => {
+      if (!dependency.eval) return dependency;
 
-    const boostrapedDependency = isLazyDependency(dependency)
-      ? dependency.eval()(context)
-      : dependency.eval(context);
+      const boostrapedDependency = isLazyDependency(dependency)
+        ? dependency.eval()(context)
+        : dependency.eval(context);
 
-    context.set(token, boostrapedDependency);
-    return boostrapedDependency;
-  }),
-);
+      context.set(token, boostrapedDependency);
 
+      return boostrapedDependency;
+    }),
+    O.fold(
+      () => pipe(
+        M.lookup(ordContextToken)(DerivedContextToken, context),
+        O.chain((derivedContext: Context) => lookup(derivedContext)(token))),
+      O.some),
+  );
+
+/**
+ * Binds context token to a lazy dependency.
+ * @since v3.0.0
+ */
 export const bindLazilyTo =
   <T>(token: ContextToken<T>) =>
   <U extends ContextReader>(dependency: U): BoundDependency<T, ContextLazyReader> =>
     ({ token, dependency: { eval: () => dependency, tag: ContextReaderTag.LAZY_READER } });
 
+/**
+ * Binds context token to a eager dependency.
+ * @since v3.0.0
+ */
 export const bindEagerlyTo =
   <T>(token: ContextToken<T>) =>
   <U extends ContextReader>(dependency: U): BoundDependency<T, ContextEagerReader> =>
     ({ token, dependency: { eval: dependency, tag: ContextReaderTag.EAGER_READER } });
 
+/**
+ * An alias to `bindLazilyTo`.
+ * Binds context token to a lazy dependency.
+ * @since v3.0.0
+ */
 export const bindTo = bindLazilyTo;
 
 export const reader = pipe(

--- a/packages/messaging/src/eventbus/messaging.eventBus.reader.ts
+++ b/packages/messaging/src/eventbus/messaging.eventBus.reader.ts
@@ -1,7 +1,6 @@
 import { pipe } from 'fp-ts/lib/pipeable';
-import { deleteAt } from 'fp-ts/lib/Map';
 import * as R from 'fp-ts/lib/Reader';
-import { Context, bindTo, setoidContextToken, createContextToken, constructContext } from '@marblejs/core';
+import { Context, bindTo, createContextToken, contextFactory, bindEagerlyTo, DerivedContextToken, logContext, LoggerTag } from '@marblejs/core';
 import { TransportLayerToken } from '../server/messaging.server.tokens';
 import { Transport, TransportLayerConnection } from '../transport/transport.interface';
 import { provideTransportLayer } from '../transport/transport.provider';
@@ -19,16 +18,18 @@ export const EventBusClientToken = createContextToken<MessagingClient>('EventBus
 
 export const eventBus = (config: EventBusConfig) => pipe(
   R.ask<Context>(),
-  R.map(async rootContext => {
+  R.map(async derivedContext => {
     const { listener } = config;
-    const derivedContext = deleteAt(setoidContextToken)(EventBusToken)(rootContext);
     const transportLayer = provideTransportLayer(Transport.LOCAL);
     const transportLayerConnection = await transportLayer.connect();
 
-    const context = await constructContext(derivedContext)(
+    const context = await contextFactory(
+      bindEagerlyTo(DerivedContextToken)(() => derivedContext),
       bindTo(TransportLayerToken)(() => transportLayer),
       bindTo(EventTimerStoreToken)(EventTimerStore),
     );
+
+    logContext(LoggerTag.EVENT_BUS)(context);
 
     listener(context)(transportLayerConnection);
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/messaging** - `EventBus` initializes the reader with the **copy** of derived context, eg. HttpServer context. Marble.js dependency injection container (aka Context) is built around JS Map. When removing a token from the context, references are changed because the whole Map is cloned.

```typescript
// the problem 👇 - new Context copy
const derivedContext = deleteAt(setoidContextToken)(SomeToken)(rootContext);

const context = await constructContext(derivedContext)(
  bindTo(FooToken)(Foo),
  bindTo(BarToken)(Bar),
);
```

## What is the new behavior?
- **@marblejs/messaging** - `EventBus` uses a new concept of derived context (aka Context in Context)

```typescript
const context = await contextFactory(
  bindEagerlyTo(DerivedContextToken)(() => derivedContext),
  bindTo(FooToken)(Foo),
  bindTo(BarToken)(Bar),
);
```

**How does it work?**
- A Reader registers a new dependency under `DerivedContext` token which points to a derived context object
- A Reader doesn't have to delete tokens which points to itself (to avoid circular context resolving) because it doesn't have to resolve it again - parent will do it automatically
- A Reader registers its own context that doesn't influence/mutate the derived parent context
- When asking for a dependency the server/listener first tries to lookup it in his own Context, if not found it will try to look for a registered `DerivedContext` and recursively invoke the lookup process again for that context.

```typescript
/**
 * Lookup the dependency for a token in a `Context`
 * @since v2.0.0
 */
export const lookup = (context: Context) => <T>(token: ContextToken<T>): O.Option<T> =>
  pipe(
    M.lookup(ordContextToken)(token, context),
    O.map(dependency => {
      if (!dependency.eval) return dependency;

      const boostrapedDependency = isLazyDependency(dependency)
        ? dependency.eval()(context)
        : dependency.eval(context);

      context.set(token, boostrapedDependency);

      return boostrapedDependency;
    }),
    O.fold(
      () => pipe(
        M.lookup(ordContextToken)(DerivedContextToken, context),
        O.chain((derivedContext: Context) => lookup(derivedContext)(token))),
      O.some),
  );
```
- The concept can be shown as follows:
```
Context:
  |- [DerivedContextToken]: DerivedContext
  |                            |- [DerivedDependencyToken_1]: DerivedDependency_1
  |                            |- [DerivedDependencyToken_2]: DerivedDependency_2
  |             
  |- [FooToken]: Foo
  |- [BarToken]: Bar
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
