### PR TITLE
fix(http): correctly calculate `Content-Length` for an empty object

### DIFF
--- a/packages/core/src/+internal/utils/any.util.ts
+++ b/packages/core/src/+internal/utils/any.util.ts
@@ -52,11 +52,6 @@ export const pipeFromArray = <T, R>(fns: Array<UnaryFunction<T, R>>): UnaryFunct
   };
 };
 
-export const isEmpty = (obj: Record<string, unknown>): boolean =>
-  isNullable(obj)
-    ? true
-    : Object.keys(obj).length === 0;
-
 const fromIO = <T>(fa: IO<T>): Observable<T> =>
   defer(() => of(fa()));
 

--- a/packages/http/src/response/http.responseHeaders.factory.ts
+++ b/packages/http/src/response/http.responseHeaders.factory.ts
@@ -1,7 +1,7 @@
 import * as O from 'fp-ts/lib/Option';
 import * as IO from 'fp-ts/lib/IO';
 import { constant, pipe } from 'fp-ts/lib/function';
-import { isStream, isEmpty, getEnvConfigOrElseAsBoolean, isString } from '@marblejs/core/dist/+internal/utils';
+import { isStream, getEnvConfigOrElseAsBoolean, isString, isNullable } from '@marblejs/core/dist/+internal/utils';
 import { ContentType, getContentLength, getContentType, getMimeType } from '../+internal/contentType.util';
 import { normalizeHeaders } from '../+internal/header.util';
 import { HttpHeaders, HttpStatus } from '../http.interface';
@@ -32,7 +32,7 @@ const useHttpHeadersNormalization = getEnvConfigOrElseAsBoolean(MARBLE_HTTP_HEAD
 const provideContentLengthHeader = (response: HttpResponseLike): HttpHeaders => {
   if (isStream(response.body)) return {};
 
-  const contentLength = isEmpty(response.body) ? 0 : Buffer.byteLength(
+  const contentLength = isNullable(response.body) ? 0 : Buffer.byteLength(
     isString(response.body) || Buffer.isBuffer(response.body)
       ? response.body
       : JSON.stringify(response.body)

--- a/packages/http/src/response/specs/http.responseHeaders.factory.spec.ts
+++ b/packages/http/src/response/specs/http.responseHeaders.factory.spec.ts
@@ -2,7 +2,7 @@ import { normalizeHeaders } from '../../+internal/header.util';
 import { DEFAULT_HEADERS, factorizeHeaders } from '../http.responseHeaders.factory';
 
 describe('#factorizeHeaders', () => {
-  test.each([ null, undefined, {}, '' ])(`returns normalized default headers for "%s" body`, (body: any) => {
+  test.each([ null, undefined, '' ])(`returns normalized default headers for "%s" body`, (body: any) => {
     const REQUEST = { status: 400, path: '/', body };
 
     expect(factorizeHeaders(REQUEST)()()).toEqual(normalizeHeaders({
@@ -17,6 +17,15 @@ describe('#factorizeHeaders', () => {
     expect(factorizeHeaders(REQUEST)()()).toEqual(normalizeHeaders({
       ...DEFAULT_HEADERS,
       'content-length': 1,
+    }));
+  });
+
+  test('returns normalized default headers if custom are not provided for empty object sent as body', () => {
+    const REQUEST = { status: 400, path: '/', body: {} };
+
+    expect(factorizeHeaders(REQUEST)()()).toEqual(normalizeHeaders({
+      ...DEFAULT_HEADERS,
+      'content-length': 2,
     }));
   });
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/http** - correctly calculate `Content-Length` for an empty object


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```