### PR TITLE
refactor(http): eagerly loaded `HttpOutputEffect`

### DIFF
--- a/packages/http/src/+internal/testing.util.ts
+++ b/packages/http/src/+internal/testing.util.ts
@@ -84,19 +84,22 @@ export const createMockEffectContext = () => {
   return createEffectContext({ ask: lookup(context), client });
 };
 
-export const createTestRoute = (opts?: { throwError?: boolean; delay?: number; method?: HttpMethod }) => {
+export const createTestRoute = (opts?: { throwError?: boolean; delay?: number; method?: HttpMethod; effectSpy?: jest.Mock }) => {
   const method = opts?.method ?? 'GET';
   const routeDelay = opts?.delay ?? 0;
 
   const req = createHttpRequest(({ url: `/delay_${routeDelay}`, method }));
   const path = factorizeRegExpWithParams(`/delay_${routeDelay}`);
 
-  const effect: HttpEffect = req$ =>
-    req$.pipe(
+  const effect: HttpEffect = req$ => {
+    opts?.effectSpy?.();
+
+    return req$.pipe(
       delay(routeDelay),
       tap(() => { if (opts?.throwError) throw new Error(); }),
       mapTo({ body: `delay_${routeDelay}` }),
     );
+  };
 
   const item: RoutingItem = {
     regExp: path.regExp,

--- a/packages/http/src/effects/http.effects.interface.ts
+++ b/packages/http/src/effects/http.effects.interface.ts
@@ -24,7 +24,7 @@ export interface HttpServerEffect<
 export interface HttpOutputEffect<
   Req extends HttpRequest = HttpRequest,
   Res extends HttpEffectResponse = HttpEffectResponse
-> extends HttpEffect<{ req: Req; res: Res }, HttpEffectResponse> {}
+> extends HttpEffect<{ req: Req; res: Res }, { req: Req; res: Res }> {}
 
 export interface HttpEffect<
   I = HttpRequest,

--- a/packages/http/src/effects/http.requestMetadata.effect.ts
+++ b/packages/http/src/effects/http.requestMetadata.effect.ts
@@ -10,11 +10,11 @@ export const requestMetadata$: HttpOutputEffect = (out$, ctx) => {
   const httpRequestMetadataStorage = useContext(HttpRequestMetadataStorageToken)(ctx.ask);
 
   return out$.pipe(
-    map(({ req, res }) => pipe(
-      getHttpRequestMetadataIdHeader(req.headers),
-      O.fold(constant(res), requestId => {
-        httpRequestMetadataStorage.set(requestId, req.meta);
-        return res;
+    map(out => pipe(
+      getHttpRequestMetadataIdHeader(out.req.headers),
+      O.fold(constant(out), requestId => {
+        httpRequestMetadataStorage.set(requestId, out.req.meta);
+        return out;
       }),
     )),
   );

--- a/packages/http/src/server/http.server.listener.ts
+++ b/packages/http/src/server/http.server.listener.ts
@@ -29,10 +29,10 @@ export const httpListener = createListener<HttpListenerConfig, HttpListener>(con
   } = config ?? {};
 
   const client = useContext(HttpServerClientToken)(ask);
-  const effectContext = createEffectContext({ ask, client });
+  const ctx = createEffectContext({ ask, client });
   const routing = factorizeRoutingWithDefaults(effects, middlewares ?? []);
   const sendResponse = handleResponse(ask);
-  const { resolve } = resolveRouting(routing, effectContext)(output$, error$);
+  const { resolve } = resolveRouting({ routing, ctx, output$, error$ });
 
   const handle = (req: IncomingMessage, res: OutgoingMessage) => {
     const marbleReq = req as HttpRequest;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[x] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
- **@marblejs/http** - `HttpOutputEffect`'s are resolved eagerly during initial bootstrap (optimized request/response processing)
- **@marblejs/http** - `HttpOutputEffect` interface change (returns `Observable<{ req: HttpRequest; res: HttpEffectResponse }>`)

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```