### PR TITLE
fix(websockets): added `path-to-regexp` package to the dependency list

### DIFF
--- a/packages/websockets/package.json
+++ b/packages/websockets/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "@types/ws": "~6.0.1",
-    "ws": "~7.4.6"
+    "ws": "~7.4.6",
+    "path-to-regexp": "^6.1.0"
   },
   "devDependencies": {
     "@marblejs/core": "^3.5.0"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #346 

## What is the new behavior?
- **@marblejs/websockets** - added `path-to-regexp` package to the dependency list


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
