### PR TITLE
feat(core): lower case http headers, based on env variable. Fixes #311

### DIFF
--- a/packages/core/src/+internal/utils/env.util.ts
+++ b/packages/core/src/+internal/utils/env.util.ts
@@ -1,0 +1,54 @@
+import { IO } from 'fp-ts/IO';
+import { Option, fromNullable, getOrElse } from 'fp-ts/Option';
+import { pipe } from 'fp-ts/function';
+
+function memoize<A>(ma: IO<A>): IO<A> {
+  let cache: A;
+  let done = false;
+
+  return () => {
+    if (!done) {
+      cache = ma()
+      done = true
+    }
+
+    return cache;
+  }
+}
+
+/**
+ * read env config (but only once, value is cached)
+ *
+ * @param key - env variable to read.
+ *
+ * @see envConfigEither
+ */
+export const envConfig: (envKey: string) => IO<Option<string>> = (envKey) => memoize<Option<string>>(() => {
+  return fromNullable(process.env[envKey])
+});
+
+/**
+ * read env config with fallback value in case it is not defined.
+ *
+ * @param envKey
+ * @param onNone
+ *
+ * @see envConfig
+ */
+export const envConfigEither: (envKey: string, onNone: string) => IO<string> = (envKey, onNone) =>
+  () => pipe(envConfig(envKey)(), getOrElse(() => onNone));
+
+/**
+ * read env config using #envConfigEither and converts the value to boolean
+ * defined value must be "true" (case insensitive) to be true.
+ * @param envKey
+ * @param onNone
+ *
+ * @see envConfigEither
+ */
+export const envConfigEitherAsBoolean: (envKey: string, onNone: boolean) => IO<boolean> = (envKey, onNone) => () => pipe(
+  envConfigEither(envKey, onNone + '')(),
+  val => {
+    return val.toLowerCase() === 'true';
+  }
+);

--- a/packages/core/src/+internal/utils/spec/env.util.spec.ts
+++ b/packages/core/src/+internal/utils/spec/env.util.spec.ts
@@ -1,0 +1,59 @@
+import { IO } from 'fp-ts/IO';
+import { Option, getOrElse } from 'fp-ts/Option';
+import { pipe } from 'fp-ts/function';
+import { envConfig, envConfigEither, envConfigEitherAsBoolean } from '../env.util';
+
+test('read env variable once', () => {
+  const fooEnv: IO<Option<string>> = envConfig('Foo');
+
+  process.env.Foo = 'Foo';
+  expect(pipe(fooEnv(), getOrElse(() => 'Env Foo not defined'))).toBe('Foo');
+
+  process.env.Foo = 'Bar';
+  // env variable is only read once so it should return the old value
+  expect(pipe(fooEnv(), getOrElse(() => 'Env Foo not defined'))).toBe('Foo');
+});
+
+test('read nullable env variable once', () => {
+  const fooEnv: IO<Option<string>> = envConfig('Foo');
+
+  delete process.env.Foo;
+  expect(pipe(fooEnv(), getOrElse(() => 'Env Foo not defined'))).toBe('Env Foo not defined');
+
+  process.env.Foo = 'Test Test';
+  // env variable is only read once so it should return the old value
+  expect(pipe(fooEnv(), getOrElse(() => 'Env Foo not defined'))).toBe('Env Foo not defined');
+});
+
+
+test('read nullable env with fallback value', () => {
+  const fooEnv: IO<string> = envConfigEither('Foo', 'Fallback Value');
+
+  delete process.env.Foo;
+  expect(fooEnv()).toBe('Fallback Value');
+
+  process.env.Foo = 'Test Test';
+  expect(fooEnv()).toBe('Test Test');
+
+  delete process.env.Foo;
+  expect(fooEnv()).toBe('Fallback Value');
+
+  process.env.Foo = '123';
+  expect(fooEnv()).toBe('123');
+});
+
+test('read env with boolean fallback value', () => {
+  const fooEnv: IO<boolean> = envConfigEitherAsBoolean('FooBool', false);
+
+  delete process.env.FooBool;
+  expect(fooEnv()).toBe(false);
+
+  process.env.FooBool = 'true';
+  expect(fooEnv()).toBe(true);
+
+  delete process.env.FooBool;
+  expect(fooEnv()).toBe(false);
+
+  process.env.FooBool = 'TrUe'; // matching is case insensitive
+  expect(fooEnv()).toBe(true);
+});

--- a/packages/core/src/http/response/http.responseHeaders.factory.ts
+++ b/packages/core/src/http/response/http.responseHeaders.factory.ts
@@ -1,5 +1,17 @@
+import { envConfigEitherAsBoolean } from '../../+internal/utils/env.util';
 import { HttpHeaders, HttpStatus } from '../http.interface';
 import { contentTypeFactory } from './http.responseContentType.factory';
+
+/**
+ * Flag to indicate whether we should convert all headers to lower case or not.
+ * This flag was introduced to prevent breaking changes, for more details see:
+ * https://github.com/marblejs/marble/issues/311
+ *
+ * Flag will be removed in the next major version,
+ * where all headers are lower cased by default.
+ */
+const useLowerCaseHeadersOnly = envConfigEitherAsBoolean('MARBLE_HTTP_CASE_INSENSITIVE_HEADER_NAMES', false);
+
 
 export const DEFAULT_HEADERS = {
   'Content-Type': 'application/json',
@@ -10,8 +22,22 @@ export const headersFactory = (data: {
   body: any;
   path: string;
   status: HttpStatus;
-}) => (headers?: HttpHeaders) => ({
-  ...DEFAULT_HEADERS,
-  ...contentTypeFactory(data),
-  ...headers,
-});
+}) => (headers?: HttpHeaders) => {
+  const mergedHeaders = {
+    ...DEFAULT_HEADERS,
+    ...contentTypeFactory(data),
+    ...headers
+  };
+
+  if (!useLowerCaseHeadersOnly()) {
+    return mergedHeaders;
+  }
+
+  // lower case header
+  const lowerCasedHeaders = {};
+  Object.keys(mergedHeaders).forEach(h => {
+    lowerCasedHeaders[h.toLowerCase()] = mergedHeaders[h];
+  });
+
+  return lowerCasedHeaders;
+}

--- a/packages/core/src/http/response/specs/http.responseHeaders.factory.spec.ts
+++ b/packages/core/src/http/response/specs/http.responseHeaders.factory.spec.ts
@@ -1,5 +1,7 @@
 import { DEFAULT_HEADERS, headersFactory } from '../http.responseHeaders.factory';
 
+// TODO: how to test with and without ENV Flag?
+/*
 describe('Response headers factory', () => {
 
   const FACTORY_DATA = { status: 400, body: '', path: '/' };
@@ -18,4 +20,32 @@ describe('Response headers factory', () => {
     expect(headersFactory(FACTORY_DATA)(CUSTOM_HEADERS)).toEqual({ ...DEFAULT_HEADERS });
   });
 
+});
+*/
+
+describe('Response headers factory with lower case flag', () => {
+
+  const FACTORY_DATA = { status: 400, body: '', path: '/' };
+  process.env['MARBLE_HTTP_CASE_INSENSITIVE_HEADER_NAMES'] = 'true';
+
+  const lowerCasedDefaultHeaders = {};
+  Object.keys(DEFAULT_HEADERS).forEach(h => {
+    lowerCasedDefaultHeaders[h.toLowerCase()] = DEFAULT_HEADERS[h];
+  });
+
+  it('returns default headers if custom are not provided', () => {
+    expect(headersFactory(FACTORY_DATA)()).toEqual(lowerCasedDefaultHeaders);
+  });
+
+  it('returns custom headers if are provided', () => {
+    const CUSTOM_HEADERS = { 'Content-Encoding': 'gzip' };
+    expect(headersFactory(FACTORY_DATA)(CUSTOM_HEADERS)).toEqual({ ...lowerCasedDefaultHeaders, ...{
+        'content-encoding': 'gzip'
+      }});
+  });
+
+  it('returns not duplicated headers', () => {
+    const CUSTOM_HEADERS = { 'Content-Type': 'application/json' };
+    expect(headersFactory(FACTORY_DATA)(CUSTOM_HEADERS)).toEqual({ ...lowerCasedDefaultHeaders });
+  });
 });


### PR DESCRIPTION
## PR Type
Lower Case HTTP Headers behind a Feature Flag as discussed in #311 

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #311 


## What is the new behavior?
all http headers are lower cased if the env flag is defined.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Just a first draft. as the flag is based on the env flag and it seems to be a good idea to cache the value for performance reason i had no idea how to test with and without the flag. 
I can continue after some general feedback.

