### PR TITLE
fix(core): context - unset redundant token if present in DerivedContext

### DIFF
--- a/packages/core/src/context/context.helper.ts
+++ b/packages/core/src/context/context.helper.ts
@@ -1,21 +1,39 @@
+import * as T from 'fp-ts/lib/Task';
+import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
+import { constant } from 'fp-ts/lib/function';
 import { logger, LoggerToken, mockLogger } from '../logger';
 import { isTestEnv } from '../+internal/utils';
-import { registerAll, BoundDependency, createContext, bindTo, resolve, Context } from './context';
+import { registerAll, BoundDependency, createContext, bindTo, resolve, Context, lookup, DerivedContextToken, unregister } from './context';
+import { ContextToken } from './context.token.factory';
+
+/**
+ * `INTERNAL` - unregisters redundant token if available in DerivedContext
+ * @since v3.4.0
+ */
+const unregisterRedundantToken = (token: ContextToken) => (context: Context): Context =>
+  pipe(
+    lookup(context)(DerivedContextToken),
+    O.chain(() => lookup(context)(token)),
+    O.fold(
+      constant(context),
+      () => unregister(token)(context)),
+  );
 
 /**
  * Constructs and resolves a new or derived context based on provided dependencies
  * @since v3.4.0
  */
-export const constructContext = (context?: Context) => (...dependencies: BoundDependency<any>[]) =>
+export const constructContext = (context?: Context) => (...dependencies: BoundDependency<any>[]): Promise<Context> =>
   pipe(
     context ?? createContext(),
     registerAll([
       bindTo(LoggerToken)(isTestEnv() ? mockLogger : logger),
       ...dependencies,
     ]),
-    resolve,
-  );
+    context => () => resolve(context),
+    T.map(unregisterRedundantToken(LoggerToken)),
+  )();
 
 /**
  * Constructs and resolves a new context based on provided dependencies

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -63,6 +63,13 @@ export const registerAll = (boundDependencies: BoundDependency<any, any>[]) => (
   );
 
 /**
+ * Unregisters given token from the context
+ * @since v3.4.0
+ */
+export const unregister = (token: ContextToken) => (context: Context): Context =>
+  M.deleteAt(setoidContextToken)(token)(context);
+
+/**
  * Resolves eager dependencies within the context
  * @since v2.0.0
  */

--- a/packages/core/src/context/specs/context.spec.ts
+++ b/packages/core/src/context/specs/context.spec.ts
@@ -17,6 +17,7 @@ import {
   ContextReaderTag,
   resolve,
   DerivedContextToken,
+  unregister,
 } from '../context';
 import { createContextToken } from '../context.token.factory';
 import { contextFactory } from '../context.helper';
@@ -94,6 +95,28 @@ describe('#registerAll', () => {
     // then
     expect(size(context)).toEqual(3);
     expect(lookup(context)(token2)).toEqual(O.some('test_2'));
+  });
+});
+
+describe('#unregister', () => {
+  test('unregisters specified token', () => {
+    // given
+    const token = createContextToken<string>();
+    const token_to_delete = createContextToken<string>();
+    const dependency = pipe(R.ask<Context>(), R.map(_ => 'test'));
+    const dependency_to_delete = pipe(R.ask<Context>(), R.map(_ => 'test_to_delete'));
+
+    const contextBefore = registerAll([
+      bindTo(token)(dependency),
+      bindTo(token_to_delete)(dependency_to_delete),
+    ])(createContext());
+
+    // when
+    const contextAfter = unregister(token_to_delete)(contextBefore);
+
+    // then
+    expect(size(contextAfter)).toEqual(1);
+    expect(lookup(contextAfter)(token_to_delete)).toEqual(O.none);
   });
 });
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/messaging** - `eventBus` registers two `LoggerToken` dependencies - one for main context, second for derived context. If custom logger is bound to derived context `LoggerToken`, then first/redundant binding is used instead.

## What is the new behavior?
- **@marblejs/core** - `constructContext` helper function registers only one `LoggerToken` if already present in derived context

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
