### PR TITLE
fix(testing): parse response body to undefined if not provided in case of "application/json" header

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -2,4 +2,7 @@ module.exports = {
   extends: [
     '@commitlint/config-conventional',
   ],
+  rules: {
+    'header-max-length': [0, 'always', 120],
+  }
 };

--- a/packages/testing/src/testBed/http/http.testBed.response.ts
+++ b/packages/testing/src/testBed/http/http.testBed.response.ts
@@ -12,7 +12,11 @@ const parseResponseBody = (props: HttpTestBedResponseProps): string | Array<any>
     O.map(body => {
       switch (getContentTypeUnsafe(props.headers)) {
         case ContentType.APPLICATION_JSON:
-          return pipe(body.toString(), parseJson);
+          return pipe(
+            body.toString(),
+            O.fromPredicate(Boolean),
+            O.map(parseJson),
+            O.toUndefined);
         case ContentType.TEXT_PLAIN:
         case ContentType.TEXT_HTML:
           return body.toString();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
- **@marblejs/testing** - parses response body to an empty string if nothing is provided and the `Content-Type` is `application/json`


## What is the new behavior?
- **@marblejs/testing** - parse response body to `undefined` if nothing is provided and the `Content-Type` is `application/json`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
