### PR TITLE
feat(messaging): pass event payload to input and output logger

### DIFF
--- a/packages/core/src/logger/logger.interface.ts
+++ b/packages/core/src/logger/logger.interface.ts
@@ -9,6 +9,7 @@ export type LoggerOptions = {
   type: string;
   message: string;
   level?: LoggerLevel;
+  data?: Record<string, unknown>;
 };
 
 export const enum LoggerTag {

--- a/packages/messaging/src/middlewares/messaging.eventLogger.middleware.spec.ts
+++ b/packages/messaging/src/middlewares/messaging.eventLogger.middleware.spec.ts
@@ -62,6 +62,7 @@ describe('inputLogger$', () => {
       message: events[0].type,
       type: 'EVENT_IN',
       tag: 'event_bus',
+      data: { payload: events[0].payload },
     });
 
     expect(loggerMock).toHaveBeenCalledWith({
@@ -69,6 +70,7 @@ describe('inputLogger$', () => {
       message: events[1].type,
       type: 'EVENT_IN',
       tag: 'event_bus',
+      data: { payload: events[1].payload },
     });
 
     expect(loggerMock).toHaveBeenCalledWith({
@@ -76,6 +78,7 @@ describe('inputLogger$', () => {
       message: events[2].type,
       type: 'EVENT_IN',
       tag: 'event_bus',
+      data: { payload: events[2].payload },
     });
   });
 
@@ -122,6 +125,7 @@ describe('inputLogger$', () => {
       message: events[0].type,
       type: 'EVENT_OUT',
       tag: 'event_bus',
+      data: { payload: events[0].payload },
     });
 
     expect(loggerMock).toHaveBeenCalledWith({
@@ -129,6 +133,7 @@ describe('inputLogger$', () => {
       message: `${events[1].type}, id: ${events[1].metadata?.correlationId} and sent to \"${events[1].metadata?.replyTo}\"`,
       type: 'EVENT_OUT',
       tag: 'event_bus',
+      data: { payload: events[1].payload },
     });
 
     expect(loggerMock).toHaveBeenCalledWith({
@@ -136,6 +141,7 @@ describe('inputLogger$', () => {
       message: `Unknown error "{"test":true}" for event "${events[2].type}"`,
       type: 'EVENT_OUT',
       tag: 'event_bus',
+      data: { payload: events[2].payload },
     });
 
     expect(loggerMock).toHaveBeenCalledWith({
@@ -143,6 +149,7 @@ describe('inputLogger$', () => {
       message: `"Error: some_error_message" for event "${events[3].type}"`,
       type: 'EVENT_OUT',
       tag: 'event_bus',
+      data: { payload: events[3].payload },
     });
 
     expect(loggerMock).toHaveBeenCalledWith({
@@ -150,6 +157,7 @@ describe('inputLogger$', () => {
       message: `Received invalid event "${events[4].type}" (UNKNOWN_CORRELATION_ID) with error: {"test":true}`,
       type: 'EVENT_OUT',
       tag: 'event_bus',
+      data: { payload: events[4].payload },
     });
 
     expect(loggerMock).toHaveBeenCalledWith({
@@ -157,6 +165,7 @@ describe('inputLogger$', () => {
       message: `Received invalid event "${events[5].type}" (some_id) with error: {"test":true}`,
       type: 'EVENT_OUT',
       tag: 'event_bus',
+      data: { payload: events[5].payload },
     });
   });
 

--- a/packages/messaging/src/middlewares/messaging.eventLogger.middleware.ts
+++ b/packages/messaging/src/middlewares/messaging.eventLogger.middleware.ts
@@ -20,7 +20,12 @@ export const inputLogger$: MsgMiddlewareEffect = (event$, ctx) => {
   return event$.pipe(
     tap(event => pipe(
       getIncomingMessageForEvent(event),
-      message => logger({ tag, message, level: LoggerLevel.INFO, type: 'EVENT_IN' }),
+      message => logger({
+        tag, message,
+        level: LoggerLevel.INFO,
+        type: 'EVENT_IN',
+        data: { payload: event.payload },
+      }),
     )()),
   );
 };
@@ -42,7 +47,12 @@ export const outputLogger$: MsgOutputEffect = (event$, ctx) => {
       event.error
         ? getErrorMessageForEvent(event)
         : getOutgoingMessageForEvent(event),
-      message => logger({ tag, message, level: event.error ? LoggerLevel.ERROR : LoggerLevel.INFO, type: 'EVENT_OUT' })
+      message => logger({
+        tag, message,
+        level: event.error ? LoggerLevel.ERROR : LoggerLevel.INFO,
+        type: 'EVENT_OUT',
+        data: { payload: event.payload },
+      }),
     )()),
   );
 };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently it is not possible to log the detailed information about the event payload. 

## What is the new behavior?

The event `payload` is passed to the `LoggerOptions` inside `data` object in input and output logger middlewares. This information can be then extracted inside logger implementation and outputted to the console.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
