### PR TITLE
fix(messaging): outputErrorEncoder$ - "null" payload case

### DIFF
--- a/packages/messaging/src/middlewares/messaging.eventOutput.middleware.spec.ts
+++ b/packages/messaging/src/middlewares/messaging.eventOutput.middleware.spec.ts
@@ -1,0 +1,55 @@
+import { Marbles } from '@marblejs/core/dist/+internal/testing';
+import { outputErrorEncoder$ } from './messaging.eventOutput.middleware';
+
+describe('outputErrorEncoder$', () => {
+  test('encodes event with error', () => {
+    // given
+    const incomingError = new Error('some_message');
+    const outgoingError = { name: 'Error', message: 'some_message' };
+
+    const event_1 = [
+      { type: 'TEST', payload: { error: incomingError } },
+      { type: 'TEST', payload: { error: outgoingError } },
+    ] as const;
+
+    const event_2 = [
+      { type: 'TEST', error: incomingError },
+      { type: 'TEST', error: outgoingError },
+    ] as const;
+
+    const event_3 = [
+      { type: 'TEST', payload: { error: incomingError }, error: incomingError },
+      { type: 'TEST', payload: { error: outgoingError }, error: outgoingError },
+    ] as const;
+
+    // when, then
+    Marbles.assertEffect(outputErrorEncoder$, [
+      ['-a-b-c-', { a: event_1[0], b: event_2[0], c: event_3[0] }],
+      ['-a-b-c-', { a: event_1[1], b: event_2[1], c: event_3[1] }],
+    ]);
+  });
+
+  test('skips event error encoding if error is nullable', () => {
+    // given
+    const event_1 = [
+      { type: 'TEST', payload: null },
+      { type: 'TEST', payload: null },
+    ] as const;
+
+    const event_2 = [
+      { type: 'TEST', payload: { error: null } },
+      { type: 'TEST', payload: { error: null } },
+    ] as const;
+
+    const event_3 = [
+      { type: 'TEST', error: null },
+      { type: 'TEST', error: null },
+    ] as const;
+
+    // when, then
+    Marbles.assertEffect(outputErrorEncoder$, [
+      ['-a-b-c-', { a: event_1[0], b: event_2[0], c: event_3[0] }],
+      ['-a-b-c-', { a: event_1[1], b: event_2[1], c: event_3[1] }],
+    ]);
+  });
+});

--- a/packages/messaging/src/middlewares/messaging.eventOutput.middleware.ts
+++ b/packages/messaging/src/middlewares/messaging.eventOutput.middleware.ts
@@ -20,19 +20,24 @@ export const outputRouter$: MsgOutputEffect = (event$, ctx) => {
   );
 };
 
-export const outputErrorEncoder$: MsgOutputEffect<Event<any>> = event$ =>
-  event$.pipe(
+export const outputErrorEncoder$: MsgOutputEffect<Event<any>> = event$ => {
+  const hasError = (event: Event<{ error?: any }>): boolean =>
+    [event.payload?.error, event.error].some(Boolean);
+
+  return event$.pipe(
     map(event => {
-      const { payload: { error: payloadError } = { error: undefined }, error } = event;
+      if (!hasError(event)) return event;
 
-      if (isNonNullable(error)) {
-        event.error = encodeError(error);
-      }
+      const eventError = event.error;
+      const payloadError = event.payload?.error;
 
-      if (isNonNullable(payloadError)) {
+      if (isNonNullable(eventError))
+        event.error = encodeError(eventError);
+
+      if (isNonNullable(payloadError))
         event.payload.error = encodeError(payloadError);
-      }
 
       return event;
     }),
   );
+}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/messaging** - `outputErrorEncoder$` crashes when `event.payload === null`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
