### PR TITLE
fix(websockets): don't re-throw an error in case of heartbeat error

### DIFF
--- a/packages/websockets/src/server/specs/websocket.server.helper.spec.ts
+++ b/packages/websockets/src/server/specs/websocket.server.helper.spec.ts
@@ -96,9 +96,8 @@ describe('#handleClientBrokenConnection', () => {
     // then
     scheduler.run(({ expectObservable, flush }) => {
       expectObservable(brokenConnection$).toBe(
-        `100ms a ${HEART_BEAT_TERMINATE_INTERVAL - 1}ms #`,
-        { a: isAlive },
-        timeoutError,
+        `100ms a ${HEART_BEAT_TERMINATE_INTERVAL - 1}ms (b|)`,
+        { a: isAlive, b: timeoutError },
       );
       flush();
       expect(client.terminate).toHaveBeenCalled();

--- a/packages/websockets/src/server/websocket.server.helper.ts
+++ b/packages/websockets/src/server/websocket.server.helper.ts
@@ -1,5 +1,5 @@
 import * as WebSocket from 'ws';
-import { EMPTY, fromEvent, merge, SchedulerLike, throwError, interval, from, iif, of } from 'rxjs';
+import { EMPTY, fromEvent, merge, SchedulerLike, interval, from, iif, of } from 'rxjs';
 import { takeUntil, catchError, tap, mapTo, timeout, map, mergeMap, mergeMapTo } from 'rxjs/operators';
 import { Context, lookup } from '@marblejs/core';
 import { WebSocketStatus, WebSocketConnectionLiveness } from '../websocket.interface';
@@ -54,7 +54,7 @@ export const handleClientBrokenConnection = (client: WebSocketClientConnection, 
     map(client => client.isAlive),
     catchError(error => {
       client.terminate();
-      return throwError(error);
+      return of(error);
     }),
   );
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #345


## What is the new behavior?

- **@marblejs/websockets** - don't re-throw an error in case of hearbeat error

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
